### PR TITLE
change stream dict to tuples.

### DIFF
--- a/viseron/components/webserver/stream_handler.py
+++ b/viseron/components/webserver/stream_handler.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Dict
+from typing import Dict, Tuple
 
 import cv2
 import imutils
@@ -161,7 +161,7 @@ class DynamicStreamHandler(StreamHandler):
 class StaticStreamHandler(StreamHandler):
     """Represents a static stream defined in config.yaml."""
 
-    active_streams: Dict[str, object] = {}
+    active_streams: Dict[Tuple[str, str], object] = {}
 
     async def stream(self, nvr, mjpeg_stream, mjpeg_stream_config, publish_frame_topic):
         """Subscribe to frames, draw on them, then publish processed frame."""
@@ -173,7 +173,7 @@ class StaticStreamHandler(StreamHandler):
             frame_topic, frame_queue, ioloop=tornado.ioloop.IOLoop.current()
         )
 
-        while self.active_streams[mjpeg_stream]:
+        while self.active_streams[(nvr.camera.identifier, mjpeg_stream)]:
             processed_frame: DataProcessedFrame = await frame_queue.get()
             ret, jpg = await self.process_frame(
                 nvr, processed_frame, mjpeg_stream_config
@@ -223,15 +223,15 @@ class StaticStreamHandler(StreamHandler):
             frame_topic, frame_queue, ioloop=tornado.ioloop.IOLoop.current()
         )
 
-        if self.active_streams.get(mjpeg_stream, False):
-            self.active_streams[mjpeg_stream] += 1
+        if self.active_streams.get((nvr.camera.identifier, mjpeg_stream), False):
+            self.active_streams[(nvr.camera.identifier, mjpeg_stream)] += 1
             LOGGER.debug(
                 f"Stream {mjpeg_stream} already active, number of streams: "
-                f"{self.active_streams[mjpeg_stream]}"
+                f"{self.active_streams[(nvr.camera.identifier,mjpeg_stream)]}"
             )
         else:
             LOGGER.debug(f"Stream {mjpeg_stream} is not active, starting")
-            self.active_streams[mjpeg_stream] = 1
+            self.active_streams[(nvr.camera.identifier, mjpeg_stream)] = 1
             tornado.ioloop.IOLoop.current().spawn_callback(
                 self.stream, nvr, mjpeg_stream, mjpeg_stream_config, frame_topic
             )
@@ -251,4 +251,4 @@ class StaticStreamHandler(StreamHandler):
                     f"{nvr.camera.identifier}"
                 )
                 break
-        self.active_streams[mjpeg_stream] -= 1
+        self.active_streams[(nvr.camera.identifier, mjpeg_stream)] -= 1


### PR DESCRIPTION
use a tuple to separate streams with same name into the respective cameras.

fixes #462 .