### PR TITLE
fix automatic pipeline trigger error after rename

### DIFF
--- a/azure-pipelines/azure-pipelines-wheels.yml
+++ b/azure-pipelines/azure-pipelines-wheels.yml
@@ -12,8 +12,8 @@ pool:
 
 resources:
   pipelines:
-    - pipeline: viserondlib
-      source: "Viseron dlib"
+    - pipeline: viserontools
+      source: "Viseron tools"
       trigger:
         branches:
           - dev


### PR DESCRIPTION
Viseron dlib pipeline hs been renamed to Viseron tools in Azure