### PR TITLE
Motion trigger recorder

### DIFF
--- a/viseron/camera/__init__.py
+++ b/viseron/camera/__init__.py
@@ -69,17 +69,18 @@ class FFMPEGCamera:
             f"@ {self.stream.fps} FPS"
         )
 
-        FrameDecoder(
-            self._logger,
-            self._config,
-            f"{self._config.camera.name_slug}.object_detection",
-            self._config.object_detection.interval,
-            self.stream,
-            self.decode_error,
-            TOPIC_FRAME_DECODE_OBJECT,
-            TOPIC_FRAME_SCAN_OBJECT,
-            preprocess_callback=detector.object_detector.preprocess,
-        )
+        if self._config.object_detection.enable:
+            FrameDecoder(
+                self._logger,
+                self._config,
+                f"{self._config.camera.name_slug}.object_detection",
+                self._config.object_detection.interval,
+                self.stream,
+                self.decode_error,
+                TOPIC_FRAME_DECODE_OBJECT,
+                TOPIC_FRAME_SCAN_OBJECT,
+                preprocess_callback=detector.object_detector.preprocess,
+            )
 
         self._logger.debug(f"Camera {self._config.camera.name} initialized")
 

--- a/viseron/config/__init__.py
+++ b/viseron/config/__init__.py
@@ -76,18 +76,37 @@ def load_config():
         sys.exit()
 
 
+def detector_enabled_check(config):
+    if not config["object_detection"]["enable"]:
+        for camera in config["cameras"]:
+            if (
+                camera.get("object_detection")
+                and camera["object_detection"].get("enable")
+                and camera["object_detection"]["enable"]
+            ):
+                raise Invalid(
+                    f"You have disabled object detection globally, "
+                    f"but have enabled object detection for camera {camera['name']}. "
+                    "This is not supported."
+                )
+    return config
+
+
 VISERON_CONFIG_SCHEMA = Schema(
-    {
-        Required("cameras"): CameraConfig.schema,
-        Optional("object_detection", default={}): ObjectDetectionConfig.schema,
-        Optional(
-            "motion_detection", default=MotionDetectionConfig.defaults
-        ): MotionDetectionConfig.schema,
-        Optional("post_processors", default={}): PostProcessorsConfig.schema,
-        Optional("recorder", default={}): RecorderConfig.schema,
-        Optional("mqtt", default=None): Any(MQTTConfig.schema, None),
-        Optional("logging", default={}): LoggingConfig.schema,
-    }
+    All(
+        {
+            Required("cameras"): CameraConfig.schema,
+            Optional("object_detection", default={}): ObjectDetectionConfig.schema,
+            Optional(
+                "motion_detection", default=MotionDetectionConfig.defaults
+            ): MotionDetectionConfig.schema,
+            Optional("post_processors", default={}): PostProcessorsConfig.schema,
+            Optional("recorder", default={}): RecorderConfig.schema,
+            Optional("mqtt", default=None): Any(MQTTConfig.schema, None),
+            Optional("logging", default={}): LoggingConfig.schema,
+        },
+        detector_enabled_check,
+    )
 )
 
 raw_config = load_config()

