### PR TITLE
Events page and streaming improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -414,18 +414,18 @@ jobs:
           exit 1
       - name: Pull current Docker dev tag
         run: |
-          docker-compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env pull amd64-viseron
-          docker-compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env pull amd64-wheels
+          docker compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env pull amd64-viseron
+          docker compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env pull amd64-wheels
       - name: Re-build wheels
         run: |
-          docker-compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env build --build-arg BUILDKIT_INLINE_CACHE=1 amd64-wheels
-          docker-compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env build --build-arg BUILDKIT_INLINE_CACHE=1 amd64-viseron
+          docker compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env build --build-arg BUILDKIT_INLINE_CACHE=1 amd64-wheels
+          docker compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env build --build-arg BUILDKIT_INLINE_CACHE=1 amd64-viseron
       - name: Build pytest Docker image
         run: |
-          docker-compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env build --build-arg BUILDKIT_INLINE_CACHE=1 amd64-viseron-tests
+          docker compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env build --build-arg BUILDKIT_INLINE_CACHE=1 amd64-viseron-tests
       - name: Run pytest
         run: |
-          if docker-compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env up amd64-viseron-tests; then
+          if docker compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env up amd64-viseron-tests; then
             exit 0
           else
             exit 1

--- a/docs/docs/developers/development_environment/setup.mdx
+++ b/docs/docs/developers/development_environment/setup.mdx
@@ -104,6 +104,6 @@ To make testing with `pytest` as easy as possible, `tox` will build and run a Do
 If you would like to run tests outside of `tox` you can build and run this container manually:
 
 ```bash
-docker-compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env build amd64-viseron-tests
-docker-compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env run --rm amd64-viseron-tests
+docker compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env build amd64-viseron-tests
+docker compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env run --rm amd64-viseron-tests
 ```

--- a/docs/docs/developers/docker.mdx
+++ b/docs/docs/developers/docker.mdx
@@ -10,20 +10,20 @@ Viseron heavily uses multistage Docker builds, and compilation of different comp
 To build all the `amd64` image from scratch the following commands can be used.
 
 ```bash
-docker-compose --file ./azure-pipelines/docker-compose-build.yaml --env ./azure-pipelines/.env build amd64-ffmpeg && \
-docker-compose --file ./azure-pipelines/docker-compose-build.yaml --env ./azure-pipelines/.env build amd64-opencv && \
-docker-compose --file ./azure-pipelines/docker-compose-build.yaml --env ./azure-pipelines/.env build amd64-dlib && \
-docker-compose --file ./azure-pipelines/docker-compose-build.yaml --env ./azure-pipelines/.env build amd64-wheels && \
-docker-compose --file ./azure-pipelines/docker-compose-build.yaml --env ./azure-pipelines/.env build amd64-base && \
-docker-compose --file ./azure-pipelines/docker-compose-build.yaml --env ./azure-pipelines/.env build amd64-viseron
+docker compose --file ./azure-pipelines/docker-compose-build.yaml --env ./azure-pipelines/.env build amd64-ffmpeg && \
+docker compose --file ./azure-pipelines/docker-compose-build.yaml --env ./azure-pipelines/.env build amd64-opencv && \
+docker compose --file ./azure-pipelines/docker-compose-build.yaml --env ./azure-pipelines/.env build amd64-dlib && \
+docker compose --file ./azure-pipelines/docker-compose-build.yaml --env ./azure-pipelines/.env build amd64-wheels && \
+docker compose --file ./azure-pipelines/docker-compose-build.yaml --env ./azure-pipelines/.env build amd64-base && \
+docker compose --file ./azure-pipelines/docker-compose-build.yaml --env ./azure-pipelines/.env build amd64-viseron
 ```
 
 Lets say you want to update to a newer version of OpenCV.
 To do this you would:
 
 - Edit `OPENCV_VERSION` in ./azure-pipelines/.env
-- Build the OpenCV image: `docker-compose --file ./azure-pipelines/docker-compose-build.yaml --env ./azure-pipelines/.env build amd64-opencv`
-- Build Viseron image: `docker-compose --file ./azure-pipelines/docker-compose-build.yaml --env ./azure-pipelines/.env build amd64-viseron`
+- Build the OpenCV image: `docker compose --file ./azure-pipelines/docker-compose-build.yaml --env ./azure-pipelines/.env build amd64-opencv`
+- Build Viseron image: `docker compose --file ./azure-pipelines/docker-compose-build.yaml --env ./azure-pipelines/.env build amd64-viseron`
 
 #### Cross-building
 
@@ -39,5 +39,5 @@ docker run --rm --privileged tonistiigi/binfmt --install all
 You can then simply build the containers like you normally would and QEMU will be invoked automatically.
 
 ```bash
-docker-compose --file ./azure-pipelines/docker-compose-build.yaml --env ./azure-pipelines/.env build aarch64-viseron
+docker compose --file ./azure-pipelines/docker-compose-build.yaml --env ./azure-pipelines/.env build aarch64-viseron
 ```

--- a/docs/src/pages/components-explorer/components/ffmpeg/config.json
+++ b/docs/src/pages/components-explorer/components/ffmpeg/config.json
@@ -271,7 +271,7 @@
               {
                 "type": "string",
                 "name": "audio_codec",
-                "description": "FFmpeg audio encoder codec for the generated segments, eg <code>aac</code>.<br>Note that if you set this, FFmpeg will have to re-encode your stream which increases system load.<br>Will use FFprobe to get this information if not given, see <a href=#ffprobe-stream-information>FFprobe stream information.</a>",
+                "description": "Audio codec of the stream, eg <code>aac</code>.<br>Will use FFprobe to get this information if not given, see <a href=#ffprobe-stream-information>FFprobe stream information.</a>",
                 "optional": true,
                 "default": "unset"
               },
@@ -478,7 +478,7 @@
                   {
                     "type": "string",
                     "name": "audio_codec",
-                    "description": "FFmpeg audio encoder codec for the generated segments, eg <code>aac</code>.<br>Note that if you set this, FFmpeg will have to re-encode your stream which increases system load.<br>Will use FFprobe to get this information if not given, see <a href=#ffprobe-stream-information>FFprobe stream information.</a>",
+                    "description": "Audio codec of the stream, eg <code>aac</code>.<br>Will use FFprobe to get this information if not given, see <a href=#ffprobe-stream-information>FFprobe stream information.</a>",
                     "optional": true,
                     "default": "unset"
                   },
