### PR TITLE
Doc typos and FFmpeg timestamp example

### DIFF
--- a/docs/src/pages/components-explorer/components/ffmpeg/index.mdx
+++ b/docs/src/pages/components-explorer/components/ffmpeg/index.mdx
@@ -298,6 +298,7 @@ ffmpeg:
       path: /Streaming/Channels/101/
       username: !secret camera_one_user
       password: !secret camera_one_pass
+      // highlight-start
       video_filters: # Rotate the frames processed by Viseron
         - transpose=1
       width: 1080 # Width of the rotated video = height of the camera
@@ -306,6 +307,36 @@ ffmpeg:
         idle_timeout: 5
         video_filters: # Rotate the recorded videos
           - transpose=1
+      // highlight-end
+```
+
+</details>
+
+### Adding timestamp to video
+
+To add a timestamp to the video you can use the `drawtext` filter in FFmpeg.<br />
+This filter is quite complex and you can read more about it [here](https://ffmpeg.org/ffmpeg-filters.html#drawtext-1).
+
+To apply the filter you need to add it to the `video_filters` option in the config.
+
+<details>
+  <summary>Config to add a timestamp to the video</summary>
+
+```yaml title="/config/config.yaml"
+
+ffmpeg:
+  camera:
+    camera_one:
+      name: Camera 1
+      host: 192.168.XX.X
+      port: 554
+      path: /Streaming/Channels/101/
+      username: !secret camera_one_user
+      password: !secret camera_one_pass
+      // highlight-start
+      video_filters:
+        - drawtext=text='%{localtime}':x=(w-tw):y=h-(2*lh):fontcolor=white:box=1:boxcolor=0x00000000@1:fontsize=20
+      // highlight-end
 ```
 
 </details>

--- a/docs/src/pages/components-explorer/components/logger/index.mdx
+++ b/docs/src/pages/components-explorer/components/logger/index.mdx
@@ -47,7 +47,7 @@ Logging messages which are less severe than the given level will be ignored.
 
 Example command to examine the logs:
 
-```bash
+```shell
 docker logs -f viseron
 ```
 

--- a/docs/src/pages/components-explorer/components/storage/config.json
+++ b/docs/src/pages/components-explorer/components/storage/config.json
@@ -1272,7 +1272,7 @@
           }
         ],
         "name": "snapshots",
-        "description": "Snapshots are images taken when events are triggered or post processors finds anything. Snapshots will be taken for object detection, motiond detection, and any post processor that scans the image, for example face and license plate recognition.",
+        "description": "Snapshots are images taken when events are triggered or post processors finds anything. Snapshots will be taken for object detection, motion detection, and any post processor that scans the image, for example face and license plate recognition.",
         "optional": true,
         "default": {}
       }

--- a/scripts/gen_docs/const.py
+++ b/scripts/gen_docs/const.py
@@ -20,7 +20,7 @@ export default ComponentMetadata;
 
 DOCS_IMPORTS = """import ComponentConfiguration from "@site/src/pages/components-explorer/_components/ComponentConfiguration";
 import ComponentHeader from "@site/src/pages/components-explorer/_components/ComponentHeader";
-import ComponentTroubleshooting from "@site/src/pages/components-explorer/components/troubleshooting.mdx";
+import ComponentTroubleshooting from "@site/src/pages/components-explorer/_components/ComponentTroubleshooting/index.mdx";
 
 import ComponentMetadata from "./_meta";
 import config from "./config.json";
@@ -47,6 +47,7 @@ Config example here
 """
 
 DOCS_FOOTER = """<ComponentTroubleshooting meta={ComponentMetadata} />
+
 """
 
 DOCS_OBJECT_DETECTOR_IMPORTS = """import ObjectDetector from "@site/src/pages/components-explorer/_domains/object_detector/index.mdx";

--- a/viseron/components/storage/const.py
+++ b/viseron/components/storage/const.py
@@ -102,7 +102,7 @@ DESC_RECORDER_TIERS = (
 DESC_SNAPSHOTS = (
     "Snapshots are images taken when events are triggered or post processors finds "
     "anything. "
-    "Snapshots will be taken for object detection, motiond detection, and any post "
+    "Snapshots will be taken for object detection, motion detection, and any post "
     "processor that scans the image, for example face and license plate recognition."
 )
 DESC_SNAPSHOTS_TIERS = (


### PR DESCRIPTION
This pull request includes several documentation updates and a small bug fix. The most important changes include adding instructions for adding a timestamp to videos using FFmpeg, correcting a typo in multiple files, and updating import paths in the `const.py` script.
