### PR TITLE
Feature/warn on missing nvr

### DIFF
--- a/viseron/components/darknet/__init__.py
+++ b/viseron/components/darknet/__init__.py
@@ -12,7 +12,8 @@ import voluptuous as vol
 
 from viseron import Viseron
 from viseron.const import ENV_CUDA_SUPPORTED
-from viseron.domains import RequireDomain, setup_domain
+from viseron.domains import OptionalDomain, RequireDomain, setup_domain
+from viseron.domains.motion_detector.const import DOMAIN as MOTION_DETECTOR_DOMAIN
 from viseron.domains.object_detector import BASE_CONFIG_SCHEMA
 from viseron.domains.object_detector.const import CONFIG_CAMERAS
 from viseron.domains.object_detector.detected_object import DetectedObject
@@ -133,6 +134,12 @@ def setup(vis: Viseron, config):
                     domain="camera",
                     identifier=camera_identifier,
                 )
+            ],
+            optional_domains=[
+                OptionalDomain(
+                    domain=MOTION_DETECTOR_DOMAIN,
+                    identifier=camera_identifier,
+                ),
             ],
         )
 

--- a/viseron/components/deepstack/__init__.py
+++ b/viseron/components/deepstack/__init__.py
@@ -5,10 +5,11 @@ import voluptuous as vol
 
 from viseron import Viseron
 from viseron.components.deepstack.face_recognition import DeepstackTrain
-from viseron.domains import RequireDomain, setup_domain
+from viseron.domains import OptionalDomain, RequireDomain, setup_domain
 from viseron.domains.face_recognition import (
     BASE_CONFIG_SCHEMA as FACE_RECOGNITION_BASE_CONFIG_SCHEMA,
 )
+from viseron.domains.motion_detector.const import DOMAIN as MOTION_DETECTOR_DOMAIN
 from viseron.domains.object_detector import (
     BASE_CONFIG_SCHEMA as OBJECT_DETECTOR_BASE_CONFIG_SCHEMA,
 )
@@ -127,6 +128,12 @@ def setup(vis: Viseron, config):
                         domain="camera",
                         identifier=camera_identifier,
                     )
+                ],
+                optional_domains=[
+                    OptionalDomain(
+                        domain=MOTION_DETECTOR_DOMAIN,
+                        identifier=camera_identifier,
+                    ),
                 ],
             )
 

--- a/viseron/components/edgetpu/__init__.py
+++ b/viseron/components/edgetpu/__init__.py
@@ -10,11 +10,12 @@ from pycoral.utils.dataset import read_label_file
 from pycoral.utils.edgetpu import list_edge_tpus, make_interpreter
 
 from viseron import Viseron
-from viseron.domains import RequireDomain, setup_domain
+from viseron.domains import OptionalDomain, RequireDomain, setup_domain
 from viseron.domains.image_classification import (
     BASE_CONFIG_SCHEMA as IMAGE_CLASSIFICATION_BASE_CONFIG_SCHEMA,
     ImageClassificationResult,
 )
+from viseron.domains.motion_detector.const import DOMAIN as MOTION_DETECTOR_DOMAIN
 from viseron.domains.object_detector import BASE_CONFIG_SCHEMA
 from viseron.domains.object_detector.const import CONFIG_CAMERAS
 from viseron.domains.object_detector.detected_object import DetectedObject
@@ -117,6 +118,12 @@ def setup(vis: Viseron, config):
                         domain="camera",
                         identifier=camera_identifier,
                     )
+                ],
+                optional_domains=[
+                    OptionalDomain(
+                        domain=MOTION_DETECTOR_DOMAIN,
+                        identifier=camera_identifier,
+                    ),
                 ],
             )
     return True


### PR DESCRIPTION
Setup `nvr` automatically for each registered camera if `nvr` is not present in config.

If `nvr` is present, warnings will be logged to alert the user.

Alsol warns if `scan_on_motion_only: true` but no motion detector is configured