### PR TITLE
Update NVIDIA link on installation doc

### DIFF
--- a/docs/docs/documentation/installation.mdx
+++ b/docs/docs/documentation/installation.mdx
@@ -181,7 +181,7 @@ services:
 
 :::caution
 
-Make sure [NVIDIA Docker](https://github.com/NVIDIA/nvidia-docker) is installed.
+Make sure [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-container-toolkit) is installed.
 
 :::
 


### PR DESCRIPTION
Currently the documentation links to `nvidia-docker`. However, this has been replaced by `nvidia-container-toolkit`. This PR updates the link and text accordingly.