### PR TITLE
fix max_recorder_keepalive when running without object detector

### DIFF
--- a/docs/src/pages/components-explorer/components/background_subtractor/config.json
+++ b/docs/src/pages/components-explorer/components/background_subtractor/config.json
@@ -29,7 +29,7 @@
                                         "type": "integer",
                                         "valueMin": 0,
                                         "name": "max_recorder_keepalive",
-                                        "description": "Value in seconds for how long motion is allowed to keep the recorder going when no objects are detected.<br>This is to prevent never-ending recordings.<br>Only applicable if <code>recorder_keepalive: true</code>.",
+                                        "description": "Value in seconds for how long motion is allowed to keep the recorder going when no objects are detected.<br>Use this to prevent never-ending recordings.<br>Only applicable if <code>recorder_keepalive: true</code>.<br><b>A value of <code>0</code> disables this functionality.</b>",
                                         "optional": true,
                                         "default": 30
                                     },

--- a/docs/src/pages/components-explorer/components/mog2/config.json
+++ b/docs/src/pages/components-explorer/components/mog2/config.json
@@ -29,7 +29,7 @@
                                         "type": "integer",
                                         "valueMin": 0,
                                         "name": "max_recorder_keepalive",
-                                        "description": "Value in seconds for how long motion is allowed to keep the recorder going when no objects are detected.<br>This is to prevent never-ending recordings.<br>Only applicable if <code>recorder_keepalive: true</code>.",
+                                        "description": "Value in seconds for how long motion is allowed to keep the recorder going when no objects are detected.<br>Use this to prevent never-ending recordings.<br>Only applicable if <code>recorder_keepalive: true</code>.<br><b>A value of <code>0</code> disables this functionality.</b>",
                                         "optional": true,
                                         "default": 30
                                     },

--- a/viseron/components/nvr/nvr.py
+++ b/viseron/components/nvr/nvr.py
@@ -436,14 +436,21 @@ class NVR:
             and self._motion_detector.motion_detected
         ):
             # Only allow motion to keep event active for a specified period of time
-            if self._motion_only_frames >= (
-                self._camera.output_fps * self._motion_detector.max_recorder_keepalive
+            if (
+                self._motion_detector.max_recorder_keepalive
+                and self._motion_only_frames
+                >= (
+                    self._camera.output_fps
+                    * self._motion_detector.max_recorder_keepalive
+                )
             ):
                 if not self._motion_recorder_keepalive_reached:
                     self._motion_recorder_keepalive_reached = True
                     self._logger.debug(
                         "Motion has kept recorder alive for longer than "
-                        "max_recorder_keepalive, event considered over anyway"
+                        "max_recorder_keepalive "
+                        f"({self._motion_detector.max_recorder_keepalive}s), "
+                        "event considered over anyway"
                     )
                 return True
             self._motion_only_frames += 1
@@ -527,6 +534,8 @@ class NVR:
 
             if self._motion_detector.trigger_recorder and not self._camera.is_recording:
                 self._start_recorder = True
+                self._motion_only_frames = 0
+                self._motion_recorder_keepalive_reached = False
 
         elif (
             self._object_detector

--- a/viseron/domains/motion_detector/const.py
+++ b/viseron/domains/motion_detector/const.py
@@ -63,6 +63,7 @@ DESC_RECORDER_KEEPALIVE = (
 DESC_MAX_RECORDER_KEEPALIVE = (
     "Value in seconds for how long motion is allowed to keep the "
     "recorder going when no objects are detected.<br>"
-    "This is to prevent never-ending recordings.<br>"
-    "Only applicable if <code>recorder_keepalive: true</code>."
+    "Use this to prevent never-ending recordings.<br>"
+    "Only applicable if <code>recorder_keepalive: true</code>.<br>"
+    "<b>A value of <code>0</code> disables this functionality.</b>"
 )


### PR DESCRIPTION
Also adds the possibility to set max_recorder_keepalive to 0 to turn of the functionality of max_recorder_keepalive