@@ -1329,9 +1329,9 @@
                   {
                     "type": "string",
                     "name": "audio_codec",
-                    "description": "FFmpeg audio encoder codec, eg <code>aac</code>.",
+                    "description": "FFmpeg audio encoder codec, eg <code>aac</code>.<br>If your source has audio and you want to remove it, set this to <code>null</code>.",
                     "optional": true,
-                    "default": "copy"
+                    "default": "unset"
                   },
                   {
                     "type": "list",

--- a/docs/src/pages/components-explorer/components/ffmpeg/index.mdx
+++ b/docs/src/pages/components-explorer/components/ffmpeg/index.mdx
@@ -164,7 +164,7 @@ ffmpeg -hide_banner -loglevel error -avoid_negative_ts make_zero -fflags nobuffe
 
 </details>
 
-### MJEPG Streams
+### MJPEG Streams
 
 <CameraMjpegStreams />
 

--- a/docs/src/pages/components-explorer/components/gstreamer/config.json
+++ b/docs/src/pages/components-explorer/components/gstreamer/config.json
@@ -1072,9 +1072,9 @@
                   {
                     "type": "string",
                     "name": "audio_codec",
-                    "description": "FFmpeg audio encoder codec, eg <code>aac</code>.",
+                    "description": "FFmpeg audio encoder codec, eg <code>aac</code>.<br>If your source has audio and you want to remove it, set this to <code>null</code>.",
                     "optional": true,
-                    "default": "copy"
+                    "default": "unset"
                   },
                   {
                     "type": "list",

--- a/docs/src/pages/components-explorer/components/gstreamer/index.mdx
+++ b/docs/src/pages/components-explorer/components/gstreamer/index.mdx
@@ -63,7 +63,7 @@ gstreamer:
 
 <Camera />
 
-### MJEPG Streams
+### MJPEG Streams
 
 <CameraMjpegStreams />
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,6 +33,7 @@
         "js-cookie": "^3.0.1",
         "monaco-editor": "^0.44.0",
         "monaco-yaml": "5.1.0",
+        "mui-nested-menu": "^3.4.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-lazyload": "^3.2.0",
@@ -42,7 +43,8 @@
         "react-transition-group": "^4.4.5",
         "typescript": "^5.3.2",
         "uuid": "^9.0.1",
-        "video.js": "^8.6.1"
+        "video.js": "^8.6.1",
+        "zustand": "^4.5.4"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.4",
@@ -7306,6 +7308,31 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/mui-nested-menu": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/mui-nested-menu/-/mui-nested-menu-3.4.0.tgz",
+      "integrity": "sha512-QUZqsCKW4tX1GwcbemBvf++ZvKsRXvHdZ+CT6GvnHvusucmEB18WKuJjAZVD8L5trXS98+9psie11Ev3FTez2A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/mux.js": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.2.tgz",
@@ -10015,6 +10042,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.4.tgz",
+      "integrity": "sha512-/BPMyLKJPtFEvVL0E9E9BTUM63MNyhPGlvxk1XjrfWTUlV+BR8jufjsovHzrtR6YNcBEcL7cMHovL1n9xHawEg==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,7 +28,7 @@
         "buffer": "^6.0.3",
         "dayjs": "^1.11.9",
         "dompurify": "^3.0.7",
-        "hls.js": "^1.5.4",
+        "hls.js": "^1.5.13",
         "http-proxy-middleware": "^2.0.2",
         "js-cookie": "^3.0.1",
         "monaco-editor": "^0.44.0",
@@ -5801,9 +5801,10 @@
       }
     },
     "node_modules/hls.js": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.5.4.tgz",
-      "integrity": "sha512-MB+e+tcBl+A/EamWvsvx7d/3m9JOLi3wbLaXyZdHlscgXkhiX5zajJxnt7lzn/w9ONxs5qaFTp/kkIMI9fD4KA=="
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.5.13.tgz",
+      "integrity": "sha512-xRgKo84nsC7clEvSfIdgn/Tc0NOT+d7vdiL/wvkLO+0k0juc26NRBPPG1SfB8pd5bHXIjMW/F5VM8VYYkOYYdw==",
+      "license": "Apache-2.0"
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "js-cookie": "^3.0.1",
     "monaco-editor": "^0.44.0",
     "monaco-yaml": "5.1.0",
+    "mui-nested-menu": "^3.4.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-lazyload": "^3.2.0",
@@ -42,7 +43,8 @@
     "react-transition-group": "^4.4.5",
     "typescript": "^5.3.2",
     "uuid": "^9.0.1",
-    "video.js": "^8.6.1"
+    "video.js": "^8.6.1",
+    "zustand": "^4.5.4"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "buffer": "^6.0.3",
     "dayjs": "^1.11.9",
     "dompurify": "^3.0.7",
-    "hls.js": "^1.5.4",
+    "hls.js": "^1.5.13",
     "http-proxy-middleware": "^2.0.2",
     "js-cookie": "^3.0.1",
     "monaco-editor": "^0.44.0",

