### PR TITLE
Add missing option - filter_args?

### DIFF
--- a/src/lib/camera.py
+++ b/src/lib/camera.py
@@ -247,6 +247,7 @@ class Stream:
             + self.stream_command(self.stream_config, self.stream_codec)
             + (["-frames:v", "1"] if single_frame else [])
             + camera_segment_args
+            + (self._config.camera.filter_args if self._pipe_frames else [])
             + (self._config.camera.output_args if self._pipe_frames else [])
         )
 


### PR DESCRIPTION
I try to rotate my camera image, but when I set `filter_args` I don't see them end up in the generated `ffmpeg` command.

My config:
```
cameras:
  - name: Ute
    mqtt_name: ute
    host: 192.168.0.*
    port: 554
    username: **
    password: "**"
    path: '/h264'
    width: 2592
    height: 1944
    fps: 5
    publish_image: true
    filter_args:
      - "-vf"
      - "rotate=45*PI/180"
```

Output from the log:
```
[2021-03-19 21:44:35] [lib.camera.ute          ] [DEBUG   ] - FFMPEG decoder command: ffmpeg -hide_banner -loglevel fatal -avoid_negative_ts make_zero -fflags nobuffer -flags low_delay -strict experimental -fflags +genpts -stimeout 5000000 -use_wallclock_as_timestamps 1 -vsync 0 -c:v h264_cuvid -rtsp_transport tcp -i rtsp://*..*@192.168.0.*:554/h264 -f segment -segment_time 5 -segment_format mp4 -reset_timestamps 1 -strftime 1 -c copy -an /segments/Ute/%Y%m%d%H%M%S.mp4 -f rawvideo -pix_fmt nv12 pipe:1
```