### PR TITLE
use ffprobe to get codec information

### DIFF
--- a/docker/rpi/Dockerfile
+++ b/docker/rpi/Dockerfile
@@ -5,6 +5,7 @@ FROM debian:buster
 
 COPY --from=opencv /usr/local /usr/local
 COPY --from=ffmpeg /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg
+COPY --from=ffmpeg /usr/local/bin/ffprobe /usr/local/bin/ffprobe
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \

--- a/docker/rpi/Dockerfile.ffmpeg
+++ b/docker/rpi/Dockerfile.ffmpeg
@@ -27,10 +27,12 @@ RUN PKG_CONFIG_PATH=/opt/vc/lib/pkgconfig ./configure --arch=armel --target-os=l
 RUN make -j4
 
 RUN ln -s `pwd`/ffmpeg /usr/local/bin/ffmpeg
+RUN ln -s `pwd`/ffprobe /usr/local/bin/ffprobe
 WORKDIR "/root"
 
 FROM debian:buster
 COPY --from=0 /root/userland/ffmpeg-4.0.2/ffmpeg /usr/local/bin/ffmpeg
+COPY --from=0 /root/userland/ffmpeg-4.0.2/ffprobe /usr/local/bin/ffprobe
 COPY --from=0 /opt/vc /opt/vc
 
 # Required to link deps

--- a/src/const.py
+++ b/src/const.py
@@ -43,7 +43,6 @@ CAMERA_INPUT_ARGS = [
 CAMERA_HWACCEL_ARGS = []
 CAMERA_OUTPUT_ARGS = ["-f", "rawvideo", "-pix_fmt", "nv12", "pipe:1"]
 
-DECODER_CODEC = ""
 ENCODER_CODEC = ""
 
 ENV_CUDA_SUPPORTED = "VISERON_CUDA_SUPPORTED"
@@ -56,9 +55,11 @@ FFMPEG_RECOVERABLE_ERRORS = ["error while decoding MB"]
 HWACCEL_VAAPI = ["-hwaccel", "vaapi", "-vaapi_device", "/dev/dri/renderD128"]
 HWACCEL_VAAPI_ENCODER_FILTER = ["-vf", "format=nv12|vaapi,hwupload"]
 HWACCEL_VAAPI_ENCODER_CODEC = "h264_vaapi"
-HWACCEL_CUDA_DECODER_CODEC = "h264_cuvid"
+
+HWACCEL_CUDA_DECODER_CODEC_MAP = {"h264": "h264_cuvid", "h265": "hevc_cuvid"}
 HWACCEL_CUDA_ENCODER_CODEC = "h264_nvenc"
-HWACCEL_RPI3_DECODER_CODEC = "h264_mmal"
+
+HWACCEL_RPI3_DECODER_CODEC_MAP = {"h264": "h264_mmal"}
 HWACCEL_RPI3_ENCODER_CODEC = "h264_omx"
 
 RECORDER_GLOBAL_ARGS = ["-hide_banner"]


### PR DESCRIPTION
Uses ffprobe to get stream information.
This also makes the default codec picker a little smarter, previously it would always grab h264 version, but now a codec map is supplied so we can choose an appropriate codec for both h264/h265. In the future this could be expanded to include more codecs