### PR TITLE
add log_all_objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ ffmpeg_recoverable_errors:
 | mask | list | optional | see [Mask config](#mask) | Allows you to specify masks in the shape of polygons. <br>Use this to ignore motion in certain areas of the image |
 | logging | dictionary | optional | see [Logging](#logging) | Overrides the camera/global log settings for the motion detector.<br>This affects all logs named ```lib.motion.<camera name>``` and  ```lib.nvr.<camera name>.motion``` |
 
+Each setting set here overrides the global [motion detection config](#motion-detection).
+
 ---
 
 ### Mask
@@ -361,6 +363,7 @@ Draw a mask over these trees and they will no longer trigger said motion.
 | -----| -----| ------- | ----------------- |------------ |
 | interval | float | optional | any float | Run object detection at this interval in seconds on the most recent frame. Overrides global [config](#object-detection) |
 | labels | list | optional | any float | A list of [labels](#labels). Overrides global [config](#labels). |
+| log_all_objects | bool | false | true/false | When set to true, **all** found objects will be logged. Can be quite noisy. Overrides global [config](#object-detection) |
 | logging | dictionary | optional | see [Logging](#logging) | Overrides the camera/global log settings for the object detector.<br>This affects all logs named ```lib.nvr.<camera name>.object``` |
 ---
 
@@ -473,6 +476,7 @@ points:
 | model_height | int | optional | any integer | Detected from model.<br>Frames will be resized to this height in order to fit model and save computing power.<br>I dont recommend changing this. |
 | interval | float | 1.0 | any float | Run object detection at this interval in seconds on the most recent frame. |
 | labels | list | optional | a list of [labels](#labels) | Global labels which applies to all cameras unless overridden |
+| log_all_objects | bool | false | true/false | When set to true, **all** found objects will be logged. Can be quite noisy |
 | logging | dictionary | optional | see [Logging](#logging) | Overrides the global log settings for the object detector.<br>This affects all logs named ```lib.detector``` and  ```lib.nvr.<camera name>.object``` |
 
 The above options are global for all types of detectors.\
@@ -584,7 +588,10 @@ The max/min width/height is used to filter out any unreasonably large/small obje
 | frames | int | 3 | any integer | Number of consecutive frames with motion before triggering, used to reduce false positives |
 | logging | dictionary | optional | see [Logging](#logging) | Overrides the global log settings for the motion detector. <br>This affects all logs named ```lib.motion.<camera name>``` and  ```lib.nvr.<camera name>.motion``` |
 
-TODO Future releases will make the motion detection easier to fine tune. Right now its a guessing game
+Motion detection works by creating a running average of frames, and then comparing the current frame to this average.\
+If enough changes have occured, motion will be detected.\
+By using a running average, the "background" image will adjust to daylight, stationary objects etc.\
+[This](https://www.pyimagesearch.com/2015/06/01/home-surveillance-and-motion-detection-with-the-raspberry-pi-python-and-opencv/) blogpost from PyImageSearch explains this procedure quite well.
 
 ---
 

--- a/src/lib/config/config_camera.py
+++ b/src/lib/config/config_camera.py
@@ -146,6 +146,7 @@ SCHEMA = Schema(
                             Optional("interval"): Any(int, float),
                             Optional("labels"): LABELS_SCHEMA,
                             Optional("logging"): LOGGING_SCHEMA,
+                            Optional("log_all_objects"): bool,
                         },
                         None,
                     ),

--- a/src/lib/config/config_object_detection.py
+++ b/src/lib/config/config_object_detection.py
@@ -85,6 +85,7 @@ SCHEMA = Schema(
             Any(float, int), Coerce(float), Range(min=0.0)
         ),
         Optional("labels", default=[{"label": "person"}]): LABELS_SCHEMA,
+        Optional("log_all_objects", default=False): bool,
         Optional("logging"): LOGGING_SCHEMA,
     },
     extra=ALLOW_EXTRA,
@@ -147,6 +148,10 @@ class ObjectDetectionConfig:
         for label in camera_object_detection.get("labels", object_detection["labels"]):
             self._labels.append(LabelConfig(label))
 
+        self._log_all_objects = camera_object_detection.get(
+            "log_all_objects", object_detection["log_all_objects"]
+        )
+
         logging = camera_object_detection.get(
             "logging", (object_detection.get("logging", None)),
         )
@@ -179,6 +184,10 @@ class ObjectDetectionConfig:
     @property
     def labels(self):
         return self._labels
+
+    @property
+    def log_all_objects(self):
+        return self._log_all_objects
 
     @property
     def logging(self):

--- a/src/lib/detector.py
+++ b/src/lib/detector.py
@@ -2,24 +2,13 @@ import importlib
 import logging
 
 import cv2
-from voluptuous import All, Any, Coerce, Optional, Range, Required, Schema
+from voluptuous import Any, Optional, Required
 
-from lib.config.config_logging import SCHEMA as LOGGING_SCHEMA
+from lib.config.config_object_detection import SCHEMA as BASE_SCEHMA
 from lib.config.config_logging import LoggingConfig
-from lib.config.config_object_detection import LABELS_SCHEMA
 from lib.helpers import calculate_relative_coords, pop_if_full
 
 LOGGER = logging.getLogger(__name__)
-
-BASE_SCEHMA = Schema(
-    {
-        Optional("interval", default=1): All(
-            Any(float, int), Coerce(float), Range(min=0.0)
-        ),
-        Optional("labels", default=[{"label": "person"}]): LABELS_SCHEMA,
-        Optional("logging"): LOGGING_SCHEMA,
-    }
-)
 
 SCHEMA = BASE_SCEHMA.extend(
     {

--- a/src/lib/detectors/darknet/__init__.py
+++ b/src/lib/detectors/darknet/__init__.py
@@ -15,7 +15,6 @@ from voluptuous import All, Any, Coerce, Optional, Range, Required
 
 import lib.detector as detector
 from const import ENV_CUDA_SUPPORTED, ENV_OPENCL_SUPPORTED
-from lib.config.config_logging import SCHEMA as LOGGING_SCHEMA
 from lib.config.config_object_detection import LABELS_SCHEMA
 
 from .defaults import LABEL_PATH, MODEL_CONFIG, MODEL_PATH

--- a/src/lib/nvr.py
+++ b/src/lib/nvr.py
@@ -502,15 +502,17 @@ class FFMPEGNVR(Thread):
             # Filter returned objects
             processed_object_frame = self.get_processed_object_frame()
             if processed_object_frame:
-                if self._object_logger.level == LOG_LEVELS["DEBUG"]:
-                    self._object_logger.debug(
-                        f"Objects: "
-                        f"{[obj.formatted for obj in processed_object_frame.objects]}"
-                    )
                 # Filter objects in the FoV
                 self.filter_fov(processed_object_frame)
                 # Filter objects in each zone
                 self.filter_zones(processed_object_frame)
+
+                if self._object_logger.level == LOG_LEVELS["DEBUG"]:
+                    if self.config.object_detection.log_all_objects:
+                        objs = [obj.formatted for obj in processed_object_frame.objects]
+                    else:
+                        objs = [obj.formatted for obj in self.objects_in_fov]
+                    self._object_logger.debug(f"Objects: {objs}")
 
             # Filter returned motion contours
             processed_motion_frame = self.get_processed_motion_frame()


### PR DESCRIPTION
Adds a new configuration option called log_all_objects which is placed under ```object_detection```

```yaml
object_detection:
  log_all_objects: true
```
If set to true, all found objects will be logged if loglevel is DEBUG (this is the behaviour today). The default is false which will only log objects that pass ```labels``` filters.

Closes #44 