### PR TITLE
raise DomainNotReady on FFProbe error/timeout

### DIFF
--- a/tests/components/ffmpeg/test_stream.py
+++ b/tests/components/ffmpeg/test_stream.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from viseron.components.ffmpeg.const import (
-    COMPONENT,
     CONFIG_AUDIO_CODEC,
     CONFIG_CODEC,
     CONFIG_FFMPEG_LOGLEVEL,
@@ -113,7 +112,6 @@ class TestStream:
     )
     def test_init(
         self,
-        vis,
         config,
         stream_information,
         expected_width,
@@ -125,9 +123,6 @@ class TestStream:
     ):
         """Test that the stream is correctly initialized."""
         mocked_camera = MockCamera(identifier="test_camera_identifier")
-        vis.data[COMPONENT] = {}
-        vis.data[COMPONENT]["test_camera_identifier"] = mocked_camera
-
         with raises, patch.object(
             Stream, "get_stream_information", MagicMock(return_value=stream_information)
         ) as mock_get_stream_information, patch.object(
@@ -135,7 +130,7 @@ class TestStream:
         ), patch.object(
             Stream, "output_stream_url", MagicMock()
         ):
-            stream = Stream(vis, config, "test_camera_identifier")
+            stream = Stream(config, mocked_camera, "test_camera_identifier")
             mock_get_stream_information.assert_called_once()
             assert stream._camera == mocked_camera  # pylint: disable=protected-access
             assert stream.width == expected_width
@@ -158,15 +153,13 @@ class TestStream:
     ):
         """Test that the correct audio codec is returned."""
         mocked_camera = MockCamera(identifier="test_camera_identifier")
-        vis.data[COMPONENT] = {}
-        vis.data[COMPONENT]["test_camera_identifier"] = mocked_camera
         config = CONFIG
         config[CONFIG_AUDIO_CODEC] = config_audio_codec
 
         with patch.object(
             Stream, "__init__", MagicMock(spec=Stream, return_value=None)
         ):