--- a/viseron/config/config_camera.py
+++ b/viseron/config/config_camera.py
@@ -165,6 +165,7 @@ CAMERA_SCHEMA = STREAM_SCEHMA.extend(
         ),
         Optional("object_detection"): Maybe(
             {
+                Optional("enable"): bool,
                 Optional("interval"): Any(int, float),
                 Optional("labels"): LABELS_SCHEMA,
                 Optional("logging"): LOGGING_SCHEMA,

--- a/viseron/config/config_camera.py
+++ b/viseron/config/config_camera.py
@@ -135,6 +135,7 @@ CAMERA_SCHEMA = STREAM_SCEHMA.extend(
             {
                 Optional("interval"): Any(int, float),
                 Optional("trigger_detector"): bool,
+                Optional("trigger_recorder"): bool,
                 Optional("timeout"): bool,
                 Optional("max_timeout"): int,
                 Optional("width"): int,

--- a/viseron/config/config_motion_detection.py
+++ b/viseron/config/config_motion_detection.py
@@ -7,6 +7,7 @@ from .config_logging import SCHEMA as LOGGING_SCHEMA, LoggingConfig
 DEFAULTS = {
     "interval": 1,
     "trigger_detector": True,
+    "trigger_recorder": False,
     "timeout": True,
     "max_timeout": 30,
     "width": 300,
@@ -23,6 +24,7 @@ SCHEMA = Schema(
             Any(float, int), Coerce(float), Range(min=0.0)
         ),
         Optional("trigger_detector", default=DEFAULTS["trigger_detector"]): bool,
+        Optional("trigger_recorder", default=DEFAULTS["trigger_recorder"]): bool,
         Optional("timeout", default=DEFAULTS["timeout"]): bool,
         Optional("max_timeout", default=DEFAULTS["max_timeout"]): int,
         Optional("width", default=DEFAULTS["width"]): int,
@@ -57,6 +59,10 @@ class MotionDetectionConfig:
         self._trigger_detector = camera_motion_detection.get(
             "trigger_detector",
             motion_detection["trigger_detector"],
+        )
+        self._trigger_recorder = camera_motion_detection.get(
+            "trigger_recorder",
+            motion_detection["trigger_recorder"],
         )
         self._timeout = camera_motion_detection.get(
             "timeout", motion_detection["timeout"]
@@ -99,6 +105,11 @@ class MotionDetectionConfig:
     def trigger_detector(self):
         """Return if motion triggers detector."""
         return self._trigger_detector
+
+    @property
+    def trigger_recorder(self):
+        """Return if motion starts the recorder."""
+        return self._trigger_recorder
 
     @property
     def timeout(self):

--- a/viseron/config/config_object_detection.py
+++ b/viseron/config/config_object_detection.py
@@ -20,6 +20,7 @@ from viseron.const import (
     ENV_RASPBERRYPI3,
     ENV_RASPBERRYPI4,
 )
+from viseron.helpers.validators import deprecated
 
 from .config_logging import SCHEMA as LOGGING_SCHEMA, LoggingConfig
 
@@ -64,6 +65,7 @@ def get_detector_type() -> str:
 LABELS_SCHEMA = Schema(
     [
         All(
+            deprecated("triggers_recording", replacement="trigger_recorder"),
             {
                 Required("label"): str,
                 Optional("confidence", default=0.8): All(
@@ -81,7 +83,7 @@ LABELS_SCHEMA = Schema(
                 Optional("width_max", default=1.0): All(
                     Any(0, 1, All(float, Range(min=0.0, max=1.0))), Coerce(float)
                 ),
-                Optional("triggers_recording", default=True): bool,
+                Optional("trigger_recorder", default=True): bool,
                 Optional("require_motion", default=False): bool,
                 Optional("post_processor", default=None): Any(str, None),
             },
@@ -101,7 +103,7 @@ class LabelConfig:
         self._height_max: float = label["height_max"]
         self._width_min: float = label["width_min"]
         self._width_max: float = label["width_max"]
-        self._triggers_recording: bool = label["triggers_recording"]
+        self._trigger_recorder: bool = label["trigger_recorder"]
         self._require_motion: bool = label["require_motion"]
         self._post_processor: str = label["post_processor"]
 
@@ -136,9 +138,9 @@ class LabelConfig:
         return self._width_max
 
     @property
-    def triggers_recording(self) -> bool:
+    def trigger_recorder(self) -> bool:
         """Return if label triggers recorder."""
-        return self._triggers_recording
+        return self._trigger_recorder
 
     @property
     def require_motion(self) -> bool:

--- a/viseron/config/config_object_detection.py
+++ b/viseron/config/config_object_detection.py
@@ -157,6 +157,7 @@ class LabelConfig:
 SCHEMA = Schema(
     {
         Optional("type", default=get_detector_type()): str,
+        Optional("enable", default=True): bool,
         Optional("interval", default=1): All(
             Any(float, int), Coerce(float), Range(min=0.0)
         ),
@@ -183,6 +184,7 @@ class ObjectDetectionConfig:
     # pylint: disable=dangerous-default-value
     def __init__(self, object_detection, camera_object_detection={}, camera_zones={}):
         self._type = object_detection["type"]
+        self._enable = camera_object_detection.get("enable", object_detection["enable"])
         self._interval = camera_object_detection.get(
             "interval", object_detection["interval"]
         )
@@ -201,7 +203,8 @@ class ObjectDetectionConfig:
         self._logging = LoggingConfig(logging) if logging else logging
 
         self._min_confidence = min(
-            label.confidence for label in self.concat_labels(camera_zones)
+            (label.confidence for label in self.concat_labels(camera_zones)),
+            default=1.0,
         )
 
     def concat_labels(self, camera_zones) -> List[LabelConfig]:
@@ -216,6 +219,11 @@ class ObjectDetectionConfig:
     def type(self) -> str:
         """Return detector type."""
         return self._type
+
+    @property
+    def enable(self) -> bool:
+        """Return if detector is enabled."""
+        return self._enable
 
     @property
     def interval(self) -> float:

--- a/viseron/detector/__init__.py
+++ b/viseron/detector/__init__.py
@@ -49,6 +49,11 @@ class Detector:
     """Subscribe to frames and run object detection using the configured detector."""
 
     def __init__(self, object_detection_config):
+        self.detection_lock = Lock()
+        # Config is not validated yet so we need to access the dictionary value
+        if not object_detection_config["enable"]:
+            return
+
         detector_module = importlib.import_module(
             "viseron.detector." + object_detection_config["type"]
         )
@@ -85,8 +90,6 @@ class Detector:
             LOGGER.setLevel(config.logging.level)
 
         LOGGER.debug(f"Initializing object detector {config.type}")
-
-        self.detection_lock = Lock()
 
         # Activate OpenCL
         if cv2.ocl.haveOpenCL():

--- a/viseron/helpers/filter.py
+++ b/viseron/helpers/filter.py
@@ -13,7 +13,7 @@ class Filter:
         self._width_max = object_filter.width_max
         self._height_min = object_filter.height_min
         self._height_max = object_filter.height_max
-        self._triggers_recording = object_filter.triggers_recording
+        self._trigger_recorder = object_filter.trigger_recorder
         self._require_motion = object_filter.require_motion
         self._post_processor = object_filter.post_processor
 
@@ -44,9 +44,9 @@ class Filter:
         )
 
     @property
-    def triggers_recording(self) -> bool:
+    def trigger_recorder(self) -> bool:
         """Return if label triggers recorder."""
-        return self._triggers_recording
+        return self._trigger_recorder
 
     @property
     def require_motion(self) -> bool:

--- a/viseron/helpers/logs.py
+++ b/viseron/helpers/logs.py
@@ -88,6 +88,7 @@ class ViseronLogFormat(ColoredFormatter):
         self.current_count = 0
 
     def format(self, record):
+        """Format log record."""
         # Save the original format configured by the user
         # when the logger formatter was instantiated
         format_orig = self._style._fmt

--- a/viseron/helpers/validators.py
+++ b/viseron/helpers/validators.py
@@ -1,0 +1,32 @@
+"""Custom voluptuous validators."""
+from typing import Callable, Optional
+
+from voluptuous import Invalid
+
+
+def deprecated(key: str, replacement: Optional[str] = None) -> Callable[[dict], dict]:
+    """Mark key as deprecated and optionally replace it."""
+
+    def validator(config):
+        """Warn if key is present. Replace it if a value is given."""
+        if key in config:
+            if replacement:
+                print(
+                    f"Config option {key} is deprecated. "
+                    f"Replace it with {replacement}. "
+                    "In the future this will produce an error"
+                )
+                value = config[key]
+                config.pop(key)
+
+                if replacement not in config:
+                    config[replacement] = value
+                    return config
+                return config
+            raise Invalid(
+                f"Config option {key} is deprecated. "
+                "Please remove it from your configuration"
+            )
+        return config
+
+    return validator

--- a/viseron/nvr.py
+++ b/viseron/nvr.py
@@ -512,6 +512,13 @@ class FFMPEGNVR:
             ):
                 self.camera.stream.decoders[self._object_decoder].scan.set()
                 self._logger.debug("Starting object detector")
+
+            if (
+                not self.recorder.is_recording
+                and self.config.motion_detection.trigger_recorder
+            ):
+                self._start_recorder = True
+
         elif (
             self.camera.stream.decoders[self._object_decoder].scan.is_set()
             and not self.recorder.is_recording

--- a/viseron/nvr.py
+++ b/viseron/nvr.py
@@ -374,7 +374,7 @@ class FFMPEGNVR:
                 objects_in_fov.append(obj)
                 labels_in_fov.append(obj.label)
 
-                if self._object_filters[obj.label].triggers_recording:
+                if self._object_filters[obj.label].trigger_recorder:
                     obj.trigger_recorder = True
 
                 if self._object_filters[obj.label].post_processor:

--- a/viseron/nvr.py
+++ b/viseron/nvr.py
@@ -166,9 +166,11 @@ class FFMPEGNVR:
 
         if config.motion_detection.trigger_detector:
             self.camera.stream.decoders[self._motion_decoder].scan.set()
-            self.camera.stream.decoders[self._object_decoder].scan.clear()
+            if config.object_detection.enable:
+                self.camera.stream.decoders[self._object_decoder].scan.clear()
         else:
-            self.camera.stream.decoders[self._object_decoder].scan.set()
+            if config.object_detection.enable:
+                self.camera.stream.decoders[self._object_decoder].scan.set()
             self.camera.stream.decoders[self._motion_decoder].scan.clear()
         self.idle_frames = 0
 
@@ -508,6 +510,7 @@ class FFMPEGNVR:
         if self.motion_detected:
             if (
                 self.config.motion_detection.trigger_detector
+                and self.config.object_detection.enable
                 and not self.camera.stream.decoders[self._object_decoder].scan.is_set()
             ):
                 self.camera.stream.decoders[self._object_decoder].scan.set()
@@ -520,7 +523,8 @@ class FFMPEGNVR:
                 self._start_recorder = True
 
         elif (
-            self.camera.stream.decoders[self._object_decoder].scan.is_set()
+            self.config.object_detection.enable
+            and self.camera.stream.decoders[self._object_decoder].scan.is_set()
             and not self.recorder.is_recording
             and self.config.motion_detection.trigger_detector
         ):
@@ -535,7 +539,10 @@ class FFMPEGNVR:
         status = "unknown"
         if self.recorder.is_recording:
             status = "recording"
-        elif self.camera.stream.decoders[self._object_decoder].scan.is_set():
+        elif (
+            self.config.object_detection.enable
+            and self.camera.stream.decoders[self._object_decoder].scan.is_set()
+        ):
             status = "scanning_for_objects"
         elif self.camera.stream.decoders[self._motion_decoder].scan.is_set():
             status = "scanning_for_motion"

--- a/viseron/zones.py
+++ b/viseron/zones.py
@@ -86,7 +86,7 @@ class Zone:
                     if obj.label not in labels_in_zone:
                         labels_in_zone.append(obj.label)
 
-                    if self._object_filters[obj.label].triggers_recording:
+                    if self._object_filters[obj.label].trigger_recorder:
                         obj.trigger_recorder = True
 
                     if self._object_filters[obj.label].post_processor:


### PR DESCRIPTION
This introduces a new config option under `motion_detection`, `trigger_recorder` which will start the recorder when motion is detected.

`triggers_recording` for labels is now called `trigger_recorder`.

There is also another config option available under `object_detection`, `enable` which you can set to `false` to disable object detection altogether and save some resources.

Closes #115, #149 