### PR TITLE
Show new recordings without refreshing

### DIFF
--- a/frontend/src/components/CameraCard.tsx
+++ b/frontend/src/components/CameraCard.tsx
@@ -1,5 +1,5 @@
 import Image from "@jy95/material-ui-image";
-import { CardActionArea, CardActions } from "@mui/material";
+import { CardActions, CardMedia } from "@mui/material";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Typography from "@mui/material/Typography";
@@ -95,7 +95,7 @@ export default function CameraCard({ camera }: CameraCardProps) {
           {camera.name}
         </Typography>
       </CardContent>
-      <CardActionArea>
+      <CardMedia>
         {/* 'alt=""' in combination with textIndent is a neat trick to hide the broken image icon */}
         <Image
           alt=""
@@ -124,7 +124,7 @@ export default function CameraCard({ camera }: CameraCardProps) {
             }));
           }}
         />
-      </CardActionArea>
+      </CardMedia>
       <CardActions>
         <CardActionButtonLink
           title="Recordings"

--- a/frontend/src/components/CardActionButton.tsx
+++ b/frontend/src/components/CardActionButton.tsx
@@ -6,6 +6,7 @@ interface CardActionButtonProps {
   title: string;
   target: string;
   width?: string;
+  disabled?: boolean;
 }
 
 type ExtendedButtonProps = ButtonProps & {
@@ -31,6 +32,7 @@ export function CardActionButtonLink({
   title,
   target,
   width = "50%",
+  disabled = false,
 }: CardActionButtonProps) {
   return (
     <StyledButton
@@ -38,6 +40,7 @@ export function CardActionButtonLink({
       to={target}
       variant="outlined"
       size="large"
+      disabled={disabled}
       sx={{
         width,
       }}

--- a/frontend/src/components/recording/RecordingCard.tsx
+++ b/frontend/src/components/recording/RecordingCard.tsx
@@ -1,4 +1,4 @@
-import { CardActionArea } from "@mui/material";
+import { CardMedia } from "@mui/material";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Typography from "@mui/material/Typography";
@@ -28,7 +28,7 @@ export default function RecordingCard({
             {recording.filename.split(".")[0]}
           </Typography>
         </CardContent>
-        <CardActionArea>
+        <CardMedia>
           <LazyLoad
             height={200}
             offset={500}
@@ -40,7 +40,7 @@ export default function RecordingCard({
               overlay={false}
             />
           </LazyLoad>
-        </CardActionArea>
+        </CardMedia>
       </Card>
     </LazyLoad>
   );

--- a/frontend/src/components/recording/RecordingCardDaily.tsx
+++ b/frontend/src/components/recording/RecordingCardDaily.tsx
@@ -1,4 +1,4 @@
-import { CardActionArea, CardActions } from "@mui/material";
+import { CardActions, CardMedia } from "@mui/material";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Typography from "@mui/material/Typography";
@@ -28,9 +28,12 @@ function getLatestRecordingDate(recordings: types.Recordings, date: string) {
   return dailyRecordings[Object.keys(dailyRecordings).sort().reverse()[0]];
 }
 
-function getVideoElement(lastRecording: types.Recording | null) {
+function getVideoElement(
+  camera: types.Camera,
+  lastRecording: types.Recording | null
+) {
   if (lastRecording === null) {
-    return <Typography align="center">No recordings found</Typography>;
+    return <VideoPlayerPlaceholder camera={camera} />;
   }
 
   const videoJsOptions = getRecordingVideoJSOptions(lastRecording);
@@ -50,23 +53,26 @@ export default function RecordingCardDaily({
           <Typography variant="h5" align="center">
             {date}
           </Typography>
-          {lastRecording && (
+          {lastRecording ? (
             <Typography align="center">{`Last recording: ${
               lastRecording.filename.split(".")[0]
             }`}</Typography>
+          ) : (
+            <Typography align="center">No recordings found</Typography>
           )}
         </CardContent>
-        <CardActionArea>
+        <CardMedia>
           <LazyLoad
             height={200}
             offset={500}
             placeholder={<VideoPlayerPlaceholder camera={camera} />}
           >
-            {getVideoElement(lastRecording)}
+            {getVideoElement(camera, lastRecording)}
           </LazyLoad>
-        </CardActionArea>
+        </CardMedia>
         <CardActions>
           <CardActionButtonLink
+            disabled={lastRecording === null}
             title="View Recordings"
             target={`/recordings/${camera.identifier}/${date}`}
             width="100%"

--- a/frontend/src/components/recording/RecordingCardLatest.tsx
+++ b/frontend/src/components/recording/RecordingCardLatest.tsx
@@ -1,4 +1,4 @@
-import { CardActionArea, CardActions } from "@mui/material";
+import { CardActions, CardMedia } from "@mui/material";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Typography from "@mui/material/Typography";
@@ -28,9 +28,12 @@ function getLatestRecording(recordings: types.Recordings) {
   return latestRecordings[Object.keys(latestRecordings).sort().reverse()[0]];
 }
 
-function getVideoElement(latestRecording: types.Recording | null) {
+function getVideoElement(
+  camera: types.Camera,
+  latestRecording: types.Recording | null
+) {
   if (latestRecording === null) {
-    return <Typography align="center">No recordings found</Typography>;
+    return <VideoPlayerPlaceholder camera={camera} />;
   }
 
   const videoJsOptions = getRecordingVideoJSOptions(latestRecording);
@@ -50,22 +53,25 @@ export default function RecordingCardLatest({
           <Typography variant="h5" align="center">
             {camera.name}
           </Typography>
-          {latestRecording && (
+          {latestRecording ? (
             <Typography align="center">{`Latest recording: ${
               latestRecording.date
             } - ${latestRecording.filename.split(".")[0]}`}</Typography>
+          ) : (
+            <Typography align="center">No recordings found</Typography>
           )}
         </CardContent>
-        <CardActionArea>
+        <CardMedia>
           <LazyLoad
             height={200}
             placeholder={<VideoPlayerPlaceholder camera={camera} />}
           >
-            {getVideoElement(latestRecording)}
+            {getVideoElement(camera, latestRecording)}
           </LazyLoad>
-        </CardActionArea>
+        </CardMedia>
         <CardActions>
           <CardActionButtonLink
+            disabled={latestRecording === null}
             title="View Recordings"
             target={`/recordings/${camera.identifier}`}
             width="100%"

--- a/frontend/src/components/videoplayer/VideoPlayer.tsx
+++ b/frontend/src/components/videoplayer/VideoPlayer.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useRef } from "react";
+import { FC, useEffect, useRef, useState } from "react";
 import videojs from "video.js";
 import "video.js/dist/video-js.css";
 import "videojs-overlay";
@@ -50,6 +50,7 @@ const VideoPlayer: FC<VideoPlayerPropsInferface> = ({
 }) => {
   const videoNode = useRef<HTMLVideoElement>(null);
   const player = useRef<videojs.Player>();
+  const [source, setSource] = useState<string>(options.sources![0].src);
 
   useEffect(() => {
     if (!player.current) {
@@ -81,6 +82,13 @@ const VideoPlayer: FC<VideoPlayerPropsInferface> = ({
     // Must disable this warning since we dont want to ever run this twice
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  if (player.current && source !== options.sources![0].src) {
+    player.current.src(options.sources!);
+    player.current.poster(options.poster!);
+    player.current.load();
+    setSource(options.sources![0].src);
+  }
 
   return (
     <div data-vjs-player>

--- a/frontend/src/lib/commands.ts
+++ b/frontend/src/lib/commands.ts
@@ -10,12 +10,25 @@ export const getCameras = (async (connection: Connection): Promise<types.Cameras
 
 export const subscribeCameras = (async (connection: Connection, cameraCallback: (camera: types.Camera) => void) => {
   const storedCameraCallback = cameraCallback;
-  const _cameraCallback = (message: types.CameraRegisteredEvent) => {
+  const _cameraCallback = (message: types.EventCameraRegistered) => {
     storedCameraCallback(message.data);
   };
   const subscription = await connection.subscribeEvent(
     "domain/registered/camera",
     _cameraCallback,
+    true
+  );
+  return subscription;
+})
+
+export const subscribeRecording = (async (connection: Connection, recordingCallback: (recordingEvent: types.EventRecorderComplete) => void) => {
+  const storedRecordingCallback = recordingCallback;
+  const _recordingCallback = (message: types.EventRecorderComplete) => {
+    storedRecordingCallback(message);
+  };
+  const subscription = await connection.subscribeEvent(
+    "*/recorder/complete",
+    _recordingCallback,
     true
   );
   return subscription;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -32,16 +32,6 @@ export type WebSocketResponse =
   | WebSocketResultResponse
   | WebSocketResultErrorResponse;
 
-
-export type EventBase = {
-  timestamp: number;
-};
-
-export type Event = EventBase & {
-  name: string;
-  data: { [key: string]: any };
-};
-
 export interface Recording {
   date: string
   filename: string
@@ -63,14 +53,47 @@ export interface Camera {
   recordings: Recordings;
 }
 
-
 export interface Cameras {
   [index: string]: Camera;
 }
 
-export type CameraRegisteredEvent = EventBase & {
+export interface DetectedObject {
+  label: string;
+confidence: number;
+rel_width: number;
+rel_height: number;
+rel_x1: number;
+rel_y1: number
+rel_x2: number;
+rel_y2: number;
+}
+
+export type EventBase = {
+  timestamp: number;
+};
+
+export type Event = EventBase & {
+  name: string;
+  data: { [key: string]: any };
+};
+
+export type EventCameraRegistered = Event & {
   name: "camera_registered";
   data: Camera;
+};
+
+export type EventRecorderComplete = Event & {
+  name: "recorder_complete";
+  data: {
+    camera: Camera
+    recording: Recording & {
+      start_time: string;
+      start_timestamp: number;
+      end_time: string;
+      end_timestamp: number;
+      objects: [DetectedObject];
+    };
+  }
 };
 
 export interface EntityAttributes {

--- a/frontend/src/lib/websockets.ts
+++ b/frontend/src/lib/websockets.ts
@@ -4,7 +4,6 @@ import { toast } from "react-toastify";
 import * as messages from "lib/messages";
 import * as types from "lib/types";
 
-const connectedToastId = "connectedToastId";
 const connectingToastId = "connectingToastId";
 const connectionLostToastId = "connectionLostToastId";
 
@@ -90,12 +89,6 @@ export class Connection {
     console.log("Connection opened");
     this.commandId = 0;
     if (this.reconnectTimer) {
-      toast("Connected to server!", {
-        toastId: connectedToastId,
-        type: toast.TYPE.INFO,
-        autoClose: 1000,
-        pauseOnFocusLoss: false,
-      });
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }

--- a/frontend/src/pages/Cameras.tsx
+++ b/frontend/src/pages/Cameras.tsx
@@ -1,5 +1,6 @@
 import Container from "@mui/material/Container";
 import Grid from "@mui/material/Grid";
+import Typography from "@mui/material/Typography";
 import { useContext } from "react";
 
 import CameraCard from "components/CameraCard";
@@ -18,6 +19,9 @@ const Cameras = () => {
 
   return (
     <Container>
+      <Typography variant="h5" align="center">
+        Cameras
+      </Typography>
       <Grid container direction="row" spacing={2}>
         {Object.keys(viseron.cameras).map((camera) => (
           <Grid

--- a/frontend/src/pages/recordings/Recordings.tsx
+++ b/frontend/src/pages/recordings/Recordings.tsx
@@ -1,5 +1,6 @@
 import Container from "@mui/material/Container";
 import Grid from "@mui/material/Grid";
+import Typography from "@mui/material/Typography";
 import { useContext } from "react";
 
 import { ScrollToTopOnMount } from "components/ScrollToTop";
@@ -20,6 +21,9 @@ const Recordings = () => {
   return (
     <Container>
       <ScrollToTopOnMount />
+      <Typography variant="h5" align="center">
+        Recordings
+      </Typography>
       <Grid container direction="row" spacing={2}>
         {Object.keys(viseron.cameras).map((camera) => (
           <Grid

--- a/tests/components/gstreamer/test_segments.py
+++ b/tests/components/gstreamer/test_segments.py
@@ -3,20 +3,20 @@ import logging
 
 from viseron.components.gstreamer.segments import Segments
 
+from tests.common import MockCamera
+
 
 class TestSegments:
     """Test the Segments class."""
 
-    @classmethod
-    def setup_class(cls):
-        """Set up testcase."""
+    def test_get_concat_segments(self, vis):
+        """Test that the segments are correctly sorted."""
         config = {}
         logger = logging.getLogger("viseron.components.gstreamer")
-        cls.segments = Segments(config, logger, "/testing")
+        mocked_camera = MockCamera(identifier="test_camera_identifier")
+        segments = Segments(logger, config, vis, mocked_camera, "/testing")
 
-    def test_get_concat_segments(self):
-        """Test that the segments are correctly sorted."""
-        segments = {
+        segs = {
             "38.mp4": {
                 "start_time": 1670490410.0108843,
                 "end_time": 1670490414.8301842,
@@ -42,7 +42,5 @@ class TestSegments:
                 "end_time": 1670490330.3205051,
             },
         }
-        concat_segments = self.segments.get_concat_segments(
-            segments, "39.mp4", "41.mp4"
-        )
+        concat_segments = segments.get_concat_segments(segs, "39.mp4", "41.mp4")
         assert concat_segments == ["39.mp4", "40.mp4", "41.mp4"]

--- a/viseron/components/ffmpeg/camera.py
+++ b/viseron/components/ffmpeg/camera.py
@@ -435,7 +435,7 @@ class Camera(AbstractCamera):
 
     def stop_recorder(self):
         """Stop camera recorder."""
-        self._recorder.stop()
+        self._recorder.stop(self.recorder.active_recording)
 
     @property
     def output_fps(self):

--- a/viseron/components/ffmpeg/recorder.py
+++ b/viseron/components/ffmpeg/recorder.py
@@ -1,14 +1,21 @@
 """Recorder."""
+from __future__ import annotations
+
 import logging
 import os
 import threading
+from typing import TYPE_CHECKING
 
-from viseron.domains.camera import CONFIG_LOOKBACK
 from viseron.domains.camera.recorder import AbstractRecorder
 from viseron.helpers import create_directory
 
 from .const import COMPONENT, CONFIG_SEGMENTS_FOLDER, RECORDER
 from .segments import SegmentCleanup, Segments
+
+if TYPE_CHECKING:
+    from viseron import Viseron
+    from viseron.domains.camera import AbstractCamera
+    from viseron.domains.camera.recorder import Recording
 
 LOGGER = logging.getLogger(__name__)
 
@@ -35,13 +42,10 @@ class ConcatThreadsContext:
 class Recorder(AbstractRecorder):
     """Creates thumbnails and recordings."""
 
-    def __init__(self, vis, config, camera):
+    def __init__(self, vis: Viseron, config, camera: AbstractCamera):
         super().__init__(vis, COMPONENT, config, camera)
         self._logger.debug("Initializing recorder")
         self._recorder_config = config[RECORDER]
-
-        self._event_start = None
-        self._event_end = None
 
         self._segment_thread_context = ConcatThreadsContext()
         self._concat_thread_lock = threading.Lock()
@@ -50,7 +54,7 @@ class Recorder(AbstractRecorder):
             self._recorder_config[CONFIG_SEGMENTS_FOLDER], self._camera.identifier
         )
         create_directory(segments_folder)
-        self._segmenter = Segments(self._logger, config, segments_folder)
+        self._segmenter = Segments(self._logger, config, vis, camera, segments_folder)
         self._segment_cleanup = SegmentCleanup(
             vis,
             self._recorder_config,
@@ -59,25 +63,19 @@ class Recorder(AbstractRecorder):
             self._segment_thread_context,
         )
 
-    def concat_segments(self):
+    def concat_segments(self, recording: Recording):
         """Concatenate FFmpeg segments to a single video."""
         with self._segment_thread_context:
             with self._concat_thread_lock:
                 self._segment_cleanup.pause()
-                self._segmenter.concat_segments(
-                    self._event_start - self._recorder_config[CONFIG_LOOKBACK],
-                    self._event_end,
-                    self.last_recording_path,
-                )
+                self._segmenter.concat_segments(recording)
                 # Dont resume cleanup if new recording started during encoding
                 if not self.is_recording:
                     self._segment_cleanup.resume()
 
-    def _start(self, shared_frame, objects_in_fov, resolution):
+    def _start(self, recording, shared_frame, objects_in_fov, resolution):
         self._segment_cleanup.pause()
-        self._event_start = int(self.last_recording_start.timestamp())
 
-    def _stop(self):
-        self._event_end = int(self.last_recording_end.timestamp())
-        concat_thread = threading.Thread(target=self.concat_segments)
+    def _stop(self, recording):
+        concat_thread = threading.Thread(target=self.concat_segments, args=(recording,))
         concat_thread.start()

--- a/viseron/components/ffmpeg/segments.py
+++ b/viseron/components/ffmpeg/segments.py
@@ -1,14 +1,19 @@
 """Concatenate FFmpeg segments to a single video file."""
+from __future__ import annotations
+
 import datetime
 import os
 import shutil
 import subprocess as sp
 import time
+from typing import TYPE_CHECKING
 
 from apscheduler.schedulers.background import BackgroundScheduler
 
 from viseron.const import VISERON_SIGNAL_SHUTDOWN
 from viseron.domains.camera import CONFIG_LOOKBACK
+from viseron.domains.camera.const import EVENT_RECORDER_COMPLETE
+from viseron.domains.camera.recorder import EventRecorderData
 
 from .const import (
     CAMERA_SEGMENT_DURATION,
@@ -21,6 +26,11 @@ from .const import (
     CONFIG_SEGMENTS_FOLDER,
 )
 
+if TYPE_CHECKING:
+    from viseron import Viseron
+    from viseron.domains.camera import AbstractCamera
+    from viseron.domains.camera.recorder import Recording
+
 
 class Segments:
     """Concatenate segments between two timestamps on-demand."""
@@ -29,10 +39,14 @@ class Segments:
         self,
         logger,
         config,
+        vis: Viseron,
+        camera: AbstractCamera,
         segments_folder,
     ):
         self._logger = logger
         self._config = config
+        self._vis = vis
+        self._camera = camera
         self._segments_folder = segments_folder
 
     def segment_duration(self, segment_file):
@@ -218,8 +232,12 @@ class Segments:
         if pipe.returncode != 0:
             self._logger.error(f"Error concatenating segments: {pipe.stderr}")
 
-    def concat_segments(self, event_start, event_end, file_name):
+    def concat_segments(self, recording: Recording):
         """Concatenate segments between event_start and event_end."""
+        event_start = recording.start_timestamp
+        event_end = (
+            recording.end_timestamp - self._config[CONFIG_RECORDER][CONFIG_LOOKBACK]
+        )
         self._logger.debug("Concatenating segments")
         segment_information = self.get_segment_information()
         if not segment_information:
@@ -249,7 +267,7 @@ class Segments:
         if not segments_to_concat:
             return
 
-        temp_file = os.path.join("/tmp", file_name)
+        temp_file = os.path.join("/tmp", recording.path)
 
         try:
             self.ffmpeg_concat(
@@ -258,10 +276,18 @@ class Segments:
                 ),
                 temp_file,
             )
-            shutil.move(temp_file, file_name)
+            shutil.move(temp_file, recording.path)
         except sp.CalledProcessError as error:
             self._logger.error("Failed to concatenate segments: %s", error)
             return
+
+        self._vis.dispatch_event(
+            EVENT_RECORDER_COMPLETE,
+            EventRecorderData(
+                camera=self._camera,
+                recording=recording,
+            ),
+        )
 
         for segment in segments_to_concat[:-1]:
             self._logger.debug(f"Removing segment: {segment}")

--- a/viseron/components/gstreamer/camera.py
+++ b/viseron/components/gstreamer/camera.py
@@ -404,7 +404,7 @@ class Camera(AbstractCamera):
 
     def stop_recorder(self):
         """Stop camera recorder."""
-        self._recorder.stop()
+        self._recorder.stop(self.recorder.active_recording)
 
     @property
     def poll_timer(self):

--- a/viseron/components/gstreamer/recorder.py
+++ b/viseron/components/gstreamer/recorder.py
@@ -1,29 +1,32 @@
 """Recorder."""
+from __future__ import annotations
+
 import logging
 import os
 import threading
+from typing import TYPE_CHECKING
 
 from viseron.components.ffmpeg.recorder import ConcatThreadsContext
-from viseron.domains.camera import CONFIG_LOOKBACK
 from viseron.domains.camera.recorder import AbstractRecorder
 from viseron.helpers import create_directory
 
 from .const import COMPONENT, CONFIG_SEGMENTS_FOLDER, RECORDER
 from .segments import SegmentCleanup, Segments
 
+if TYPE_CHECKING:
+    from viseron import Viseron
+    from viseron.domains.camera import AbstractCamera
+    from viseron.domains.camera.recorder import Recording
 LOGGER = logging.getLogger(__name__)
 
 
 class Recorder(AbstractRecorder):
     """Creates thumbnails and recordings."""
 
-    def __init__(self, vis, config, camera):
+    def __init__(self, vis: Viseron, config, camera: AbstractCamera):
         super().__init__(vis, COMPONENT, config, camera)
         self._logger.debug("Initializing gstreamer recorder")
         self._recorder_config = config[RECORDER]
-
-        self._event_start = None
-        self._event_end = None
 
         self._segment_thread_context = ConcatThreadsContext()
         self._concat_thread_lock = threading.Lock()
@@ -32,7 +35,7 @@ class Recorder(AbstractRecorder):
             self._recorder_config[CONFIG_SEGMENTS_FOLDER], self._camera.identifier
         )
         create_directory(segments_folder)
-        self._segmenter = Segments(self._logger, config, segments_folder)
+        self._segmenter = Segments(self._logger, config, vis, camera, segments_folder)
         self._segment_cleanup = SegmentCleanup(
             vis,
             self._recorder_config,
@@ -41,25 +44,20 @@ class Recorder(AbstractRecorder):
             self._segment_thread_context,
         )
 
-    def concat_segments(self):
+    def concat_segments(self, recording: Recording):
         """Concatenate GStreamer segments to a single video."""
         with self._segment_thread_context:
             with self._concat_thread_lock:
                 self._segment_cleanup.pause()
-                self._segmenter.concat_segments(
-                    self._event_start - self._recorder_config[CONFIG_LOOKBACK],
-                    self._event_end,
-                    self.last_recording_path,
-                )
+                self._segmenter.concat_segments(recording)
+
                 # Dont resume cleanup if new recording started during encoding
                 if not self.is_recording:
                     self._segment_cleanup.resume()
 
-    def _start(self, shared_frame, objects_in_fov, resolution):
+    def _start(self, recording, shared_frame, objects_in_fov, resolution):
         self._segment_cleanup.pause()
-        self._event_start = int(self.last_recording_start.timestamp())
 
-    def _stop(self):
-        self._event_end = int(self.last_recording_end.timestamp())
-        concat_thread = threading.Thread(target=self.concat_segments)
+    def _stop(self, recording):
+        concat_thread = threading.Thread(target=self.concat_segments, args=(recording,))
         concat_thread.start()

--- a/viseron/domains/camera/const.py
+++ b/viseron/domains/camera/const.py
@@ -13,6 +13,7 @@ EVENT_STATUS_CONNECTED = "connected"
 
 EVENT_RECORDER_START = "{camera_identifier}/recorder/start"
 EVENT_RECORDER_STOP = "{camera_identifier}/recorder/stop"
+EVENT_RECORDER_COMPLETE = "{camera_identifier}/recorder/complete"
 
 EVENT_CAMERA_START = "{camera_identifier}/camera/start"
 EVENT_CAMERA_STOP = "{camera_identifier}/camera/stop"

--- a/viseron/domains/camera/entity/image.py
+++ b/viseron/domains/camera/entity/image.py
@@ -10,7 +10,7 @@ from . import CameraEntity
 
 if TYPE_CHECKING:
     from viseron import Event, Viseron
-    from viseron.domains.camera.recorder import EventRecorderStart
+    from viseron.domains.camera.recorder import EventRecorderData
 
     from .. import AbstractCamera
 
@@ -48,10 +48,11 @@ class ThumbnailImage(CameraImage):
             "thumbnail_path": self._attr_thumbnail_path,
         }
 
-    def handle_event(self, event_data: Event[EventRecorderStart]):
+    def handle_event(self, event_data: Event[EventRecorderData]):
         """Handle recorder start event."""
-        self._attr_start_time = event_data.data.start_time.isoformat()
-        self._attr_path = event_data.data.path
-        self._attr_thumbnail_path = event_data.data.thumbnail_path
-        self._image = event_data.data.thumbnail
+        recording = event_data.data.recording
+        self._attr_start_time = recording.start_time.isoformat()
+        self._attr_path = recording.path
+        self._attr_thumbnail_path = recording.thumbnail_path
+        self._image = recording.thumbnail
         self.set_state()


### PR DESCRIPTION
We now subscribe to new recordings, which makes it possible to load new recordings without refreshing the page.

Also makes the layout a bit more consistent when a camera has no recordings