-            stream = Stream(vis, config, "test_camera_identifier")
+            stream = Stream(config, mocked_camera, "test_camera_identifier")
             stream._logger = MagicMock()  # pylint: disable=protected-access
             assert (
                 stream.get_audio_codec(config, stream_audio_codec, extension)

--- a/viseron/components/ffmpeg/stream.py
+++ b/viseron/components/ffmpeg/stream.py
@@ -29,7 +29,6 @@ from viseron.watchdog.subprocess_watchdog import RestartablePopen
 from .const import (
     CAMERA_INPUT_ARGS,
     CAMERA_SEGMENT_ARGS,
-    COMPONENT,
     CONFIG_AUDIO_CODEC,
     CONFIG_CODEC,
     CONFIG_FFMPEG_LOGLEVEL,
@@ -68,14 +67,13 @@ from .const import (
 )
 
 if TYPE_CHECKING:
-    from viseron import Viseron
     from viseron.components.ffmpeg.camera import Camera
 
 
 class Stream:
     """Represents a stream of frames from a camera."""
 
-    def __init__(self, vis: Viseron, config, camera_identifier):
+    def __init__(self, config, camera: Camera, camera_identifier):
         self._logger = logging.getLogger(__name__ + "." + camera_identifier)
         self._logger.addFilter(
             UnhelpfullLogFilter(config[CONFIG_FFMPEG_RECOVERABLE_ERRORS])
@@ -83,8 +81,7 @@ class Stream:
         self._config = config
         self._camera_identifier = camera_identifier
 
-        self._camera: Camera = vis.data[COMPONENT][camera_identifier]
-        self._recorder = vis.data[COMPONENT][camera_identifier].recorder
+        self._camera: Camera = camera
 
         self._pipe = None
         self._segment_process = None

--- a/viseron/components/gstreamer/camera.py
+++ b/viseron/components/gstreamer/camera.py
@@ -48,6 +48,7 @@ from viseron.domains.camera.const import (
     EVENT_CAMERA_STARTED,
     EVENT_CAMERA_STOPPED,
 )
+from viseron.exceptions import DomainNotReady, FFprobeError, FFprobeTimeout
 from viseron.helpers.validators import CameraIdentifier, CoerceNoneToDict, Maybe
 from viseron.watchdog.thread_watchdog import RestartableThread
 
@@ -273,7 +274,10 @@ CONFIG_SCHEMA = vol.Schema(
 
 def setup(vis: Viseron, config, identifier):
     """Set up the gstreamer camera domain."""
-    Camera(vis, config[identifier], identifier)
+    try:
+        Camera(vis, config[identifier], identifier)
+    except (FFprobeError, FFprobeTimeout) as error:
+        raise DomainNotReady from error
     return True
 
 
@@ -283,6 +287,10 @@ class Camera(AbstractCamera):
     def __init__(self, vis: Viseron, config, identifier):
         self._poll_timer = None
         self._frame_reader: RestartableThread | None = None
+        # Stream must be initialized before super().__init__ is called as it raises
+        # FFprobeError/FFprobeTimeout which is caught in setup() and re-raised as
+        # DomainNotReady
+        self.stream = Stream(config, self, identifier)
 
         super().__init__(vis, COMPONENT, config, identifier)
         self._capture_frames = False
@@ -314,8 +322,6 @@ class Camera(AbstractCamera):
         """Start processing of camera frames."""
         self._poll_timer = None
         self._logger.debug(f"Initializing camera {self.name}")
-
-        self.stream = Stream(self._vis, self._config, self.identifier)
 
         self.resolution = self.stream.width, self.stream.height
         self._logger.debug(

--- a/viseron/components/gstreamer/pipeline.py
+++ b/viseron/components/gstreamer/pipeline.py
@@ -12,7 +12,6 @@ from viseron.components.ffmpeg.const import (
 from viseron.domains.camera.const import CONFIG_EXTENSION
 
 from .const import (
-    COMPONENT,
     CONFIG_AUDIO_CODEC,
     CONFIG_AUDIO_PIPELINE,
     CONFIG_GSTREAMER_LOGLEVEL,
@@ -46,11 +45,8 @@ class AbstractPipeline(ABC):
 class RawPipeline(AbstractPipeline):
     """Raw GStreamer pipeline."""
 
-    def __init__(self, vis, config, stream: Stream, camera_identifier):
-        self._vis = vis
+    def __init__(self, config):
         self._config = config
-        self._stream = stream
-        self._camera = vis.data[COMPONENT][camera_identifier]
 
     def build_pipeline(self):
         """Build pipeline."""
@@ -60,11 +56,10 @@ class RawPipeline(AbstractPipeline):
 class BasePipeline(AbstractPipeline):
     """Base GStreamer pipeline."""
 
-    def __init__(self, vis, config, stream: Stream, camera_identifier):
-        self._vis = vis
+    def __init__(self, config, stream: Stream, camera_identifier):
         self._config = config
         self._stream = stream
-        self._camera = vis.data[COMPONENT][camera_identifier]
+        self._camera_identifier = camera_identifier
 
     def global_args(self):
         """Return GStreamer global args."""
@@ -198,7 +193,7 @@ class BasePipeline(AbstractPipeline):
         """Generate GStreamer segment args."""
         segment_filepattern = os.path.join(
             self._config[CONFIG_RECORDER][CONFIG_SEGMENTS_FOLDER],
-            self._camera.identifier,
+            self._camera_identifier,
             f"%01d.{self._config[CONFIG_RECORDER][CONFIG_EXTENSION]}",
         )
         return (

--- a/viseron/exceptions.py
+++ b/viseron/exceptions.py
@@ -24,7 +24,12 @@ class ComponentNotReady(NotReadyError):
 
 
 class DomainNotReady(NotReadyError):
-    """Error that indicates that a domain is not ready."""
+    """Error that indicates that a domain is not ready.
+
+    It is VERY important that this exception is never raised after
+    add_entity/add_entities is called, since that will cause the entity to be added
+    twice and cause issues.
+    """
 
 
 class DataStreamNotLoaded(ViseronError):


### PR DESCRIPTION
This PR will address the FFprobeError problem (Viseron not trying to reconnect to cameras if they are unavailable during restart) outlined in this issue: #466