### PR TITLE
make sure segments are not deleted during concat

### DIFF
--- a/tests/components/gstreamer/__init__.py
+++ b/tests/components/gstreamer/__init__.py
@@ -1,0 +1,1 @@
+"""GStreamer tests."""

--- a/tests/components/gstreamer/test_segments.py
+++ b/tests/components/gstreamer/test_segments.py
@@ -1,0 +1,48 @@
+"""GStreamer segments tests."""
+import logging
+
+from viseron.components.gstreamer.segments import Segments
+
+
+class TestSegments:
+    """Test the Segments class."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set up testcase."""
+        config = {}
+        logger = logging.getLogger("viseron.components.gstreamer")
+        cls.segments = Segments(config, logger, "/testing")
+
+    def test_get_concat_segments(self):
+        """Test that the segments are correctly sorted."""
+        segments = {
+            "38.mp4": {
+                "start_time": 1670490410.0108843,
+                "end_time": 1670490414.8301842,
+            },
+            "39.mp4": {
+                "start_time": 1670490414.8788238,
+                "end_time": 1670490419.7802238,
+            },
+            "40.mp4": {
+                "start_time": 1670490419.610765,
+                "end_time": 1670490424.517965,
+            },
+            "41.mp4": {
+                "start_time": 1670490424.4067051,
+                "end_time": 1670490429.3205051,
+            },
+            "42.mp4": {
+                "start_time": 1670490429.4067051,
+                "end_time": 1670490434.3205051,
+            },
+            "4.mp4": {
+                "start_time": 1670490325.4067051,
+                "end_time": 1670490330.3205051,
+            },
+        }
+        concat_segments = self.segments.get_concat_segments(
+            segments, "39.mp4", "41.mp4"
+        )
+        assert concat_segments == ["39.mp4", "40.mp4", "41.mp4"]

--- a/viseron/components/gstreamer/recorder.py
+++ b/viseron/components/gstreamer/recorder.py
@@ -1,8 +1,9 @@
 """Recorder."""
 import logging
 import os
-from threading import Thread
+import threading
 
+from viseron.components.ffmpeg.recorder import ConcatThreadsContext
 from viseron.domains.camera import CONFIG_LOOKBACK
 from viseron.domains.camera.recorder import AbstractRecorder
 from viseron.helpers import create_directory
@@ -24,25 +25,35 @@ class Recorder(AbstractRecorder):
         self._event_start = None
         self._event_end = None
 
+        self._segment_thread_context = ConcatThreadsContext()
+        self._concat_thread_lock = threading.Lock()
+
         segments_folder = os.path.join(
             self._recorder_config[CONFIG_SEGMENTS_FOLDER], self._camera.identifier
         )
         create_directory(segments_folder)
         self._segmenter = Segments(self._logger, config, segments_folder)
         self._segment_cleanup = SegmentCleanup(
-            vis, self._recorder_config, self._camera.identifier, self._logger
+            vis,
+            self._recorder_config,
+            self._camera.identifier,
+            self._logger,
+            self._segment_thread_context,
         )
 
     def concat_segments(self):
         """Concatenate GStreamer segments to a single video."""
-        self._segmenter.concat_segments(
-            self._event_start - self._recorder_config[CONFIG_LOOKBACK],
-            self._event_end,
-            self.last_recording_path,
-        )
-        # Dont resume cleanup if new recording started during encoding
-        if not self.is_recording:
-            self._segment_cleanup.resume()
+        with self._segment_thread_context:
+            with self._concat_thread_lock:
+                self._segment_cleanup.pause()
+                self._segmenter.concat_segments(
+                    self._event_start - self._recorder_config[CONFIG_LOOKBACK],
+                    self._event_end,
+                    self.last_recording_path,
+                )
+                # Dont resume cleanup if new recording started during encoding
+                if not self.is_recording:
+                    self._segment_cleanup.resume()
 
     def _start(self, shared_frame, objects_in_fov, resolution):
         self._segment_cleanup.pause()
@@ -50,5 +61,5 @@ class Recorder(AbstractRecorder):
 
     def _stop(self):
         self._event_end = int(self.last_recording_end.timestamp())
-        concat_thread = Thread(target=self.concat_segments)
+        concat_thread = threading.Thread(target=self.concat_segments)
         concat_thread.start()

--- a/viseron/components/gstreamer/segments.py
+++ b/viseron/components/gstreamer/segments.py
@@ -114,8 +114,10 @@ class Segments:
 
     def get_concat_segments(self, segments, start_segment, end_segment):
         """Return all segments between start_segment and end_segment."""
-        segment_list = list(segments.keys())
-        segment_list.sort()
+        # Sort segments by start time
+        segment_list = sorted(
+            segments.keys(), key=lambda x: (segments[x]["start_time"])
+        )
         try:
             return segment_list[
                 len(segment_list)
@@ -242,15 +244,20 @@ class Segments:
             self._logger.error("Failed to concatenate segments: %s", error)
             return
 
+        for segment in segments_to_concat[:-1]:
+            self._logger.debug(f"Removing segment: {segment}")
+            os.remove(os.path.join(self._segments_folder, segment))
+
         self._logger.debug("Segments concatenated")
 
 
 class SegmentCleanup:
     """Clean up segments created by GStreamer."""
 
-    def __init__(self, vis, config, camera_name, logger):
+    def __init__(self, vis, config, camera_name, logger, segment_thread_context):
         self._vis = vis
         self._logger = logger
+        self._segment_thread_context = segment_thread_context
         self._directory = os.path.join(config[CONFIG_SEGMENTS_FOLDER], camera_name)
         # Make sure we dont delete a segment which is needed by recorder
         self._max_age = config[CONFIG_LOOKBACK] + (CAMERA_SEGMENT_DURATION * 3)
@@ -267,6 +274,12 @@ class SegmentCleanup:
 
     def cleanup(self, force=False):
         """Delete all segments that are no longer needed."""
+        if not force and self._segment_thread_context.count > 0:
+            self._logger.debug(
+                "Skipping segment cleanup since segment concatenation is running"
+            )
+            return
+
         now = datetime.datetime.now().timestamp()
         for segment in os.listdir(self._directory):
             if force:

--- a/viseron/components/nvr/nvr.py
+++ b/viseron/components/nvr/nvr.py
@@ -542,6 +542,7 @@ class NVR:
 
     def start_recorder(self, shared_frame):
         """Start recorder."""
+        self._idle_frames = 0
         self._camera.start_recorder(
             shared_frame,
             self._object_detector.objects_in_fov if self._object_detector else None,
@@ -578,7 +579,7 @@ class NVR:
             ):
                 self._frame_scanners[MOTION_DETECTOR].scan = False
                 self._logger.info("Pausing motion detector")
-
+            self._idle_frames = 0
             self._camera.stop_recorder()
 
     def process_frame(self, shared_frame: SharedFrame):


### PR DESCRIPTION
If a new recording started while concatenation of segments from a previous recording was still running, it could lead to segments being deleted when they shouldnt be.

This PR adds some extra fail safes to try and prevent that.

Discussed in this thread #403