### PR TITLE
Add newline after jpgboundary

### DIFF
--- a/viseron/components/webserver/stream_handler.py
+++ b/viseron/components/webserver/stream_handler.py
@@ -227,7 +227,7 @@ class StaticStreamHandler(StreamHandler):
         while True:
             try:
                 jpg = await frame_queue.get()
-                self.write("--jpgboundary")
+                self.write("--jpgboundary\r\n")
                 self.write("Content-type: image/jpeg\r\n")
                 self.write("Content-length: %s\r\n\r\n" % len(jpg))
                 self.write(jpg.tobytes())


### PR DESCRIPTION
```
curl -i http://viseron:8888/camera_one/mjpeg-stream --output -
HTTP/1.1 200 OK
Server: TornadoServer/6.1
Content-Type: multipart/x-mixed-replace;boundary=--jpgboundary
Date: Thu, 23 Jun 2022 08:35:10 GMT
Connection: close
Transfer-Encoding: chunked

--jpgboundaryContent-type: image/jpeg
Content-length: 3927190
```

this caused safari to render page as text not JPG