### PR TITLE
Feature/added detect_remote_faces to face_recognition domain

### DIFF
--- a/docs/src/pages/components-explorer/components/codeprojectai/config.json
+++ b/docs/src/pages/components-explorer/components/codeprojectai/config.json
@@ -411,6 +411,13 @@
           },
           {
             "type": "boolean",
+            "name": "detect_remote_faces",
+            "description": "If true, faces trained using other methods will be detected.",
+            "optional": true,
+            "default": false
+          },
+          {
+            "type": "boolean",
             "name": "train",
             "description": "Train CodeProject.AI to recognize faces on Viseron start. Disable this when you have a good model trained.",
             "optional": true,

--- a/docs/src/pages/components-explorer/components/compreface/config.json
+++ b/docs/src/pages/components-explorer/components/compreface/config.json
@@ -101,6 +101,13 @@
           },
           {
             "type": "boolean",
+            "name": "detect_remote_faces",
+            "description": "If true, faces trained using other methods will be detected.",
+            "optional": true,
+            "default": false
+          },
+          {
+            "type": "boolean",
             "name": "train",
             "description": "Train CompreFace to recognize faces on Viseron start. Disable this when you have a good model trained.",
             "optional": true,

--- a/docs/src/pages/components-explorer/components/deepstack/config.json
+++ b/docs/src/pages/components-explorer/components/deepstack/config.json
@@ -425,6 +425,13 @@
           },
           {
             "type": "boolean",
+            "name": "detect_remote_faces",
+            "description": "If true, faces trained using other methods will be detected.",
+            "optional": true,
+            "default": false
+          },
+          {
+            "type": "boolean",
             "name": "train",
             "description": "Train DeepStack to recognize faces on Viseron start. Disable this when you have a good model trained.",
             "optional": true,

--- a/docs/src/pages/components-explorer/components/dlib/config.json
+++ b/docs/src/pages/components-explorer/components/dlib/config.json
@@ -79,6 +79,13 @@
             "default": 5
           },
           {
+            "type": "boolean",
+            "name": "detect_remote_faces",
+            "description": "If true, faces trained using other methods will be detected.",
+            "optional": true,
+            "default": false
+          },
+          {
             "type": "select",
             "options": [
               {

--- a/viseron/components/codeprojectai/face_recognition.py
+++ b/viseron/components/codeprojectai/face_recognition.py
@@ -86,6 +86,7 @@ class FaceRecognition(AbstractFaceRecognition):
             if detection["userid"] != "unknown":
                 self._logger.debug(f"Face found: {detection}")
                 self.known_face_found(
+                    COMPONENT,
                     detection["userid"],
                     (
                         detection["x_min"],
@@ -96,7 +97,7 @@ class FaceRecognition(AbstractFaceRecognition):
                     confidence=detection["confidence"],
                 )
             elif self._config[CONFIG_SAVE_UNKNOWN_FACES]:
-                self.unknown_face_found(cropped_frame)
+                self.unknown_face_found(COMPONENT, cropped_frame)
 
     def process(self, post_processor_frame: PostProcessorFrame) -> None:
         """Process received frame."""

--- a/viseron/components/compreface/const.py
+++ b/viseron/components/compreface/const.py
@@ -25,6 +25,7 @@ CONFIG_LIMIT = "limit"
 CONFIG_PREDICTION_COUNT = "prediction_count"
 CONFIG_FACE_PLUGINS = "face_plugins"
 CONFIG_STATUS = "status"
+CONFIG_DETECT_REMOTE_FACES = "detect_remote_faces"
 
 DEFAULT_TRAIN = False
 DEFAULT_DET_PROB_THRESHOLD = 0.8
@@ -33,6 +34,7 @@ DEFAULT_LIMIT = 0
 DEFAULT_PREDICTION_COUNT = 1
 DEFAULT_FACE_PLUGINS: Final = None
 DEFAULT_STATUS = False
+DEFAULT_DETECT_REMOTE_FACES = False
 
 DESC_TRAIN = (
     "Train CompreFace to recognize faces on Viseron start. "
@@ -65,3 +67,4 @@ DESC_FACE_PLUGINS = (
 DESC_STATUS = (
     "If true includes system information like execution_time and plugin_version fields."
 )
+DESC_DETECT_REMOTE_FACES = "If true faces trained using other methods will be detected."

--- a/viseron/components/compreface/face_recognition.py
+++ b/viseron/components/compreface/face_recognition.py
@@ -109,6 +109,7 @@ class FaceRecognition(AbstractFaceRecognition):
             if subject["similarity"] >= self._config[CONFIG_SIMILARITTY_THRESHOLD]:
                 self._logger.debug(f"Face found: {subject}")
                 self.known_face_found(
+                    COMPONENT,
                     subject["subject"],
                     (
                         result["box"]["x_min"],
@@ -120,7 +121,7 @@ class FaceRecognition(AbstractFaceRecognition):
                     extra_attributes=result,
                 )
             elif self._config[CONFIG_SAVE_UNKNOWN_FACES]:
-                self.unknown_face_found(cropped_frame)
+                self.unknown_face_found(COMPONENT, cropped_frame)
 
     def process(self, post_processor_frame: PostProcessorFrame) -> None:
         """Process received frame."""

--- a/viseron/components/deepstack/face_recognition.py
+++ b/viseron/components/deepstack/face_recognition.py
@@ -83,6 +83,7 @@ class FaceRecognition(AbstractFaceRecognition):
             if detection["userid"] != "unknown":
                 self._logger.debug(f"Face found: {detection}")
                 self.known_face_found(
+                    COMPONENT,
                     detection["userid"],
                     (
                         detection["x_min"],
@@ -93,7 +94,7 @@ class FaceRecognition(AbstractFaceRecognition):
                     confidence=detection["confidence"],
                 )
             elif self._config[CONFIG_SAVE_UNKNOWN_FACES]:
-                self.unknown_face_found(cropped_frame)
+                self.unknown_face_found(COMPONENT, cropped_frame)
 
     def process(self, post_processor_frame: PostProcessorFrame) -> None:
         """Process received frame."""

--- a/viseron/components/dlib/face_recognition.py
+++ b/viseron/components/dlib/face_recognition.py
@@ -83,9 +83,9 @@ class FaceRecognition(AbstractFaceRecognition):
 
         for face, coordinates in faces:
             if face != "unknown":
-                self.known_face_found(face, coordinates)
+                self.known_face_found(COMPONENT, face, coordinates)
             elif self._config[CONFIG_SAVE_UNKNOWN_FACES]:
-                self.unknown_face_found(cropped_frame)
+                self.unknown_face_found(COMPONENT, cropped_frame)
 
     def process(self, post_processor_frame: PostProcessorFrame) -> None:
         """Process received frame."""

--- a/viseron/domains/face_recognition/const.py
+++ b/viseron/domains/face_recognition/const.py
@@ -16,11 +16,13 @@ CONFIG_FACE_RECOGNITION_PATH = "face_recognition_path"
 CONFIG_SAVE_UNKNOWN_FACES = "save_unknown_faces"
 CONFIG_UNKNOWN_FACES_PATH = "unknown_faces_path"
 CONFIG_EXPIRE_AFTER = "expire_after"
+CONFIG_DETECT_REMOTE_FACES = "detect_remote_faces"
 
 DEFAULT_FACE_RECOGNITION_PATH = "/config/face_recognition/faces"
 DEFAULT_SAVE_UNKNOWN_FACES = False
 DEFAULT_UNKNOWN_FACES_PATH = f"{DEFAULT_FACE_RECOGNITION_PATH}/unknown"
 DEFAULT_EXPIRE_AFTER = 5
+DEFAULT_DETECT_REMOTE_FACES = False
 
 DESC_FACE_RECOGNITION_PATH = (
     "Path to folder which contains subdirectories with images for each face to track."
@@ -33,4 +35,7 @@ DESC_SAVE_UNKNOWN_FACES = (
 DESC_UNKNOWN_FACES_PATH = "Path to folder where unknown faces will be stored."
 DESC_EXPIRE_AFTER = (
     "Time in seconds before a detected face is no longer considered detected."
+)
+DESC_DETECT_REMOTE_FACES = (
+    "If true, faces trained using other methods will be detected."
 )


### PR DESCRIPTION
Adds `detect_remote_faces` to face_recognition domain. 
The purpose of the config is to enable the face_recognition components to detect faces that are trained in other ways as I mentioned in #604 

For example in my case I would like to continue train Compreface using the native UI. 
I wanted to make this config available only for Compreface but was difficult for me on how the logic is currently implemented. Then I thought that this behavior could be useful even on other face recognition components.

This PR also fixes the error occured in #603 by checking the existence of the train dir. 