--- a/frontend/src/components/events/EventPlayerCard.tsx
+++ b/frontend/src/components/events/EventPlayerCard.tsx
@@ -1,5 +1,5 @@
+import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
-import CardMedia from "@mui/material/CardMedia";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import Hls from "hls.js";
@@ -36,19 +36,28 @@ export const PlayerCard = ({
       variant="outlined"
       sx={(theme) => ({
         marginBottom: theme.margin,
-        position: "relative",
+        width: "100%",
+        height: "100%",
+        alignItems: "center",
+        display: "flex",
       })}
     >
-      {camera && <CameraNameOverlay camera={camera} />}
-      <CardMedia>
-        {camera && requestedTimestamp ? (
-          <TimelinePlayer
-            containerRef={playerCardRef}
-            hlsRef={hlsRef}
-            camera={camera}
-            requestedTimestamp={requestedTimestamp}
-          />
-        ) : (
+      {camera && requestedTimestamp ? (
+        <TimelinePlayer
+          containerRef={playerCardRef}
+          hlsRef={hlsRef}
+          camera={camera}
+          requestedTimestamp={requestedTimestamp}
+        />
+      ) : (
+        <Box
+          sx={{
+            position: "relative",
+            width: "100%",
+            maxHeight: "100%",
+          }}
+        >
+          {camera && <CameraNameOverlay camera={camera} />}
           <VideoPlayerPlaceholder
             aspectRatio={camera ? camera.width / camera.height : undefined}
             text={
@@ -60,8 +69,8 @@ export const PlayerCard = ({
             }
             src={src}
           />
-        )}
-      </CardMedia>
+        </Box>
+      )}
     </Card>
   );
 };

--- a/frontend/src/components/events/EventTable.tsx
+++ b/frontend/src/components/events/EventTable.tsx
@@ -9,7 +9,7 @@ import ServerDown from "svg/undraw/server_down.svg?react";
 
 import { ErrorMessage } from "components/error/ErrorMessage";
 import { EventTableItem } from "components/events/EventTableItem";
-import { getEventTimestamp } from "components/events/utils";
+import { getEventTimestamp, useFilterStore } from "components/events/utils";
 import { Loading } from "components/loading/Loading";
 import { useEvents } from "lib/api/events";
 import { useHlsAvailableTimespans } from "lib/api/hls";
@@ -103,6 +103,7 @@ export const EventTable = memo(
     });
 
     useOnScroll(parentRef);
+    const { filters } = useFilterStore();
 
     if (eventsQuery.isError || availableTimespansQuery.isError) {
       return (
@@ -130,7 +131,10 @@ export const EventTable = memo(
       );
     }
 
-    const groupedEvents = groupEventsByTime(eventsQuery.data.events);
+    const filteredEvents = eventsQuery.data.events.filter(
+      (event) => filters[event.type].checked,
+    );
+    const groupedEvents = groupEventsByTime(filteredEvents);
     return (
       <Box>
         <Grid container direction="row" columns={1}>

--- a/frontend/src/components/events/FilterMenu.tsx
+++ b/frontend/src/components/events/FilterMenu.tsx
@@ -1,0 +1,108 @@
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import FilterListIcon from "@mui/icons-material/FilterList";
+import {
+  Checkbox,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+} from "@mui/material";
+import IconButton from "@mui/material/IconButton";
+import { NestedMenuItem } from "mui-nested-menu";
+import React, { MouseEvent, useState } from "react";
+
+import { getIconFromType, useFilterStore } from "components/events/utils";
+import * as types from "lib/types";
+
+interface MenuProps {
+  anchorOrigin: {
+    vertical: "bottom" | "top";
+    horizontal: "left" | "right";
+  };
+  transformOrigin: {
+    vertical: "bottom" | "top";
+    horizontal: "left" | "right";
+  };
+}
+
+const menuProps: MenuProps = {
+  anchorOrigin: {
+    vertical: "top",
+    horizontal: "left",
+  },
+  transformOrigin: {
+    vertical: "top",
+    horizontal: "right",
+  },
+};
+
+export const FilterMenu: React.FC = () => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const { filters, toggleFilter } = useFilterStore();
+
+  const handleClick = (event: MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleCheckboxClick =
+    (filterKey: types.CameraEvent["type"]) =>
+    (event: MouseEvent<HTMLElement>) => {
+      event.stopPropagation();
+      event.preventDefault();
+      toggleFilter(filterKey);
+    };
+
+  return (
+    <>
+      <IconButton
+        onClick={handleClick}
+        sx={(theme) => ({
+          borderRadius: 0,
+          color: theme.palette.primary.main,
+        })}
+      >
+        <FilterListIcon />
+      </IconButton>
+      <Menu
+        id="filter-menu"
+        anchorEl={anchorEl}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        <NestedMenuItem
+          leftIcon={<ChevronLeftIcon />}
+          rightIcon={<div />}
+          label="Events"
+          parentMenuOpen={open}
+          MenuProps={menuProps}
+        >
+          {Object.keys(filters).map((filterKey) => {
+            const key = filterKey as types.CameraEvent["type"];
+            const Icon = getIconFromType(key);
+            return (
+              <MenuItem
+                key={filters[key].label}
+                onClick={handleCheckboxClick(key)}
+              >
+                <Checkbox
+                  checked={filters[key].checked}
+                  onClick={handleCheckboxClick(key)}
+                />
+                <ListItemIcon>
+                  <Icon />
+                </ListItemIcon>
+                <ListItemText primary={filters[key].label} />
+              </MenuItem>
+            );
+          })}
+        </NestedMenuItem>
+      </Menu>
+    </>
+  );
+};

--- a/frontend/src/components/events/FloatingMenu.tsx
+++ b/frontend/src/components/events/FloatingMenu.tsx
@@ -1,0 +1,80 @@
+import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
+import VideocamIcon from "@mui/icons-material/Videocam";
+import Box from "@mui/material/Box";
+import Fab from "@mui/material/Fab";
+import Tooltip from "@mui/material/Tooltip";
+import { Dayjs } from "dayjs";
+import { memo, useState } from "react";
+
+import { CameraPickerDialog } from "components/events/CameraPickerDialog";
+import { EventDatePickerDialog } from "components/events/EventDatePickerDialog";
+import * as types from "lib/types";
+
+type FloatingMenuProps = {
+  cameras: types.CamerasOrFailedCameras;
+  selectedCamera: types.Camera | types.FailedCamera | null;
+
+  date: Dayjs | null;
+  setDate: (date: Dayjs | null) => void;
+
+  changeSelectedCamera: (
+    ev: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    camera: types.Camera | types.FailedCamera,
+  ) => void;
+};
+
+export const FloatingMenu = memo(
+  ({
+    cameras,
+    selectedCamera,
+    date,
+    setDate,
+    changeSelectedCamera,
+  }: FloatingMenuProps) => {
+    const [cameraDialogOpen, setCameraDialogOpen] = useState(false);
+    const [dateDialogOpen, setDateDialogOpen] = useState(false);
+
+    return (
+      <>
+        <CameraPickerDialog
+          open={cameraDialogOpen}
+          setOpen={setCameraDialogOpen}
+          cameras={cameras}
+          changeSelectedCamera={changeSelectedCamera}
+          selectedCamera={selectedCamera}
+        />
+        <EventDatePickerDialog
+          open={dateDialogOpen}
+          setOpen={setDateDialogOpen}
+          date={date}
+          camera={selectedCamera}
+          onChange={(value) => {
+            setDateDialogOpen(false);
+            setDate(value);
+          }}
+        />
+        <Box sx={{ position: "absolute", bottom: 14, right: 24 }}>
+          <Tooltip title="Select Camera">
+            <Fab
+              size="medium"
+              color="primary"
+              onClick={() => setCameraDialogOpen(true)}
+            >
+              <VideocamIcon />
+            </Fab>
+          </Tooltip>
+          <Tooltip title="Select Date">
+            <Fab
+              size="medium"
+              color="primary"
+              sx={{ marginLeft: 1 }}
+              onClick={() => setDateDialogOpen(true)}
+            >
+              <CalendarMonthIcon />
+            </Fab>
+          </Tooltip>
+        </Box>
+      </>
+    );
+  },
+);

--- a/frontend/src/components/events/Layouts.tsx
+++ b/frontend/src/components/events/Layouts.tsx
@@ -1,116 +1,97 @@
-import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
-import FilterAltIcon from "@mui/icons-material/FilterAlt";
-import VideocamIcon from "@mui/icons-material/Videocam";
 import TabContext from "@mui/lab/TabContext";
 import TabList from "@mui/lab/TabList";
 import TabPanel from "@mui/lab/TabPanel";
+import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
-import Container from "@mui/material/Container";
-import SpeedDial from "@mui/material/SpeedDial";
-import SpeedDialAction from "@mui/material/SpeedDialAction";
+import Grid from "@mui/material/Grid";
 import Tab from "@mui/material/Tab";
 import Typography from "@mui/material/Typography";
 import { useTheme } from "@mui/material/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import { Dayjs } from "dayjs";
 import Hls from "hls.js";
-import { SyntheticEvent, memo, useEffect, useRef, useState } from "react";
+import { SyntheticEvent, memo, useEffect, useRef } from "react";
 
-import { CameraPickerDialog } from "components/events/CameraPickerDialog";
-import { EventDatePickerDialog } from "components/events/EventDatePickerDialog";
 import { PlayerCard } from "components/events/EventPlayerCard";
 import { EventTable } from "components/events/EventTable";
-import { EventsCameraGrid } from "components/events/EventsCameraGrid";
 import { FilterMenu } from "components/events/FilterMenu";
+import { FloatingMenu } from "components/events/FloatingMenu";
 import { TimelineTable } from "components/events/timeline/TimelineTable";
 import { COLUMN_HEIGHT, COLUMN_HEIGHT_SMALL } from "components/events/utils";
 import { insertURLParameter } from "lib/helpers";
 import * as types from "lib/types";
 
-type FiltersProps = {
-  cameras: types.CamerasOrFailedCameras;
-  selectedCamera: types.Camera | types.FailedCamera | null;
-
-  date: Dayjs | null;
-  setDate: (date: Dayjs | null) => void;
-
-  changeSelectedCamera: (
-    ev: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-    camera: types.Camera | types.FailedCamera,
-  ) => void;
+const useSetTableHeight = (
+  cardRef: React.RefObject<HTMLDivElement>,
+  tabListRef: React.RefObject<HTMLDivElement>,
+  eventsRef: React.RefObject<HTMLDivElement>,
+  timelineRef: React.RefObject<HTMLDivElement>,
+) => {
+  const resizeObserver = useRef<ResizeObserver>();
+  useEffect(() => {
+    if (cardRef.current) {
+      resizeObserver.current = new ResizeObserver(() => {
+        if (
+          !cardRef.current ||
+          !tabListRef.current ||
+          !eventsRef.current ||
+          !timelineRef.current
+        ) {
+          return;
+        }
+        timelineRef.current.style.height = `calc(${cardRef.current.clientHeight}px - ${tabListRef.current.clientHeight}px)`;
+        eventsRef.current.style.height = timelineRef.current.style.height;
+      });
+      resizeObserver.current.observe(cardRef.current);
+    }
+    return () => {
+      if (resizeObserver.current) {
+        resizeObserver.current.disconnect();
+      }
+    };
+  }, [cardRef, eventsRef, tabListRef, timelineRef]);
 };
 
-const Filters = memo(
-  ({
-    cameras,
-    selectedCamera,
-    date,
-    setDate,
-    changeSelectedCamera,
-  }: FiltersProps) => {
-    const [open, setOpen] = useState(false);
-    const [cameraDialogOpen, setCameraDialogOpen] = useState(false);
-    const [dateDialogOpen, setDateDialogOpen] = useState(false);
-    const theme = useTheme();
-
-    const handleClose = () => {
-      setOpen(false);
+const useSetCardHeight = (
+  gridRef: React.RefObject<HTMLDivElement>,
+  cardRef: React.RefObject<HTMLDivElement>,
+  playerCardRef: React.RefObject<HTMLDivElement>,
+  smBreakpoint: boolean,
+) => {
+  const theme = useTheme();
+  const resizeObserver = useRef<ResizeObserver>();
+  useEffect(() => {
+    if (playerCardRef.current) {
+      resizeObserver.current = new ResizeObserver(() => {
+        if (
+          !smBreakpoint &&
+          cardRef.current &&
+          playerCardRef.current &&
+          gridRef.current
+        ) {
+          cardRef.current.style.height = `calc(${COLUMN_HEIGHT_SMALL} - ${
+            theme.headerHeight
+          }px - ${playerCardRef.current!.clientHeight}px)`;
+          cardRef.current.style.maxHeight = "unset";
+          gridRef.current.style.height = "unset";
+          gridRef.current.style.maxHeight = "unset";
+        } else if (smBreakpoint && cardRef.current && gridRef.current) {
+          cardRef.current.style.height = `calc(${COLUMN_HEIGHT} - ${theme.headerHeight}px)`;
+          cardRef.current.style.maxHeight = cardRef.current.style.height;
+          gridRef.current.style.height = cardRef.current.style.height;
+          gridRef.current.style.maxHeight = cardRef.current.style.maxHeight;
+        }
+      });
+      resizeObserver.current.observe(playerCardRef.current);
+    }
+    return () => {
+      if (resizeObserver.current) {
+        resizeObserver.current.disconnect();
+      }
     };
-
-    const handleClick = () => {
-      setOpen(!open);
-    };
-
-    return (
-      <>
-        <CameraPickerDialog
-          open={cameraDialogOpen}
-          setOpen={setCameraDialogOpen}
-          cameras={cameras}
-          changeSelectedCamera={changeSelectedCamera}
-          selectedCamera={selectedCamera}
-        />
-        <EventDatePickerDialog
-          open={dateDialogOpen}
-          setOpen={setDateDialogOpen}
-          date={date}
-          camera={selectedCamera}
-          onChange={(value) => {
-            setDateDialogOpen(false);
-            setDate(value);
-          }}
-        />
-        <SpeedDial
-          ariaLabel="Filters"
-          sx={{ position: "absolute", bottom: 16, right: 16 }}
-          icon={<FilterAltIcon />}
-          onClose={handleClose}
-          onClick={handleClick}
-          open={open}
-        >
-          <SpeedDialAction
-            icon={<VideocamIcon />}
-            tooltipTitle={"Select camera"}
-            onClick={() => setCameraDialogOpen(true)}
-            FabProps={{
-              size: "medium",
-              sx: { backgroundColor: theme.palette.primary.main },
-            }}
-          />
-          <SpeedDialAction
-            icon={<CalendarMonthIcon />}
-            tooltipTitle={"Select date"}
-            onClick={() => setDateDialogOpen(true)}
-            FabProps={{
-              size: "medium",
-              sx: { backgroundColor: theme.palette.primary.main },
-            }}
-          />
-        </SpeedDial>
-      </>
-    );
-  },
-);
+  }, [cardRef, gridRef, playerCardRef, smBreakpoint, theme.headerHeight]);
+};
 
 type TabsProps = {
   hlsRef: React.MutableRefObject<Hls | null>;
@@ -137,7 +118,7 @@ const Tabs = ({
   const tabListRef = useRef<HTMLDivElement | null>(null);
   const eventsRef = useRef<HTMLDivElement | null>(null);
   const timelineRef = useRef<HTMLDivElement | null>(null);
-  const tabListHeight = tabListRef.current?.getBoundingClientRect().height;
+  useSetTableHeight(cardRef, tabListRef, eventsRef, timelineRef);
 
   const handleTabChange = (
     event: SyntheticEvent,
@@ -162,12 +143,17 @@ const Tabs = ({
           display: "flex",
         })}
       >
-        <Tab label="Events" value="events" sx={{ padding: 0, flexGrow: 1 }} />
+        <Tab
+          label="Events"
+          value="events"
+          sx={{ padding: 0, maxWidth: "100%", flexGrow: 1 }}
+        />
         <Tab
           label="Timeline"
           value="timeline"
           sx={(theme) => ({
             padding: 0,
+            maxWidth: "100%",
             flexGrow: 1,
             borderRight: 1,
             borderColor: theme.palette.divider,
@@ -181,7 +167,6 @@ const Tabs = ({
         sx={{
           padding: 0,
           paddingTop: "5px",
-          height: `calc(${cardRef.current?.offsetHeight}px - ${tabListHeight}px)`,
           overflow: "auto",
           overflowX: "hidden",
         }}
@@ -208,7 +193,6 @@ const Tabs = ({
           padding: 0,
           paddingTop: "5px",
           paddingBottom: "50px",
-          height: `calc(${cardRef.current?.offsetHeight}px - ${tabListHeight}px)`,
           overflow: "auto",
           overflowX: "hidden",
         }}
@@ -265,147 +249,57 @@ export const Layout = memo(
     setSelectedTab,
   }: LayoutProps) => {
     const theme = useTheme();
+    const smBreakpoint = useMediaQuery(theme.breakpoints.up("sm"));
     const hlsRef = useRef<Hls | null>(null);
     const cardRef = useRef<HTMLDivElement | null>(null);
     const playerCardRef = useRef<HTMLDivElement | null>(null);
+    const gridRef = useRef<HTMLDivElement | null>(null);
+    useSetCardHeight(gridRef, cardRef, playerCardRef, smBreakpoint);
+
     return (
-      <Container style={{ display: "flex" }}>
-        <div
-          style={{
-            width: "100%",
-            display: "flex",
-            flexDirection: "column",
-            marginRight: theme.margin,
-          }}
+      <Box>
+        <Grid
+          container
+          direction={"row"}
+          rowSpacing={{ xs: 0.5, sm: 0 }}
+          columnSpacing={1}
         >
-          <PlayerCard
-            camera={selectedCamera}
-            selectedEvent={selectedEvent}
-            requestedTimestamp={requestedTimestamp}
-            selectedTab={selectedTab}
-            hlsRef={hlsRef}
-            playerCardRef={playerCardRef}
-          />
-          <EventsCameraGrid
-            playerCardRef={playerCardRef}
+          <Grid ref={gridRef} item xs={12} sm={8} display="flex">
+            <PlayerCard
+              camera={selectedCamera}
+              selectedEvent={selectedEvent}
+              requestedTimestamp={requestedTimestamp}
+              selectedTab={selectedTab}
+              hlsRef={hlsRef}
+              playerCardRef={playerCardRef}
+            />
+          </Grid>
+          <Grid item xs={12} sm={4}>
+            <Card ref={cardRef} variant="outlined">
+              <CardContent sx={{ padding: 0 }}>
+                <Tabs
+                  hlsRef={hlsRef}
+                  date={date}
+                  selectedTab={selectedTab}
+                  setSelectedTab={setSelectedTab}
+                  selectedCamera={selectedCamera}
+                  selectedEvent={selectedEvent}
+                  setSelectedEvent={setSelectedEvent}
+                  setRequestedTimestamp={setRequestedTimestamp}
+                  cardRef={cardRef}
+                />
+              </CardContent>
+            </Card>
+          </Grid>
+          <FloatingMenu
             cameras={cameras}
-            changeSelectedCamera={changeSelectedCamera}
             selectedCamera={selectedCamera}
-          ></EventsCameraGrid>
-        </div>
-        <Card
-          ref={cardRef}
-          variant="outlined"
-          sx={{
-            width: "650px",
-            height: `calc(${COLUMN_HEIGHT} - ${theme.headerHeight}px)`,
-          }}
-        >
-          <CardContent sx={{ padding: 0 }}>
-            <Tabs
-              hlsRef={hlsRef}
-              date={date}
-              selectedTab={selectedTab}
-              setSelectedTab={setSelectedTab}
-              selectedCamera={selectedCamera}
-              selectedEvent={selectedEvent}
-              setSelectedEvent={setSelectedEvent}
-              setRequestedTimestamp={setRequestedTimestamp}
-              cardRef={cardRef}
-            />
-          </CardContent>
-        </Card>
-        <Filters
-          cameras={cameras}
-          selectedCamera={selectedCamera}
-          date={date}
-          setDate={setDate}
-          changeSelectedCamera={changeSelectedCamera}
-        />
-      </Container>
-    );
-  },
-);
-
-export const LayoutSmall = memo(
-  ({
-    cameras,
-    selectedCamera,
-    selectedEvent,
-    setSelectedEvent,
-    changeSelectedCamera,
-    date,
-    setDate,
-    requestedTimestamp,
-    setRequestedTimestamp,
-    selectedTab,
-    setSelectedTab,
-  }: LayoutProps) => {
-    const theme = useTheme();
-    const hlsRef = useRef<Hls | null>(null);
-    const cardRef = useRef<HTMLDivElement | null>(null);
-    const playerCardRef = useRef<HTMLDivElement | null>(null);
-
-    // Observe div height to calculate the height of the EventTable
-    const [height, setHeight] = useState();
-    const observedDiv: any = useRef<HTMLDivElement>();
-    const resizeObserver = useRef<ResizeObserver>();
-    useEffect(() => {
-      if (observedDiv.current) {
-        resizeObserver.current = new ResizeObserver(() => {
-          setHeight(observedDiv.current.clientHeight + theme.headerHeight);
-        });
-        resizeObserver.current.observe(observedDiv.current);
-      }
-      return () => {
-        if (resizeObserver.current) {
-          resizeObserver.current.disconnect();
-        }
-      };
-    }, [theme.headerHeight]);
-
-    return (
-      <Container maxWidth={false} sx={{ height: "100%" }}>
-        <div ref={observedDiv}>
-          <PlayerCard
-            camera={selectedCamera}
-            selectedEvent={selectedEvent}
-            requestedTimestamp={requestedTimestamp}
-            selectedTab={selectedTab}
-            hlsRef={hlsRef}
-            playerCardRef={playerCardRef}
+            date={date}
+            setDate={setDate}
+            changeSelectedCamera={changeSelectedCamera}
           />
-        </div>
-        <Card
-          ref={cardRef}
-          variant="outlined"
-          sx={{
-            width: "100%",
-            height: `calc(${COLUMN_HEIGHT_SMALL} - ${height}px)`,
-          }}
-        >
-          <CardContent sx={{ padding: 0 }}>
-            <Tabs
-              hlsRef={hlsRef}
-              date={date}
-              selectedTab={selectedTab}
-              setSelectedTab={setSelectedTab}
-              selectedCamera={selectedCamera}
-              selectedEvent={selectedEvent}
-              setSelectedEvent={setSelectedEvent}
-              setRequestedTimestamp={setRequestedTimestamp}
-              cardRef={cardRef}
-            />
-          </CardContent>
-        </Card>
-        <Filters
-          cameras={cameras}
-          selectedCamera={selectedCamera}
-          date={date}
-          setDate={setDate}
-          changeSelectedCamera={changeSelectedCamera}
-        />
-      </Container>
+        </Grid>
+      </Box>
     );
   },
 );

--- a/frontend/src/components/events/Layouts.tsx
+++ b/frontend/src/components/events/Layouts.tsx
@@ -4,7 +4,6 @@ import VideocamIcon from "@mui/icons-material/Videocam";
 import TabContext from "@mui/lab/TabContext";
 import TabList from "@mui/lab/TabList";
 import TabPanel from "@mui/lab/TabPanel";
-import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Container from "@mui/material/Container";
@@ -22,8 +21,9 @@ import { EventDatePickerDialog } from "components/events/EventDatePickerDialog";
 import { PlayerCard } from "components/events/EventPlayerCard";
 import { EventTable } from "components/events/EventTable";
 import { EventsCameraGrid } from "components/events/EventsCameraGrid";
+import { FilterMenu } from "components/events/FilterMenu";
 import { TimelineTable } from "components/events/timeline/TimelineTable";
-import { COLUMN_HEIGHT } from "components/events/utils";
+import { COLUMN_HEIGHT, COLUMN_HEIGHT_SMALL } from "components/events/utils";
 import { insertURLParameter } from "lib/helpers";
 import * as types from "lib/types";
 
@@ -113,7 +113,6 @@ const Filters = memo(
 );
 
 type TabsProps = {
-  parentRef: React.MutableRefObject<HTMLDivElement | null>;
   hlsRef: React.MutableRefObject<Hls | null>;
   date: Dayjs | null;
   selectedTab: "events" | "timeline";
@@ -122,9 +121,9 @@ type TabsProps = {
   selectedEvent: types.CameraEvent | null;
   setSelectedEvent: (event: types.CameraEvent) => void;
   setRequestedTimestamp: (timestamp: number | null) => void;
+  cardRef: React.RefObject<HTMLDivElement>;
 };
 const Tabs = ({
-  parentRef,
   hlsRef,
   date,
   selectedTab,
@@ -133,7 +132,13 @@ const Tabs = ({
   selectedEvent,
   setSelectedEvent,
   setRequestedTimestamp,
+  cardRef,
 }: TabsProps) => {
+  const tabListRef = useRef<HTMLDivElement | null>(null);
+  const eventsRef = useRef<HTMLDivElement | null>(null);
+  const timelineRef = useRef<HTMLDivElement | null>(null);
+  const tabListHeight = tabListRef.current?.getBoundingClientRect().height;
+
   const handleTabChange = (
     event: SyntheticEvent,
     tab: "events" | "timeline",
@@ -147,23 +152,43 @@ const Tabs = ({
 
   return (
     <TabContext value={selectedTab}>
-      <Box
-        sx={{
+      <TabList
+        ref={tabListRef}
+        onChange={handleTabChange}
+        sx={(theme) => ({
+          width: "100%",
           borderBottom: 1,
-          borderColor: "divider",
+          borderColor: theme.palette.divider,
           display: "flex",
-          justifyContent: "space-evenly",
+        })}
+      >
+        <Tab label="Events" value="events" sx={{ padding: 0, flexGrow: 1 }} />
+        <Tab
+          label="Timeline"
+          value="timeline"
+          sx={(theme) => ({
+            padding: 0,
+            flexGrow: 1,
+            borderRight: 1,
+            borderColor: theme.palette.divider,
+          })}
+        />
+        <FilterMenu />
+      </TabList>
+      <TabPanel
+        ref={eventsRef}
+        value="events"
+        sx={{
+          padding: 0,
+          paddingTop: "5px",
+          height: `calc(${cardRef.current?.offsetHeight}px - ${tabListHeight}px)`,
+          overflow: "auto",
+          overflowX: "hidden",
         }}
       >
-        <TabList onChange={handleTabChange} sx={{ width: "100%" }}>
-          <Tab label="Events" value="events" sx={{ width: "50%" }} />
-          <Tab label="Timeline" value="timeline" sx={{ width: "50%" }} />
-        </TabList>
-      </Box>
-      <TabPanel value="events" sx={{ padding: 0, paddingTop: "5px" }}>
         {selectedCamera ? (
           <EventTable
-            parentRef={parentRef}
+            parentRef={eventsRef}
             camera={selectedCamera}
             date={date}
             selectedEvent={selectedEvent}
@@ -176,12 +201,23 @@ const Tabs = ({
           </Typography>
         )}
       </TabPanel>
-      <TabPanel value="timeline" sx={{ padding: 0, paddingTop: "5px" }}>
+      <TabPanel
+        ref={timelineRef}
+        value="timeline"
+        sx={{
+          padding: 0,
+          paddingTop: "5px",
+          paddingBottom: "50px",
+          height: `calc(${cardRef.current?.offsetHeight}px - ${tabListHeight}px)`,
+          overflow: "auto",
+          overflowX: "hidden",
+        }}
+      >
         {selectedCamera ? (
           <TimelineTable
             // Force re-render when camera or date changes
             key={`${selectedCamera.identifier}-${date?.unix().toString()}`}
-            parentRef={parentRef}
+            parentRef={timelineRef}
             hlsRef={hlsRef}
             camera={selectedCamera}
             date={date}
@@ -229,8 +265,8 @@ export const Layout = memo(
     setSelectedTab,
   }: LayoutProps) => {
     const theme = useTheme();
-    const parentRef = useRef<HTMLDivElement | null>(null);
     const hlsRef = useRef<Hls | null>(null);
+    const cardRef = useRef<HTMLDivElement | null>(null);
     const playerCardRef = useRef<HTMLDivElement | null>(null);
     return (
       <Container style={{ display: "flex" }}>
@@ -258,18 +294,15 @@ export const Layout = memo(
           ></EventsCameraGrid>
         </div>
         <Card
-          ref={parentRef}
+          ref={cardRef}
           variant="outlined"
           sx={{
             width: "650px",
             height: `calc(${COLUMN_HEIGHT} - ${theme.headerHeight}px)`,
-            overflow: "auto",
-            overflowX: "hidden",
           }}
         >
           <CardContent sx={{ padding: 0 }}>
             <Tabs
-              parentRef={parentRef}
               hlsRef={hlsRef}
               date={date}
               selectedTab={selectedTab}
@@ -278,6 +311,7 @@ export const Layout = memo(
               selectedEvent={selectedEvent}
               setSelectedEvent={setSelectedEvent}
               setRequestedTimestamp={setRequestedTimestamp}
+              cardRef={cardRef}
             />
           </CardContent>
         </Card>
@@ -308,8 +342,8 @@ export const LayoutSmall = memo(
     setSelectedTab,
   }: LayoutProps) => {
     const theme = useTheme();
-    const parentRef = useRef<HTMLDivElement | null>(null);
     const hlsRef = useRef<Hls | null>(null);
+    const cardRef = useRef<HTMLDivElement | null>(null);
     const playerCardRef = useRef<HTMLDivElement | null>(null);
 
     // Observe div height to calculate the height of the EventTable
@@ -343,17 +377,15 @@ export const LayoutSmall = memo(
           />
         </div>
         <Card
-          ref={parentRef}
+          ref={cardRef}
           variant="outlined"
           sx={{
             width: "100%",
-            overflow: "auto",
-            height: `calc(97dvh - ${height}px)`,
+            height: `calc(${COLUMN_HEIGHT_SMALL} - ${height}px)`,
           }}
         >
           <CardContent sx={{ padding: 0 }}>
             <Tabs
-              parentRef={parentRef}
               hlsRef={hlsRef}
               date={date}
               selectedTab={selectedTab}
@@ -362,6 +394,7 @@ export const LayoutSmall = memo(
               selectedEvent={selectedEvent}
               setSelectedEvent={setSelectedEvent}
               setRequestedTimestamp={setRequestedTimestamp}
+              cardRef={cardRef}
             />
           </CardContent>
         </Card>

--- a/frontend/src/components/events/SnapshotEvent.tsx
+++ b/frontend/src/components/events/SnapshotEvent.tsx
@@ -1,11 +1,4 @@
 import Image from "@jy95/material-ui-image";
-import AirIcon from "@mui/icons-material/Air";
-import DirectionsCarIcon from "@mui/icons-material/DirectionsCar";
-import PersonIcon from "@mui/icons-material/DirectionsWalk";
-import FaceIcon from "@mui/icons-material/Face";
-import ImageSearchIcon from "@mui/icons-material/ImageSearch";
-import PetsIcon from "@mui/icons-material/Pets";
-import VideoFileIcon from "@mui/icons-material/VideoFile";
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
@@ -26,9 +19,9 @@ import {
   extractUniqueTypes,
   getEventTime,
   getEventTimestamp,
+  getIcon,
   getSrc,
 } from "components/events/utils";
-import LicensePlateRecgnitionIcon from "components/icons/LicensePlateRecognition";
 import { toTitleCase } from "lib/helpers";
 import * as types from "lib/types";
 
@@ -42,43 +35,6 @@ const CustomWidthTooltip = styled(({ className, ...props }: TooltipProps) => (
     maxWidth: "100vw",
   },
 }));
-
-const labelToIcon = (label: string) => {
-  switch (label) {
-    case "person":
-      return PersonIcon;
-
-    case "car":
-    case "truck":
-    case "vehicle":
-      return DirectionsCarIcon;
-
-    case "dog":
-    case "cat":
-    case "animal":
-      return PetsIcon;
-
-    default:
-      return ImageSearchIcon;
-  }
-};
-
-const getIcon = (event: types.CameraEvent) => {
-  switch (event.type) {
-    case "object":
-      return labelToIcon(event.label);
-    case "face_recognition":
-      return FaceIcon;
-    case "license_plate_recognition":
-      return LicensePlateRecgnitionIcon;
-    case "motion":
-      return AirIcon;
-    case "recording":
-      return VideoFileIcon;
-    default:
-      return event satisfies never;
-  }
-};
 
 const getText = (event: types.CameraEvent) => {
   const date = new Date(getEventTime(event));
@@ -233,11 +189,8 @@ export const SnapshotIcon = ({ events }: { events: types.CameraEvent[] }) => {
         }}
       >
         <Icon
+          color="primary"
           style={{
-            color:
-              theme.palette.mode === "dark"
-                ? theme.palette.primary[600]
-                : theme.palette.primary[300],
             height: EVENT_ICON_HEIGHT,
             width: EVENT_ICON_HEIGHT,
           }}

--- a/frontend/src/components/events/timeline/TimelinePlayer.tsx
+++ b/frontend/src/components/events/timeline/TimelinePlayer.tsx
@@ -10,6 +10,7 @@ import {
   findFragmentByTimestamp,
 } from "components/events/utils";
 import { useAuthContext } from "context/AuthContext";
+import { useFirstRender } from "hooks/UseFirstRender";
 import { getToken } from "lib/tokens";
 import * as types from "lib/types";
 
@@ -151,6 +152,7 @@ const initializePlayer = (
 
   // Handle errors
   hlsRef.current.on(Hls.Events.ERROR, (_event, data) => {
+    console.error("HLS error", data.details, data.type, data.fatal);
     if (data.fatal) {
       switch (data.type) {
         case Hls.ErrorTypes.NETWORK_ERROR:
@@ -218,8 +220,15 @@ const useSeekToTimestamp = (
   requestedTimestamp: number,
   camera: types.Camera | types.FailedCamera,
 ) => {
+  // Avoid running on first render to not call loadSource twice
+  const firstRender = useFirstRender();
   useEffect(() => {
-    if (!hlsRef.current || !videoRef.current || !hlsRef.current.media) {
+    if (
+      !hlsRef.current ||
+      !videoRef.current ||
+      !hlsRef.current.media ||
+      firstRender
+    ) {
       return;
     }
 
@@ -262,6 +271,7 @@ const useSeekToTimestamp = (
     videoRef.current.play();
   }, [
     camera,
+    firstRender,
     hlsClientIdRef,
     hlsRef,
     initialProgramDateTime,

--- a/frontend/src/components/events/timeline/TimelineTable.tsx
+++ b/frontend/src/components/events/timeline/TimelineTable.tsx
@@ -14,6 +14,7 @@ import {
   calculateStart,
   getDateAtPosition,
   getTimelineItems,
+  useFilterStore,
 } from "components/events/utils";
 import { Loading } from "components/loading/Loading";
 import { ViseronContext } from "context/ViseronContext";
@@ -129,14 +130,17 @@ export const TimelineTable = memo(
         keepPreviousData: true,
       },
     });
+
+    const { filters } = useFilterStore();
     const timelineItems = useMemo(
       () =>
         getTimelineItems(
           startRef,
           eventsQuery.data?.events || [],
           availableTimespansQuery.data?.timespans || [],
+          filters,
         ),
-      [eventsQuery.data, availableTimespansQuery.data],
+      [eventsQuery.data, availableTimespansQuery.data, filters],
     );
 
     if (eventsQuery.error || availableTimespansQuery.error) {

--- a/frontend/src/components/events/utils.tsx
+++ b/frontend/src/components/events/utils.tsx
@@ -18,7 +18,7 @@ export const TICK_HEIGHT = 8;
 export const SCALE = 60;
 export const EXTRA_TICKS = 10;
 export const COLUMN_HEIGHT = "99dvh";
-export const COLUMN_HEIGHT_SMALL = "97dvh";
+export const COLUMN_HEIGHT_SMALL = "98.5dvh";
 export const EVENT_ICON_HEIGHT = 30;
 
 type Filters = {

--- a/frontend/src/components/icons/LicensePlateRecognition.tsx
+++ b/frontend/src/components/icons/LicensePlateRecognition.tsx
@@ -2,16 +2,25 @@ import DirectionsCarIcon from "@mui/icons-material/DirectionsCar";
 import SearchIcon from "@mui/icons-material/Search";
 import Box from "@mui/material/Box";
 
-const LicensePlateRecgnition = () => (
+type LicensePlateRecognitionProps = {
+  color?:
+    | "disabled"
+    | "action"
+    | "inherit"
+    | "primary"
+    | "secondary"
+    | "error"
+    | "info"
+    | "success"
+    | "warning"
+    | undefined;
+};
+
+const LicensePlateRecognition = ({
+  color = undefined,
+}: LicensePlateRecognitionProps) => (
   <Box sx={{ position: "relative" }}>
-    <DirectionsCarIcon
-      sx={(theme) => ({
-        color:
-          theme.palette.mode === "dark"
-            ? theme.palette.primary[600]
-            : theme.palette.primary[300],
-      })}
-    />
+    <DirectionsCarIcon color={color} />
     <SearchIcon
       sx={(theme) => ({
         position: "absolute",
@@ -22,17 +31,14 @@ const LicensePlateRecgnition = () => (
       })}
     />
     <SearchIcon
-      sx={(theme) => ({
+      color={color}
+      sx={{
         position: "absolute",
         right: "-6.5px",
         bottom: "-1px",
-        color:
-          theme.palette.mode === "dark"
-            ? theme.palette.primary[600]
-            : theme.palette.primary[300],
-      })}
+      }}
     />
   </Box>
 );
 
-export default LicensePlateRecgnition;
+export default LicensePlateRecognition;

--- a/frontend/src/components/videoplayer/VideoPlayerPlaceholder.tsx
+++ b/frontend/src/components/videoplayer/VideoPlayerPlaceholder.tsx
@@ -20,7 +20,10 @@ export default function VideoPlayerPlaceholder({
   const theme = useTheme();
 
   return (
-    <Box sx={{ position: "relative" }} data-testid="video-player-placeholder">
+    <Box
+      sx={{ position: "relative", width: "100%" }}
+      data-testid="video-player-placeholder"
+    >
       <Image
         src={src || blankImage}
         aspectRatio={aspectRatio}
@@ -35,12 +38,10 @@ export default function VideoPlayerPlaceholder({
             textAlign: "center",
             position: "absolute",
             opacity: "0.5",
-            top: "0",
+            top: "50%",
             bottom: "0",
             left: "0",
             right: "0",
-            height: "fit-content",
-            margin: "auto",
           }}
         >
           {text}

--- a/frontend/src/hooks/UseFirstRender.tsx
+++ b/frontend/src/hooks/UseFirstRender.tsx
@@ -1,0 +1,11 @@
+import { useEffect, useRef } from "react";
+
+export function useFirstRender() {
+  const firstRender = useRef(true);
+
+  useEffect(() => {
+    firstRender.current = false;
+  }, []);
+
+  return firstRender.current;
+}

--- a/frontend/src/pages/Events.tsx
+++ b/frontend/src/pages/Events.tsx
@@ -89,6 +89,13 @@ const Events = () => {
     }
   }, [date]);
 
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "scroll";
+    };
+  }, []);
+
   if (camerasQuery.isError) {
     return (
       <ErrorMessage

--- a/frontend/src/pages/Events.tsx
+++ b/frontend/src/pages/Events.tsx
@@ -1,12 +1,10 @@
-import { useTheme } from "@mui/material/styles";
-import useMediaQuery from "@mui/material/useMediaQuery";
 import dayjs, { Dayjs } from "dayjs";
 import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import ServerDown from "svg/undraw/server_down.svg?react";
 
 import { ErrorMessage } from "components/error/ErrorMessage";
-import { Layout, LayoutSmall } from "components/events/Layouts";
+import { Layout } from "components/events/Layouts";
 import { Loading } from "components/loading/Loading";
 import { useTitle } from "hooks/UseTitle";
 import { useCameras, useCamerasFailed } from "lib/api/cameras";
@@ -26,8 +24,6 @@ const getDefaultTab = (searchParams: URLSearchParams) => {
 
 const Events = () => {
   useTitle("Events");
-  const theme = useTheme();
-  const matches = useMediaQuery(theme.breakpoints.up("sm"));
   const [searchParams] = useSearchParams();
   const camerasQuery = useCameras({});
   const failedCamerasQuery = useCamerasFailed({});
@@ -121,9 +117,8 @@ const Events = () => {
     return null;
   }
 
-  const LayoutVariant = matches ? Layout : LayoutSmall;
   return (
-    <LayoutVariant
+    <Layout
       cameras={cameraData}
       selectedCamera={selectedCamera}
       selectedEvent={selectedEvent}

--- a/tests/domains/camera/test_fragmenter.py
+++ b/tests/domains/camera/test_fragmenter.py
@@ -28,6 +28,7 @@ def test_generate_playlist() -> None:
 #EXT-X-TARGETDURATION:6
 #EXT-X-INDEPENDENT-SEGMENTS
 #EXT-X-MAP:URI="/test/init.mp4"
+#EXT-X-DISCONTINUITY
 #EXT-X-PROGRAM-DATE-TIME:{program_date_time}
 #EXTINF:5.1,
 /test/test1.mp4
@@ -35,7 +36,6 @@ def test_generate_playlist() -> None:
 #EXT-X-PROGRAM-DATE-TIME:{program_date_time}
 #EXTINF:4.123,
 /test/test2.mp4
-#EXT-X-DISCONTINUITY
 #EXT-X-ENDLIST"""
     )
 
@@ -84,10 +84,10 @@ class TestFragmenter:
         )
 
     @patch("viseron.domains.camera.fragmenter.shutil.move")
-    def test_move_to_segments_folder(self, mock_shutil_move: Mock):
+    def test_move_to_segments_folder_mp4box(self, mock_shutil_move: Mock):
         """Test that the files are moved to the segments folder."""
         mock_shutil_move.return_value = MagicMock()
-        self.fragmenter._move_to_segments_folder(  # pylint: disable=protected-access
+        self.fragmenter._move_to_segments_folder_mp4box(  # pylint: disable=protected-access
             "test.mp4"
         )
         mock_shutil_move.assert_any_call(

--- a/tests/domains/camera/test_fragmenter.py
+++ b/tests/domains/camera/test_fragmenter.py
@@ -1,13 +1,48 @@
 """Tests for fragmenter."""
 from __future__ import annotations
 
+import datetime
 import os
 import shutil
 import tempfile
 from unittest.mock import MagicMock, Mock, patch
 
-from viseron.domains.camera.fragmenter import Fragment, Fragmenter, generate_playlist
+from viseron.domains.camera.fragmenter import (
+    Fragment,
+    Fragmenter,
+    _extract_extinf_number,
+    _extract_program_date_time,
+    generate_playlist,
+)
 from viseron.helpers import utcnow
+
+PLAYLIST_CONTENT = """#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-PLAYLIST-TYPE:EVENT
+#EXT-X-MAP:URI="init.mp4"
+#EXTINF:6.001628,
+#EXT-X-PROGRAM-DATE-TIME:2024-08-08T09:59:00.229+0000
+1723111140.m4s
+#EXTINF:4.010498,
+#EXT-X-PROGRAM-DATE-TIME:2024-08-08T09:59:06.231+0000
+1723111146.m4s
+#EXTINF:5.957438,
+#EXT-X-PROGRAM-DATE-TIME:2024-08-08T09:59:10.241+0000
+1723111150.m4s
+#EXTINF:5.021240,
+#EXT-X-PROGRAM-DATE-TIME:2024-08-08T09:59:16.199+0000
+1723111156.m4s
+#EXTINF:4.983073,
+#EXT-X-PROGRAM-DATE-TIME:2024-08-08T09:59:21.220+0000
+1723111161.m4s
+#EXTINF:4.986003,
+#EXT-X-PROGRAM-DATE-TIME:2024-08-08T09:59:26.203+0000
+1723111166.m4s
+#EXTINF:4.987305,
+#EXT-X-PROGRAM-DATE-TIME:2024-08-08T09:59:31.189+0000
+1723111171.m4s"""
 
 
 def test_generate_playlist() -> None:
@@ -100,3 +135,15 @@ class TestFragmenter:
             os.path.join(self.camera.segments_folder, "init.mp4"),
         )
         assert mock_shutil_move.call_count == 2
+
+
+def test_extract_extinf_number():
+    """Test _extract_extinf_number."""
+    extinf_number = _extract_extinf_number(PLAYLIST_CONTENT, "1723111150.m4s")
+    assert extinf_number == 5.957438
+
+
+def test_extract_program_date_time() -> None:
+    """Test _extract_program_date_time."""
+    date_time_tag = _extract_program_date_time(PLAYLIST_CONTENT, "1723111156.m4s")
+    assert date_time_tag == datetime.datetime(2024, 8, 8, 9, 59, 16, 199000)

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,9 @@ commands =
 
 [testenv:pytest]
 commands_pre =
-  docker-compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env build amd64-viseron-tests-tox
+  docker compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env build amd64-viseron-tests-tox
 commands =
-  docker-compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env run --rm amd64-viseron-tests-tox bash -c "chown -R abc:abc /src && su abc -c 'pytest --cov=viseron/ --cov-report term-missing -s {posargs: tests/}'"
+  docker compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env run --rm amd64-viseron-tests-tox bash -c "chown -R abc:abc /src && su abc -c 'pytest --cov=viseron/ --cov-report term-missing -s {posargs: tests/}'"
 
 
 [testenv:pylint]

--- a/viseron/components/ffmpeg/const.py
+++ b/viseron/components/ffmpeg/const.py
@@ -16,19 +16,6 @@ STREAM_FORMAT_MAP = {
 
 RECORDER = "recorder"
 
-CAMERA_SEGMENT_DURATION = 5
-CAMERA_SEGMENT_ARGS = [
-    "-f",
-    "segment",
-    "-segment_time",
-    str(CAMERA_SEGMENT_DURATION),
-    "-reset_timestamps",
-    "1",
-    "-strftime",
-    "1",
-    "-c:v",
-    "copy",
-]
 CAMERA_INPUT_ARGS = [
     "-avoid_negative_ts",
     "make_zero",

--- a/viseron/components/ffmpeg/const.py
+++ b/viseron/components/ffmpeg/const.py
@@ -121,9 +121,8 @@ DESC_CODEC = (
     "see <a href=#ffprobe-stream-information>FFprobe stream information.</a>"
 )
 DESC_AUDIO_CODEC = (
-    "FFmpeg audio encoder codec for the generated segments, eg <code>aac</code>.<br>"
-    "Note that if you set this, FFmpeg will have to re-encode your stream which "
-    "increases system load.<br>Will use FFprobe to get this information if not given, "
+    "Audio codec of the stream, eg <code>aac</code>.<br>"
+    "Will use FFprobe to get this information if not given, "
     "see <a href=#ffprobe-stream-information>FFprobe stream information.</a>"
 )
 DESC_RTSP_TRANSPORT = (
@@ -153,7 +152,7 @@ CONFIG_RECORDER_OUPTUT_ARGS = "output_args"
 
 DEFAULT_RECORDER_HWACCEL_ARGS: list[str] = []
 DEFAULT_RECORDER_CODEC = "copy"
-DEFAULT_RECORDER_AUDIO_CODEC = "copy"
+DEFAULT_RECORDER_AUDIO_CODEC = "unset"
 DEFAULT_RECORDER_VIDEO_FILTERS: list[str] = []
 DEFAULT_RECORDER_AUDIO_FILTERS: list[str] = []
 DEFAULT_RECORDER_OUTPUT_ARGS: list[str] = []
@@ -161,7 +160,10 @@ DEFAULT_SEGMENTS_FOLDER = "/segments"
 
 DESC_RECORDER_HWACCEL_ARGS = "FFmpeg encoder hardware acceleration arguments."
 DESC_RECORDER_CODEC = "FFmpeg video encoder codec, eg <code>h264_nvenc</code>."
-DESC_RECORDER_AUDIO_CODEC = "FFmpeg audio encoder codec, eg <code>aac</code>."
+DESC_RECORDER_AUDIO_CODEC = (
+    "FFmpeg audio encoder codec, eg <code>aac</code>.<br>"
+    "If your source has audio and you want to remove it, set this to <code>null</code>."
+)
 DESC_RECORDER_VIDEO_FILTERS = (
     "A list of FFmpeg filter arguments. "
     "These filters are applied to the recorder videos."

--- a/viseron/components/gstreamer/pipeline.py
+++ b/viseron/components/gstreamer/pipeline.py
@@ -5,8 +5,7 @@ import os
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
-from viseron.components.ffmpeg.const import CAMERA_SEGMENT_DURATION
-from viseron.const import ENV_VAAPI_SUPPORTED
+from viseron.const import CAMERA_SEGMENT_DURATION, ENV_VAAPI_SUPPORTED
 
 from .const import (
     CONFIG_AUDIO_CODEC,

--- a/viseron/components/nvr/nvr.py
+++ b/viseron/components/nvr/nvr.py
@@ -663,7 +663,7 @@ class NVR:
         This makes sure all frames are cleaned up eventually.
         """
         timer = threading.Timer(
-            2, self._camera.shared_frames.remove, args=(shared_frame,)
+            2, self._camera.shared_frames.remove, args=(shared_frame, self._camera)
         )
         timer.start()
 
@@ -726,7 +726,7 @@ class NVR:
                 shared_frame = self._frame_queue.get(timeout=1)
             except Empty:
                 break
-            self._camera.shared_frames.remove(shared_frame)
+            self._camera.shared_frames.remove(shared_frame, self._camera)
 
         for timer in self._removal_timers:
             timer.cancel()

--- a/viseron/const.py
+++ b/viseron/const.py
@@ -86,18 +86,7 @@ CAMERA_INPUT_ARGS = [
     "0",
 ]
 CAMERA_SEGMENT_DURATION = 5
-CAMERA_SEGMENT_ARGS = [
-    "-f",
-    "segment",
-    "-segment_time",
-    str(CAMERA_SEGMENT_DURATION),
-    "-reset_timestamps",
-    "1",
-    "-strftime",
-    "1",
-    "-c:v",
-    "copy",
-]
+
 
 ENV_CUDA_SUPPORTED = "VISERON_CUDA_SUPPORTED"
 ENV_VAAPI_SUPPORTED = "VISERON_VAAPI_SUPPORTED"

--- a/viseron/domains/camera/__init__.py
+++ b/viseron/domains/camera/__init__.py
@@ -451,6 +451,8 @@ class AbstractCamera(ABC):
             "height": self.resolution[1],
             "access_token": self.access_token,
             "still_image_refresh_interval": self.still_image[CONFIG_REFRESH_INTERVAL],
+            "is_on": self.is_on,
+            "connected": self.connected,
         }
 
     def generate_token(self):
@@ -502,6 +504,7 @@ class AbstractCamera(ABC):
         )
         if self.is_recording:
             self.stop_recorder()
+        self.current_frame = None
 
     @abstractmethod
     def _stop_camera(self):

--- a/viseron/domains/camera/shared_frames.py
+++ b/viseron/domains/camera/shared_frames.py
@@ -6,9 +6,13 @@ import threading
 import time
 import uuid
 from functools import lru_cache
+from typing import TYPE_CHECKING
 
 import cv2
 import numpy as np
+
+if TYPE_CHECKING:
+    from viseron.domains.camera import AbstractCamera
 
 LOGGER = logging.getLogger(__name__)
 
@@ -120,10 +124,12 @@ class SharedFrames:
         except KeyError:
             pass
 
-    def remove(self, shared_frame: SharedFrame) -> None:
+    def remove(self, shared_frame: SharedFrame, camera: AbstractCamera) -> None:
         """Remove frame from shared memory."""
-        if shared_frame.reference_count > 0:
-            threading.Timer(1, self.remove, args=(shared_frame,)).start()
+        if shared_frame.reference_count > 0 or (
+            camera and camera.current_frame == shared_frame
+        ):
+            threading.Timer(1, self.remove, args=(shared_frame, camera)).start()
             return
 
         self._remove(shared_frame.name)


### PR DESCRIPTION
- Adds filters to the Events and Timeline tabs so you can filter out only the events you want (Motion, object, ALPR etc)
- Upgrades HLS.js
- Fix calling loadSource twice when viewing 24/7 recordings, resulting in a browser console error
- Generate HLS segments directly from ffmpeg instead of writing `mp4` files and manually fragmenting.
This significantly improves the stream quality and removes some choppyness.
- Make Events page more compact by removing the camera selection grid. Selecting cameras is done using the floating action button in the bottom right corner
- Never delete a frame from memory if it is still the current frame.
Should reduce some intermittent errors in the logs
- Use the ffmpeg `hls_flags program_date_time` option to get the exact creation time for segments. Previously milliseconds were discarded causing some timing issues
- Use settings under `recorder` for transcoding the generated segments
