### PR TITLE
scale the non-padded axis

### DIFF
--- a/tests/helpers/test__init__.py
+++ b/tests/helpers/test__init__.py
@@ -10,6 +10,22 @@ from viseron import helpers
     "frame_res, model_res, bbox, expected, raises, message",
     [
         (
+            (1920, 1080),
+            (300, 300),
+            (75, 90, 105, 120),
+            (480, 156, 672, 348),
+            nullcontext(),
+            None,
+        ),
+        (
+            (1080, 1920),
+            (300, 300),
+            (75, 90, 105, 120),
+            (60, 576, 252, 768),
+            nullcontext(),
+            None,
+        ),
+        (
             (640, 360),
             (640, 640),
             (10, 320, 10, 320),

--- a/viseron/helpers/__init__.py
+++ b/viseron/helpers/__init__.py
@@ -390,7 +390,12 @@ def convert_letterboxed_bbox(
             * frame_width
             / model_width
         )
-        return x1, y1, x2, y2
+        return (
+            (x1 / model_width) * frame_width,  # Scale width from model to frame width
+            y1,
+            (x2 / model_width) * frame_width,  # Scale width from model to frame width
+            y2,
+        )
 
     # Vertical padding
     x1 = (
@@ -403,7 +408,12 @@ def convert_letterboxed_bbox(
         * frame_height
         / model_width
     )
-    return x1, y1, x2, y2
+    return (
+        x1,
+        (y1 / model_height) * frame_height,  # Scale height from model to frame height
+        x2,
+        (y2 / model_height) * frame_height,  # Scale height from model to frame height
+    )
 
 
 def memory_usage_profiler(logger, key_type="lineno", limit=5):


### PR DESCRIPTION
Fix bug which caused bounding boxes to have wrong offset on non padded axis when image was letterboxed resized