### PR TITLE
install libpng-dev in jetson nano dlib and base

### DIFF
--- a/docker/jetson-nano/Dockerfile.base
+++ b/docker/jetson-nano/Dockerfile.base
@@ -48,6 +48,7 @@ RUN \
   libhdf5-100 \
   liblapacke \
   libopenexr22 \
+  libpng-dev \
   libpng16-16 \
   libatomic1 \
   # L4T (needed by ffmpeg)

--- a/docker/jetson-nano/Dockerfile.dlib
+++ b/docker/jetson-nano/Dockerfile.dlib
@@ -48,6 +48,7 @@ RUN buildDeps="autoconf \
   git \
   libopenblas-dev \
   liblapack-dev \
+  libpng-dev \
   make \
   python3-dev \
   python3-pip \


### PR DESCRIPTION
dlib statically links libpng if it cant be found which does not work when running multi stage docker builds

Closes #403