### PR TITLE
Mount config folder in repo to /config in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,6 +20,9 @@
   },
   "userEnvProbe": "loginInteractiveShell",
   "runArgs": ["-e", "GIT_EDITOR=code --wait"],
+  "mounts": [
+    "source=${localWorkspaceFolder}/config,target=/config,type=bind,consistency=cached"
+  ],
   "customizations": {
     "vscode": {
       "extensions": [
@@ -85,6 +88,12 @@
         "files.associations": {
           "**/azure-pipelines/*.yml": "azure-pipelines",
           "**/azure-pipelines/*.yaml": "azure-pipelines"
+        },
+        "search.exclude": {
+          "**/node_modules": true,
+          "**/build": true,
+          "**/.docusaurus": true,
+          "**/dist": true
         }
       }
     }

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -39,14 +39,6 @@ else
     python3 -c "import viseron.config; viseron.config.create_default_config('$FILE')"
 fi
 
-# Create symlink to config file
-FILE=/config/config.yaml
-if test -f "$FILE"; then
-    echo "Config symlink already exists"
-else
-    echo "Creating config symlink"
-    ln -s $WORKSPACE_DIR/config/config.yaml /config/config.yaml
-fi
 
 # Create .env.local
 FILE=$WORKSPACE_DIR/frontend/.env.local

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
           echo "key=${{ runner.os }}-${{ github.job }}-${{ env.cache-name }}-${{ env.CACHE_VERSION }}-${{ hashFiles('.pre-commit-config.yaml') }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements_test.txt') }}-${{ hashFiles('requirements_ci.txt') }}" >> $GITHUB_OUTPUT
       - name: Restore Python virtual environment
         id: cache-venv
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: venv
           key: ${{ steps.python-venv-cache-key.outputs.key }}
@@ -73,7 +73,7 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Restore base Python virtual environment
         id: cache-venv
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: venv
           key: ${{ needs.prepare-python-venv.outputs.python-venv-cache-key }}
@@ -91,7 +91,7 @@ jobs:
       # Install pre-commit hooks into the cached virtual environment
       - name: Restore pre-commit hooks
         id: cache-pre-commit
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
           key: ${{ steps.pre-commit-cache-key.outputs.key }}
@@ -116,7 +116,7 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Restore base Python virtual environment
         id: cache-venv
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: venv
           key: ${{ needs.prepare-python-venv.outputs.python-venv-cache-key }}
@@ -127,7 +127,7 @@ jobs:
           exit 1
       - name: Restore pre-commit environment from cache
         id: cache-pre-commit
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
           key: ${{ needs.prepare-pre-commit.outputs.pre-commit-cache-key }}
@@ -156,7 +156,7 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Restore base Python virtual environment
         id: cache-venv
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: venv
           key: ${{ needs.prepare-python-venv.outputs.python-venv-cache-key }}
@@ -167,7 +167,7 @@ jobs:
           exit 1
       - name: Restore pre-commit environment from cache
         id: cache-pre-commit
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
           key: ${{ needs.prepare-pre-commit.outputs.pre-commit-cache-key }}
@@ -196,7 +196,7 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Restore base Python virtual environment
         id: cache-venv
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: venv
           key: ${{ needs.prepare-python-venv.outputs.python-venv-cache-key }}
@@ -207,7 +207,7 @@ jobs:
           exit 1
       - name: Restore pre-commit environment from cache
         id: cache-pre-commit
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
           key: ${{ needs.prepare-pre-commit.outputs.pre-commit-cache-key }}
@@ -236,7 +236,7 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Restore base Python virtual environment
         id: cache-venv
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: venv
           key: ${{ needs.prepare-python-venv.outputs.python-venv-cache-key }}
@@ -247,7 +247,7 @@ jobs:
           exit 1
       - name: Restore pre-commit environment from cache
         id: cache-pre-commit
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
           key: ${{ needs.prepare-pre-commit.outputs.pre-commit-cache-key }}
@@ -277,7 +277,7 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Restore base Python virtual environment
         id: cache-venv
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: venv
           key: ${{ needs.prepare-python-venv.outputs.python-venv-cache-key }}
@@ -288,7 +288,7 @@ jobs:
           exit 1
       - name: Restore pre-commit environment from cache
         id: cache-pre-commit
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
           key: ${{ needs.prepare-pre-commit.outputs.pre-commit-cache-key }}
@@ -322,7 +322,7 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Restore base Python virtual environment
         id: cache-venv
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: venv
           key: ${{ needs.prepare-python-venv.outputs.python-venv-cache-key }}
@@ -333,7 +333,7 @@ jobs:
           exit 1
       - name: Restore pre-commit environment from cache
         id: cache-pre-commit
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
           key: ${{ needs.prepare-pre-commit.outputs.pre-commit-cache-key }}
@@ -362,7 +362,7 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Restore base Python virtual environment
         id: cache-venv
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: venv
           key: ${{ needs.prepare-python-venv.outputs.python-venv-cache-key }}
@@ -373,7 +373,7 @@ jobs:
           exit 1
       - name: Restore pre-commit environment from cache
         id: cache-pre-commit
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
           key: ${{ needs.prepare-pre-commit.outputs.pre-commit-cache-key }}
@@ -404,7 +404,7 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Restore base Python virtual environment
         id: cache-venv
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: venv
           key: ${{ needs.prepare-python-venv.outputs.python-venv-cache-key }}
@@ -451,7 +451,7 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Restore base Python virtual environment
         id: cache-venv
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: venv
           key: ${{ needs.prepare-python-venv.outputs.python-venv-cache-key }}
@@ -462,7 +462,7 @@ jobs:
           exit 1
       - name: Restore pre-commit environment from cache
         id: cache-pre-commit
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
           key: ${{ needs.prepare-pre-commit.outputs.pre-commit-cache-key }}


### PR DESCRIPTION
A while back the mount for the config directory was removed due issues with it missing on the host.

It should now work properly to mount it since the config folder exists in the repo.

I did notice some strange behaviour with the mount not working since i already had files in the `/config` dir in the container, so make sure to fully clean your environment before rebuilding the devcontainer