### PR TITLE
add new config option for still image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -399,23 +399,9 @@ jobs:
       - name: Pull current Docker dev tag
         run: |
           docker-compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env pull amd64-viseron
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v32
-        with:
-          files: |
-            requirements.txt
-            docker/Dockerfile.wheels
-            azure-pipelines/.env
-      - name: List all modified files
-        run: |
-          for file in "${{ steps.changed-files.outputs.all_modified_files }}"; do
-            echo "$file was modified"
-          done
-      - name: Re-build wheels if requirements.txt or Dockerfile.wheels has changed
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
           docker-compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env pull amd64-wheels
+      - name: Re-build wheels
+        run: |
           docker-compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env build --build-arg BUILDKIT_INLINE_CACHE=1 amd64-wheels
           docker-compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env build --build-arg BUILDKIT_INLINE_CACHE=1 amd64-viseron
       - name: Build pytest Docker image

--- a/docs/src/pages/components-explorer/_components/ComponentConfiguration/index.tsx
+++ b/docs/src/pages/components-explorer/_components/ComponentConfiguration/index.tsx
@@ -162,6 +162,7 @@ function getDefault(item: any) {
 
 // Return div with header containing item name/type/required/default value
 function buildHeader(item: any) {
+  const optional = item.optional || item.inclusive;
   return (
     <div className="config-variables-header">
       {item.name ? (
@@ -169,15 +170,17 @@ function buildHeader(item: any) {
       ) : null}
       {/* Zero width space to prevent selecting type when double clicking the name */}
       &#8203;
-      <span className={styles.configVariablesType}>{item.type}</span>
+      <span className={styles.configVariablesType}>
+        {item.format ? item.format : item.type}
+      </span>
       <span className={styles.configVariablesRequired}>
-        {item.optional ? " (" : null}
+        {optional ? " (" : null}
         <span
           className={clsx(styles.configVariablesRequired, {
-            [styles.true]: !item.optional,
+            [styles.true]: !optional,
           })}
         >
-          {item.optional ? "optional" : " required"}
+          {optional ? "optional" : " required"}
         </span>
         {getDefault(item)}
       </span>

--- a/docs/src/pages/components-explorer/components/ffmpeg/config.json
+++ b/docs/src/pages/components-explorer/components/ffmpeg/config.json
@@ -121,6 +121,61 @@
                 "default": null
               },
               {
+                "type": "map",
+                "value": [
+                  {
+                    "type": "string",
+                    "name": "url",
+                    "description": "URL to the still image. If this is omitted, the camera stream will be used to get the image.",
+                    "optional": true,
+                    "default": null
+                  },
+                  {
+                    "type": "string",
+                    "name": "username",
+                    "description": "Username for authentication.<br>Only applicable if <code>url</code> is set.",
+                    "inclusive": true,
+                    "default": null
+                  },
+                  {
+                    "type": "string",
+                    "name": "password",
+                    "description": "Password for authentication.<br>Only applicable if <code>url</code> is set.",
+                    "inclusive": true,
+                    "default": null
+                  },
+                  {
+                    "type": "select",
+                    "options": [
+                      {
+                        "type": "constant",
+                        "value": "basic"
+                      },
+                      {
+                        "type": "constant",
+                        "value": "digest"
+                      }
+                    ],
+                    "name": "authentication",
+                    "description": "Authentication method to use.<br>Only applicable if <code>url</code> is set.",
+                    "optional": true,
+                    "default": null
+                  },
+                  {
+                    "type": "integer",
+                    "valueMin": 1,
+                    "name": "refresh_interval",
+                    "description": "Number of seconds between refreshes of the still image in the frontend.",
+                    "optional": true,
+                    "default": 10
+                  }
+                ],
+                "name": "still_image",
+                "description": "Options for still image.",
+                "optional": true,
+                "default": null
+              },
+              {
                 "type": "select",
                 "options": [
                   {

--- a/docs/src/pages/components-explorer/components/gstreamer/config.json
+++ b/docs/src/pages/components-explorer/components/gstreamer/config.json
@@ -121,6 +121,61 @@
                 "default": null
               },
               {
+                "type": "map",
+                "value": [
+                  {
+                    "type": "string",
+                    "name": "url",
+                    "description": "URL to the still image. If this is omitted, the camera stream will be used to get the image.",
+                    "optional": true,
+                    "default": null
+                  },
+                  {
+                    "type": "string",
+                    "name": "username",
+                    "description": "Username for authentication.<br>Only applicable if <code>url</code> is set.",
+                    "inclusive": true,
+                    "default": null
+                  },
+                  {
+                    "type": "string",
+                    "name": "password",
+                    "description": "Password for authentication.<br>Only applicable if <code>url</code> is set.",
+                    "inclusive": true,
+                    "default": null
+                  },
+                  {
+                    "type": "select",
+                    "options": [
+                      {
+                        "type": "constant",
+                        "value": "basic"
+                      },
+                      {
+                        "type": "constant",
+                        "value": "digest"
+                      }
+                    ],
+                    "name": "authentication",
+                    "description": "Authentication method to use.<br>Only applicable if <code>url</code> is set.",
+                    "optional": true,
+                    "default": null
+                  },
+                  {
+                    "type": "integer",
+                    "valueMin": 1,
+                    "name": "refresh_interval",
+                    "description": "Number of seconds between refreshes of the still image in the frontend.",
+                    "optional": true,
+                    "default": 10
+                  }
+                ],
+                "name": "still_image",
+                "description": "Options for still image.",
+                "optional": true,
+                "default": null
+              },
+              {
                 "type": "select",
                 "options": [
                   {

--- a/frontend/src/components/camera/CameraCard.tsx
+++ b/frontend/src/components/camera/CameraCard.tsx
@@ -1,10 +1,10 @@
+import Image from "@jy95/material-ui-image";
 import Card from "@mui/material/Card";
 import CardActions from "@mui/material/CardActions";
 import CardContent from "@mui/material/CardContent";
 import CardMedia from "@mui/material/CardMedia";
 import Typography from "@mui/material/Typography";
 import { useTheme } from "@mui/material/styles";
-import Image from "@jy95/material-ui-image";
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { usePageVisibility } from "react-page-visibility";
 
@@ -132,9 +132,14 @@ export default function CameraCard({ camera_identifier }: CameraCardProps) {
     // If element is on screen and browser is visible, start interval to fetch images
     if (onScreen && isVisible && connected && cameraQuery.isSuccess) {
       updateImage();
-      updateSnapshot.current = setInterval(() => {
-        updateImage();
-      }, 10000);
+      updateSnapshot.current = setInterval(
+        () => {
+          updateImage();
+        },
+        cameraQuery.data.still_image_refresh_interval
+          ? cameraQuery.data.still_image_refresh_interval * 1000
+          : 10000
+      );
       // If element is hidden or browser loses focus, stop updating images
     } else if (updateSnapshot.current) {
       clearInterval(updateSnapshot.current);
@@ -145,7 +150,14 @@ export default function CameraCard({ camera_identifier }: CameraCardProps) {
         clearInterval(updateSnapshot.current);
       }
     };
-  }, [updateImage, isVisible, onScreen, connected, cameraQuery.isSuccess]);
+  }, [
+    updateImage,
+    isVisible,
+    onScreen,
+    connected,
+    cameraQuery.isSuccess,
+    cameraQuery.data,
+  ]);
 
   useCameraToken(camera_identifier, auth.enabled);
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -92,6 +92,7 @@ export interface Camera {
   width: number;
   height: number;
   access_token: string;
+  still_image_refresh_interval: number;
   failed: false;
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ codeproject-ai-api==0.1
 colorlog==5.0.1
 compreface-sdk==0.6.0
 face-recognition==1.3.0
+httpx==0.24.1
 imutils==0.5.3
 numpy==1.23.5
 paho-mqtt==1.5.0

--- a/viseron/__init__.py
+++ b/viseron/__init__.py
@@ -102,6 +102,8 @@ def enable_logging() -> None:
     logging.getLogger("apscheduler.executors").setLevel(logging.ERROR)
     logging.getLogger("requests").setLevel(logging.WARNING)
     logging.getLogger("urllib3").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("httpcore").setLevel(logging.WARNING)
     logging.getLogger("tornado.access").setLevel(logging.WARNING)
     logging.getLogger("tornado.application").setLevel(logging.WARNING)
     logging.getLogger("tornado.general").setLevel(logging.WARNING)

--- a/viseron/components/webserver/api/v1/camera.py
+++ b/viseron/components/webserver/api/v1/camera.py
@@ -4,9 +4,22 @@ from __future__ import annotations
 import logging
 from http import HTTPStatus
 
+import cv2
+import httpx
+import imutils
+import numpy as np
 import voluptuous as vol
 
 from viseron.components.webserver.api.handlers import BaseAPIHandler
+from viseron.domains.camera import AbstractCamera
+from viseron.domains.camera.const import (
+    AUTHENTICATION_BASIC,
+    AUTHENTICATION_DIGEST,
+    CONFIG_AUTHENTICATION,
+    CONFIG_PASSWORD,
+    CONFIG_URL,
+    CONFIG_USERNAME,
+)
 from viseron.helpers.validators import request_argument_bool
 
 LOGGER = logging.getLogger(__name__)
@@ -43,29 +56,98 @@ class CameraAPIHandler(BaseAPIHandler):
         },
     ]
 
+    def _get_auth(
+        self, camera: AbstractCamera
+    ) -> httpx.DigestAuth | httpx.BasicAuth | None:
+        """Return auth for camera."""
+        if (
+            camera.still_image
+            and camera.still_image[CONFIG_USERNAME]
+            and camera.still_image[CONFIG_PASSWORD]
+        ):
+            if camera.still_image[CONFIG_AUTHENTICATION] == AUTHENTICATION_DIGEST:
+                return httpx.DigestAuth(
+                    camera.still_image[CONFIG_USERNAME],
+                    camera.still_image[CONFIG_PASSWORD],
+                )
+            if camera.still_image[CONFIG_AUTHENTICATION] == AUTHENTICATION_BASIC:
+                return httpx.BasicAuth(
+                    camera.still_image[CONFIG_USERNAME],
+                    camera.still_image[CONFIG_PASSWORD],
+                )
+        return None
+
+    def _snapshot_from_url(self, camera: AbstractCamera) -> bytes | None:
+        """Return snapshot from camera url."""
+        auth = self._get_auth(camera)
+        response = httpx.get(
+            camera.still_image[CONFIG_URL],
+            auth=auth,
+        )
+        if response.status_code == 200:
+            img_array = np.asarray(bytearray(response.content), dtype=np.uint8)
+            img = cv2.imdecode(img_array, -1)
+            if self.request_arguments["width"] and self.request_arguments["height"]:
+                img = cv2.resize(
+                    img,
+                    (self.request_arguments["width"], self.request_arguments["height"]),
+                    interpolation=cv2.INTER_AREA,
+                )
+            elif self.request_arguments["width"] or self.request_arguments["height"]:
+                img = imutils.resize(
+                    img,
+                    self.request_arguments["width"],
+                    self.request_arguments["height"],
+                )
+
+            ret, jpg = cv2.imencode(".jpg", img, [int(cv2.IMWRITE_JPEG_QUALITY), 100])
+            if ret:
+                return jpg.tobytes()
+            return None
+
+        LOGGER.error(
+            "Failed to retrieve the image from the camera. Status code: %s",
+            response.status_code,
+        )
+        return None
+
+    def _snapshot_from_memory(self, camera: AbstractCamera) -> bytes | None:
+        """Return snapshot from camera memory."""
+        if camera.current_frame:
+            ret, jpg = camera.get_snapshot(
+                camera.current_frame,
+                self.request_arguments["width"],
+                self.request_arguments["height"],
+            )
+            if ret:
+                return jpg
+        return None
+
     def get_snapshot(self, camera_identifier: str) -> None:
         """Return camera snapshot."""
         camera = self._get_camera(camera_identifier)
 
-        if not camera or not camera.current_frame:
+        if not camera:
             self.response_error(
                 HTTPStatus.NOT_FOUND,
                 reason=f"Camera {camera_identifier} not found",
             )
             return
 
-        ret, jpg = camera.get_snapshot(
-            camera.current_frame,
-            self.request_arguments["width"],
-            self.request_arguments["height"],
-        )
+        jpg = None
+        if camera.still_image[CONFIG_URL]:
+            jpg = self._snapshot_from_url(camera)
+        else:
+            jpg = self._snapshot_from_memory(camera)
 
-        if ret:
-            self.response_success(response=jpg, headers={"Content-Type": "image/jpeg"})
+        if jpg is None:
+            self.response_error(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                reason="Could not fetch camera snapshot",
+            )
             return
-        self.response_error(
-            HTTPStatus.INTERNAL_SERVER_ERROR, reason="Could not fetch camera snapshot"
-        )
+
+        self.response_success(response=jpg, headers={"Content-Type": "image/jpeg"})
         return
 
     def get_camera(self, camera_identifier: str) -> None:

--- a/viseron/domains/camera/const.py
+++ b/viseron/domains/camera/const.py
@@ -101,6 +101,44 @@ DESC_FILENAME_PATTERN_THUMBNAIL = (
 )
 
 
+# STILL_IMAGE_SCHEMA constants
+CONFIG_STILL_IMAGE = "still_image"
+CONFIG_URL = "url"
+CONFIG_USERNAME = "username"
+CONFIG_PASSWORD = "password"
+CONFIG_AUTHENTICATION = "authentication"
+CONFIG_REFRESH_INTERVAL = "refresh_interval"
+
+DEFAULT_STILL_IMAGE: Final = None
+DEFAULT_URL: Final = None
+DEFAULT_USERNAME: Final = None
+DEFAULT_PASSWORD: Final = None
+DEFAULT_AUTHENTICATION: Final = None
+DEFAULT_REFRESH_INTERVAL: Final = 10
+
+DESC_STILL_IMAGE = "Options for still image."
+DESC_URL = (
+    "URL to the still image. "
+    "If this is omitted, the camera stream will be used to get the image."
+)
+DESC_USERNAME = (
+    "Username for authentication.<br>Only applicable if <code>url</code> is set."
+)
+DESC_PASSWORD = (
+    "Password for authentication.<br>Only applicable if <code>url</code> is set."
+)
+DESC_AUTHENTICATION = (
+    "Authentication method to use.<br>Only applicable if <code>url</code> is set."
+)
+DESC_REFRESH_INTERVAL = (
+    "Number of seconds between refreshes of the still image in the frontend."
+)
+
+INCLUSION_GROUP_AUTHENTICATION = "authentication"
+
+AUTHENTICATION_BASIC = "basic"
+AUTHENTICATION_DIGEST = "digest"
+
 # BASE_CONFIG_SCHEMA constants
 CONFIG_NAME = "name"
 CONFIG_MJPEG_STREAMS = "mjpeg_streams"


### PR DESCRIPTION
Adds the possibility to fetch the still image directly from a URL instead of taking it from the stream using `still_image`.

Also adds the ability to refresh the image in the frontend faster using `refresh_interval`