### PR TITLE
pin types-requests to 2.31.0.6

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -30,6 +30,6 @@ pyflakes==3.0.1
 pyupgrade==3.15.2
 
 # types
-types-requests
+types-requests==2.31.0.6
 types-python-slugify
 pygobject-stubs


### PR DESCRIPTION
Pins the version of `types-requests` to prevent installing a version of urllib3 which is broken for the pinned version of requests