### PR TITLE
Events and timeline navigation improvements

### DIFF
--- a/frontend/src/components/events/CameraPickerDialog.tsx
+++ b/frontend/src/components/events/CameraPickerDialog.tsx
@@ -5,17 +5,14 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 
 import { EventsCameraGrid } from "components/events/EventsCameraGrid";
-import * as types from "lib/types";
 
 type CameraPickerDialogProps = {
   open: boolean;
   setOpen: (open: boolean) => void;
-  cameras: types.CamerasOrFailedCameras;
 };
 export const CameraPickerDialog = ({
   open,
   setOpen,
-  cameras,
 }: CameraPickerDialogProps) => {
   const handleClose = () => {
     setOpen(false);
@@ -25,7 +22,7 @@ export const CameraPickerDialog = ({
     <Dialog fullWidth maxWidth={false} open={open} onClose={handleClose}>
       <DialogTitle>Cameras</DialogTitle>
       <DialogContent onClick={handleClose}>
-        <EventsCameraGrid cameras={cameras} />
+        <EventsCameraGrid />
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose}>Close</Button>

--- a/frontend/src/components/events/EventDatePickerDialog.tsx
+++ b/frontend/src/components/events/EventDatePickerDialog.tsx
@@ -9,10 +9,9 @@ import {
 import dayjs, { Dayjs } from "dayjs";
 import { useMemo } from "react";
 
+import { useFilteredCameras, useTimespans } from "components/events/utils";
 import { useEventsAmountMultiple } from "lib/api/events";
 import * as types from "lib/types";
-
-import { useCameraStore, useTimespans } from "./utils";
 
 function HasEvent(
   props: PickersDayProps<Dayjs> & { highlightedDays?: Record<string, any> },
@@ -121,9 +120,9 @@ export function EventDatePickerDialog({
   date,
   onChange,
 }: EventDatePickerDialogProps) {
-  const { selectedCameras } = useCameraStore();
+  const filteredCameras = useFilteredCameras();
   const eventsAmountQuery = useEventsAmountMultiple({
-    camera_identifiers: selectedCameras,
+    camera_identifiers: Object.keys(filteredCameras),
   });
   const availableTimespans = useTimespans(null, 5, open);
   const highlightedDays = useMemo(

--- a/frontend/src/components/events/EventDatePickerDialog.tsx
+++ b/frontend/src/components/events/EventDatePickerDialog.tsx
@@ -124,7 +124,7 @@ export function EventDatePickerDialog({
   const eventsAmountQuery = useEventsAmountMultiple({
     camera_identifiers: Object.keys(filteredCameras),
   });
-  const availableTimespans = useTimespans(null, 5, open);
+  const { availableTimespans } = useTimespans(null, 5, open);
   const highlightedDays = useMemo(
     () =>
       eventsAmountQuery.data

--- a/frontend/src/components/events/EventPlayerCard.tsx
+++ b/frontend/src/components/events/EventPlayerCard.tsx
@@ -24,6 +24,7 @@ import {
   LIVE_EDGE_DELAY,
   getSrc,
   playerCardSmMaxHeight,
+  useEventStore,
   useFilteredCameras,
   useHlsStore,
   useReferencePlayerStore,
@@ -446,11 +447,7 @@ const PlayerGrid = ({
   </Grid>
 );
 
-type PlayerCardProps = {
-  selectedEvent: types.CameraEvent | null;
-  selectedTab: "events" | "timeline";
-};
-export const PlayerCard = ({ selectedEvent }: PlayerCardProps) => {
+export const PlayerCard = () => {
   const theme = useTheme();
   const paperRef: React.MutableRefObject<HTMLDivElement | null> = useRef(null);
   const playerItemRefs = useRef<(PlayerItemRef | null)[]>([]);
@@ -459,6 +456,7 @@ export const PlayerCard = ({ selectedEvent }: PlayerCardProps) => {
   };
 
   const camerasAll = useCamerasAll();
+  const { selectedEvent } = useEventStore();
 
   const {
     handlePlayPause,

--- a/frontend/src/components/events/EventPlayerCard.tsx
+++ b/frontend/src/components/events/EventPlayerCard.tsx
@@ -29,6 +29,7 @@ import {
   useReferencePlayerStore,
 } from "components/events/utils";
 import { useResizeObserver } from "hooks/UseResizeObserver";
+import { useCamerasAll } from "lib/api/cameras";
 import { isTouchDevice } from "lib/helpers";
 import * as types from "lib/types";
 
@@ -446,17 +447,18 @@ const PlayerGrid = ({
 );
 
 type PlayerCardProps = {
-  cameras: types.CamerasOrFailedCameras;
   selectedEvent: types.CameraEvent | null;
   selectedTab: "events" | "timeline";
 };
-export const PlayerCard = ({ cameras, selectedEvent }: PlayerCardProps) => {
+export const PlayerCard = ({ selectedEvent }: PlayerCardProps) => {
   const theme = useTheme();
   const paperRef: React.MutableRefObject<HTMLDivElement | null> = useRef(null);
   const playerItemRefs = useRef<(PlayerItemRef | null)[]>([]);
   const setPlayerItemRef = (index: number) => (ref: PlayerItemRef | null) => {
     playerItemRefs.current[index] = ref;
   };
+
+  const camerasAll = useCamerasAll();
 
   const {
     handlePlayPause,
@@ -499,7 +501,7 @@ export const PlayerCard = ({ cameras, selectedEvent }: PlayerCardProps) => {
   );
 
   const camera = selectedEvent
-    ? cameras[selectedEvent.camera_identifier]
+    ? camerasAll.combinedData[selectedEvent.camera_identifier]
     : null;
   const src = camera && selectedEvent ? getSrc(selectedEvent) : undefined;
 

--- a/frontend/src/components/events/EventPlayerCard.tsx
+++ b/frontend/src/components/events/EventPlayerCard.tsx
@@ -485,7 +485,7 @@ export const PlayerCard = ({ cameras, selectedEvent }: PlayerCardProps) => {
     });
   }, []);
 
-  const filteredCameras = useFilteredCameras(cameras);
+  const filteredCameras = useFilteredCameras();
   const gridLayout = useGridLayout(
     paperRef,
     filteredCameras,

--- a/frontend/src/components/events/EventTable.tsx
+++ b/frontend/src/components/events/EventTable.tsx
@@ -1,14 +1,14 @@
 import Typography from "@mui/material/Typography";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import dayjs, { Dayjs } from "dayjs";
-import { memo, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { memo, useLayoutEffect, useMemo, useState } from "react";
 
 import { EventTableItem } from "components/events/EventTableItem";
 import {
   getEventTimestamp,
   useFilterStore,
   useFilteredCameras,
-  useTimespans,
+  useTimespansRef,
 } from "components/events/utils";
 import { Loading } from "components/loading/Loading";
 import { useEventsMultiple } from "lib/api/events";
@@ -62,92 +62,78 @@ const useGroupedEvents = (snapshotEvents: types.CameraEvent[]) => {
 type EventTableProps = {
   parentRef: React.RefObject<HTMLDivElement>;
   date: Dayjs | null;
-  selectedEvent: types.CameraEvent | null;
-  setSelectedEvent: (event: types.CameraEvent) => void;
 };
 
-export const EventTable = memo(
-  ({ parentRef, date, selectedEvent, setSelectedEvent }: EventTableProps) => {
-    const formattedDate = dayjs(date).format("YYYY-MM-DD");
+export const EventTable = memo(({ parentRef, date }: EventTableProps) => {
+  const formattedDate = dayjs(date).format("YYYY-MM-DD");
+  const [elementHeight, setElementHeight] = useState<number | null>(null);
+  const filteredCameras = useFilteredCameras();
+  const eventsQueries = useEventsMultiple({
+    camera_identifiers: Object.keys(filteredCameras),
+    date: formattedDate,
+    configOptions: { enabled: !!date },
+  });
 
-    const [elementHeight, setElementHeight] = useState<number | null>(null);
-    const filteredCameras = useFilteredCameras();
-    const eventsQueries = useEventsMultiple({
-      camera_identifiers: Object.keys(filteredCameras),
-      date: formattedDate,
-      configOptions: { enabled: !!date },
-    });
+  // Subscribe to timespans so it updates for child components
+  useTimespansRef(date);
 
-    // Store as ref to prevent re-render of EventTableItem
-    const availableTimespansRef = useRef<types.HlsAvailableTimespan[]>([]);
-    const availableTimespans = useTimespans(date);
-    availableTimespansRef.current = availableTimespans;
+  const groupedEvents = useGroupedEvents(eventsQueries.data || []);
 
-    const groupedEvents = useGroupedEvents(eventsQueries.data || []);
+  const parentElement = parentRef.current;
+  const rowVirtualizer = useVirtualizer({
+    count: groupedEvents.length,
+    getScrollElement: () => parentElement,
+    estimateSize: () => elementHeight || 100,
+    overscan: 5,
+  });
 
-    const parentElement = parentRef.current;
-    const rowVirtualizer = useVirtualizer({
-      count: groupedEvents.length,
-      getScrollElement: () => parentElement,
-      estimateSize: () => elementHeight || 100,
-      overscan: 5,
-    });
+  useLayoutEffect(() => {
+    rowVirtualizer.measure();
+  }, [rowVirtualizer, elementHeight]);
 
-    useLayoutEffect(() => {
-      rowVirtualizer.measure();
-    }, [rowVirtualizer, elementHeight]);
+  if (eventsQueries.isPending) {
+    return <Loading text="Loading Events" fullScreen={false} />;
+  }
 
-    if (eventsQueries.isPending) {
-      return <Loading text="Loading Events" fullScreen={false} />;
-    }
-
-    if (!eventsQueries.data || objIsEmpty(eventsQueries.data)) {
-      return (
-        <Typography align="center" padding={2}>
-          No Events found for {formattedDate}
-        </Typography>
-      );
-    }
-
+  if (!eventsQueries.data || objIsEmpty(eventsQueries.data)) {
     return (
-      <div
-        style={{
-          height: `${rowVirtualizer.getTotalSize()}px`,
-          width: "100%",
-          position: "relative",
-        }}
-      >
-        {rowVirtualizer.getVirtualItems().map((virtualRow) => {
-          const events = groupedEvents[virtualRow.index];
-          const oldestEvent = events[events.length - 1];
-          return (
-            <div
-              key={virtualRow.key}
-              style={{
-                position: "absolute",
-                top: 0,
-                left: 0,
-                width: "100%",
-                height: `${virtualRow.size}px`,
-                transform: `translateY(${virtualRow.start}px)`,
-              }}
-            >
-              <EventTableItem
-                events={events}
-                setSelectedEvent={setSelectedEvent}
-                selected={
-                  !!selectedEvent && selectedEvent.id === oldestEvent.id
-                }
-                availableTimespansRef={availableTimespansRef}
-                isScrolling={rowVirtualizer.isScrolling}
-                virtualRowIndex={virtualRow.index}
-                measureElement={rowVirtualizer.measureElement}
-                setElementHeight={setElementHeight}
-              />
-            </div>
-          );
-        })}
-      </div>
+      <Typography align="center" padding={2}>
+        No Events found for {formattedDate}
+      </Typography>
     );
-  },
-);
+  }
+  return (
+    <div
+      style={{
+        height: `${rowVirtualizer.getTotalSize()}px`,
+        width: "100%",
+        position: "relative",
+      }}
+    >
+      {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+        const events = groupedEvents[virtualRow.index];
+        return (
+          <div
+            key={virtualRow.key}
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              width: "100%",
+              height: `${virtualRow.size}px`,
+              transform: `translateY(${virtualRow.start}px)`,
+            }}
+          >
+            <EventTableItem
+              events={events}
+              isScrolling={rowVirtualizer.isScrolling}
+              virtualRowIndex={virtualRow.index}
+              measureElement={rowVirtualizer.measureElement}
+              setElementHeight={setElementHeight}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+});

--- a/frontend/src/components/events/EventTable.tsx
+++ b/frontend/src/components/events/EventTable.tsx
@@ -61,20 +61,13 @@ const useGroupedEvents = (snapshotEvents: types.CameraEvent[]) => {
 
 type EventTableProps = {
   parentRef: React.RefObject<HTMLDivElement>;
-  cameras: types.CamerasOrFailedCameras;
   date: Dayjs | null;
   selectedEvent: types.CameraEvent | null;
   setSelectedEvent: (event: types.CameraEvent) => void;
 };
 
 export const EventTable = memo(
-  ({
-    parentRef,
-    cameras,
-    date,
-    selectedEvent,
-    setSelectedEvent,
-  }: EventTableProps) => {
+  ({ parentRef, date, selectedEvent, setSelectedEvent }: EventTableProps) => {
     const formattedDate = dayjs(date).format("YYYY-MM-DD");
 
     const [elementHeight, setElementHeight] = useState<number | null>(null);
@@ -140,7 +133,6 @@ export const EventTable = memo(
               }}
             >
               <EventTableItem
-                cameras={cameras}
                 events={events}
                 setSelectedEvent={setSelectedEvent}
                 selected={

--- a/frontend/src/components/events/EventTable.tsx
+++ b/frontend/src/components/events/EventTable.tsx
@@ -2,14 +2,12 @@ import Typography from "@mui/material/Typography";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import dayjs, { Dayjs } from "dayjs";
 import { memo, useLayoutEffect, useMemo, useRef, useState } from "react";
-import ServerDown from "svg/undraw/server_down.svg?react";
 
-import { ErrorMessage } from "components/error/ErrorMessage";
 import { EventTableItem } from "components/events/EventTableItem";
 import {
   getEventTimestamp,
-  useCameraStore,
   useFilterStore,
+  useFilteredCameras,
   useTimespans,
 } from "components/events/utils";
 import { Loading } from "components/loading/Loading";
@@ -80,9 +78,9 @@ export const EventTable = memo(
     const formattedDate = dayjs(date).format("YYYY-MM-DD");
 
     const [elementHeight, setElementHeight] = useState<number | null>(null);
-    const { selectedCameras } = useCameraStore();
+    const filteredCameras = useFilteredCameras();
     const eventsQueries = useEventsMultiple({
-      camera_identifiers: selectedCameras,
+      camera_identifiers: Object.keys(filteredCameras),
       date: formattedDate,
       configOptions: { enabled: !!date },
     });
@@ -105,21 +103,6 @@ export const EventTable = memo(
     useLayoutEffect(() => {
       rowVirtualizer.measure();
     }, [rowVirtualizer, elementHeight]);
-
-    if (eventsQueries.isError) {
-      return (
-        <ErrorMessage
-          text={"Error loading Events"}
-          subtext={
-            eventsQueries.error?.response?.data.error ||
-            eventsQueries.error?.message
-          }
-          image={
-            <ServerDown width={150} height={150} role="img" aria-label="Void" />
-          }
-        />
-      );
-    }
 
     if (eventsQueries.isPending) {
       return <Loading text="Loading Events" fullScreen={false} />;

--- a/frontend/src/components/events/EventTable.tsx
+++ b/frontend/src/components/events/EventTable.tsx
@@ -67,7 +67,6 @@ type EventTableProps = {
   date: Dayjs | null;
   selectedEvent: types.CameraEvent | null;
   setSelectedEvent: (event: types.CameraEvent) => void;
-  setRequestedTimestamp: (timestamp: number | null) => void;
 };
 
 export const EventTable = memo(
@@ -77,7 +76,6 @@ export const EventTable = memo(
     date,
     selectedEvent,
     setSelectedEvent,
-    setRequestedTimestamp,
   }: EventTableProps) => {
     const formattedDate = dayjs(date).format("YYYY-MM-DD");
 
@@ -165,7 +163,6 @@ export const EventTable = memo(
                 selected={
                   !!selectedEvent && selectedEvent.id === oldestEvent.id
                 }
-                setRequestedTimestamp={setRequestedTimestamp}
                 availableTimespansRef={availableTimespansRef}
                 isScrolling={rowVirtualizer.isScrolling}
                 virtualRowIndex={virtualRow.index}

--- a/frontend/src/components/events/EventTableItem.tsx
+++ b/frontend/src/components/events/EventTableItem.tsx
@@ -17,27 +17,27 @@ import {
   useReferencePlayerStore,
 } from "components/events/utils";
 import { useFirstRender } from "hooks/UseFirstRender";
-import { BLANK_IMAGE, getTimeFromDate } from "lib/helpers";
+import {
+  BLANK_IMAGE,
+  getCameraNameFromQueryCache,
+  getTimeFromDate,
+} from "lib/helpers";
 import * as types from "lib/types";
 
 type EventTableItemIconProps = {
   sortedEvents: types.CameraEvent[];
-  cameras: types.CamerasOrFailedCameras;
 };
 
-const EventTableItemIcon = ({
-  sortedEvents,
-  cameras,
-}: EventTableItemIconProps) => {
+const EventTableItemIcon = ({ sortedEvents }: EventTableItemIconProps) => {
   const uniqueEvents = extractUniqueTypes(sortedEvents);
+  const cameraName = getCameraNameFromQueryCache(
+    sortedEvents[0].camera_identifier,
+  );
+
   return (
     <div>
       <Typography fontSize=".75rem" fontWeight="bold" align="center">
-        {`${
-          cameras && cameras[sortedEvents[0].camera_identifier]
-            ? cameras[sortedEvents[0].camera_identifier].name
-            : sortedEvents[0].camera_identifier
-        }`}
+        {cameraName}
       </Typography>
       <Typography
         fontSize=".75rem"
@@ -83,7 +83,6 @@ const isTimespanAvailable = (
 };
 
 type EventTableItemProps = {
-  cameras: types.CamerasOrFailedCameras;
   events: types.CameraEvent[];
   setSelectedEvent: (event: types.CameraEvent) => void;
   selected: boolean;
@@ -95,7 +94,6 @@ type EventTableItemProps = {
 };
 export const EventTableItem = memo(
   ({
-    cameras,
     events,
     setSelectedEvent,
     selected,
@@ -186,10 +184,7 @@ export const EventTableItem = memo(
             alignItems="center"
           >
             <Grid size={8}>
-              <EventTableItemIcon
-                sortedEvents={sortedEvents}
-                cameras={cameras}
-              />
+              <EventTableItemIcon sortedEvents={sortedEvents} />
             </Grid>
             <Grid size={4}>
               <CardMedia

--- a/frontend/src/components/events/EventTableItem.tsx
+++ b/frontend/src/components/events/EventTableItem.tsx
@@ -5,6 +5,7 @@ import Grid from "@mui/material/Grid2";
 import Typography from "@mui/material/Typography";
 import { useTheme } from "@mui/material/styles";
 import { memo, useCallback, useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
 
 import { SnapshotIcon } from "components/events/SnapshotEvent";
 import {
@@ -13,6 +14,7 @@ import {
   getEventTime,
   getEventTimestamp,
   getSrc,
+  useReferencePlayerStore,
 } from "components/events/utils";
 import { useFirstRender } from "hooks/UseFirstRender";
 import { BLANK_IMAGE, getTimeFromDate } from "lib/helpers";
@@ -85,7 +87,6 @@ type EventTableItemProps = {
   events: types.CameraEvent[];
   setSelectedEvent: (event: types.CameraEvent) => void;
   selected: boolean;
-  setRequestedTimestamp: (timestamp: number | null) => void;
   availableTimespansRef: React.MutableRefObject<types.HlsAvailableTimespan[]>;
   isScrolling: boolean;
   virtualRowIndex: number;
@@ -98,7 +99,6 @@ export const EventTableItem = memo(
     events,
     setSelectedEvent,
     selected,
-    setRequestedTimestamp,
     availableTimespansRef,
     isScrolling,
     virtualRowIndex,
@@ -107,6 +107,13 @@ export const EventTableItem = memo(
   }: EventTableItemProps) => {
     const theme = useTheme();
     const firstRender = useFirstRender();
+
+    const { setRequestedTimestamp } = useReferencePlayerStore(
+      useShallow((state) => ({
+        setRequestedTimestamp: state.setRequestedTimestamp,
+      })),
+    );
+
     // Show the oldest event first in the list, API returns latest first
     const sortedEvents = useMemo(
       () =>
@@ -129,7 +136,7 @@ export const EventTableItem = memo(
       }
 
       setSelectedEvent(sortedEvents[0]);
-      setRequestedTimestamp(null);
+      setRequestedTimestamp(0);
     }, [
       sortedEvents,
       availableTimespansRef,

--- a/frontend/src/components/events/EventsCameraGrid.tsx
+++ b/frontend/src/components/events/EventsCameraGrid.tsx
@@ -3,7 +3,7 @@ import Grow from "@mui/material/Grow";
 import { useTheme } from "@mui/material/styles";
 
 import { CameraCard } from "components/camera/CameraCard";
-import { useCameraStore } from "components/events/utils";
+import { useCameraStore, useFilteredCameras } from "components/events/utils";
 import * as types from "lib/types";
 
 type EventsCameraGridProps = {
@@ -11,7 +11,8 @@ type EventsCameraGridProps = {
 };
 export function EventsCameraGrid({ cameras }: EventsCameraGridProps) {
   const theme = useTheme();
-  const { selectedCameras, toggleCamera } = useCameraStore();
+  const { toggleCamera } = useCameraStore();
+  const filteredCameras = useFilteredCameras();
 
   const handleCameraClick = (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
@@ -47,8 +48,8 @@ export function EventsCameraGrid({ cameras }: EventsCameraGridProps) {
                       event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
                     ) => handleCameraClick(event, cameras[camera_identifier])}
                     border={
-                      selectedCameras &&
-                      selectedCameras.includes(camera_identifier)
+                      filteredCameras &&
+                      Object.keys(filteredCameras).includes(camera_identifier)
                         ? `2px solid ${theme.palette.primary[400]}`
                         : "2px solid transparent"
                     }

--- a/frontend/src/components/events/EventsCameraGrid.tsx
+++ b/frontend/src/components/events/EventsCameraGrid.tsx
@@ -4,14 +4,13 @@ import { useTheme } from "@mui/material/styles";
 
 import { CameraCard } from "components/camera/CameraCard";
 import { useCameraStore, useFilteredCameras } from "components/events/utils";
+import { useCamerasAll } from "lib/api/cameras";
 import * as types from "lib/types";
 
-type EventsCameraGridProps = {
-  cameras: types.CamerasOrFailedCameras;
-};
-export function EventsCameraGrid({ cameras }: EventsCameraGridProps) {
+export function EventsCameraGrid() {
   const theme = useTheme();
   const { toggleCamera } = useCameraStore();
+  const camerasAll = useCamerasAll();
   const filteredCameras = useFilteredCameras();
 
   const handleCameraClick = (
@@ -25,39 +24,42 @@ export function EventsCameraGrid({ cameras }: EventsCameraGridProps) {
 
   return (
     <Grid container spacing={0.5}>
-      {cameras
-        ? Object.keys(cameras)
-            .sort()
-            .map((camera_identifier) => (
-              <Grow in appear key={camera_identifier}>
-                <Grid
-                  key={camera_identifier}
-                  size={{
-                    xs: 12,
-                    sm: 12,
-                    md: 6,
-                    lg: 6,
-                    xl: 4,
-                  }}
-                >
-                  <CameraCard
-                    camera_identifier={camera_identifier}
-                    compact
-                    buttons={false}
-                    onClick={(
-                      event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-                    ) => handleCameraClick(event, cameras[camera_identifier])}
-                    border={
-                      filteredCameras &&
-                      Object.keys(filteredCameras).includes(camera_identifier)
-                        ? `2px solid ${theme.palette.primary[400]}`
-                        : "2px solid transparent"
-                    }
-                  />
-                </Grid>
-              </Grow>
-            ))
-        : null}
+      {Object.keys(camerasAll.combinedData)
+        .sort()
+        .map((camera_identifier) => (
+          <Grow in appear key={camera_identifier}>
+            <Grid
+              key={camera_identifier}
+              size={{
+                xs: 12,
+                sm: 12,
+                md: 6,
+                lg: 6,
+                xl: 4,
+              }}
+            >
+              <CameraCard
+                camera_identifier={camera_identifier}
+                compact
+                buttons={false}
+                onClick={(
+                  event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+                ) =>
+                  handleCameraClick(
+                    event,
+                    camerasAll.combinedData[camera_identifier],
+                  )
+                }
+                border={
+                  filteredCameras &&
+                  Object.keys(filteredCameras).includes(camera_identifier)
+                    ? `2px solid ${theme.palette.primary[400]}`
+                    : "2px solid transparent"
+                }
+              />
+            </Grid>
+          </Grow>
+        ))}
     </Grid>
   );
 }

--- a/frontend/src/components/events/ExportDialog.tsx
+++ b/frontend/src/components/events/ExportDialog.tsx
@@ -8,7 +8,7 @@ import { DateTimePicker } from "@mui/x-date-pickers/DateTimePicker";
 import { Dayjs } from "dayjs";
 import { useState } from "react";
 
-import { useCameraStore } from "components/events/utils";
+import { useFilteredCameras } from "components/events/utils";
 import { useExportTimespan } from "lib/commands";
 import { is12HourFormat } from "lib/helpers";
 
@@ -21,7 +21,7 @@ export const ExportDialog = ({ open, setOpen }: ExportDialogProps) => {
   const [startDate, setStartDate] = useState<Dayjs | null>(null);
   const [endDate, setEndDate] = useState<Dayjs | null>(null);
 
-  const { selectedCameras } = useCameraStore();
+  const filteredCameras = useFilteredCameras();
   const exportTimespan = useExportTimespan();
 
   const handleClose = () => {
@@ -37,7 +37,11 @@ export const ExportDialog = ({ open, setOpen }: ExportDialogProps) => {
 
   const handleExport = () => {
     if (!startDate || !endDate) return;
-    exportTimespan(selectedCameras, startDate.unix(), endDate.unix());
+    exportTimespan(
+      Object.keys(filteredCameras),
+      startDate.unix(),
+      endDate.unix(),
+    );
     handleClose();
   };
 

--- a/frontend/src/components/events/FloatingMenu.tsx
+++ b/frontend/src/components/events/FloatingMenu.tsx
@@ -10,69 +10,64 @@ import { memo, useState } from "react";
 import { CameraPickerDialog } from "components/events/CameraPickerDialog";
 import { EventDatePickerDialog } from "components/events/EventDatePickerDialog";
 import { ExportDialog } from "components/events/ExportDialog";
-import * as types from "lib/types";
 
 type FloatingMenuProps = {
-  cameras: types.CamerasOrFailedCameras;
   date: Dayjs | null;
   setDate: (date: Dayjs | null) => void;
 };
 
-export const FloatingMenu = memo(
-  ({ cameras, date, setDate }: FloatingMenuProps) => {
-    const [cameraDialogOpen, setCameraDialogOpen] = useState(false);
-    const [dateDialogOpen, setDateDialogOpen] = useState(false);
-    const [exportDialogOpen, setExportDialogOpen] = useState(false);
+export const FloatingMenu = memo(({ date, setDate }: FloatingMenuProps) => {
+  const [cameraDialogOpen, setCameraDialogOpen] = useState(false);
+  const [dateDialogOpen, setDateDialogOpen] = useState(false);
+  const [exportDialogOpen, setExportDialogOpen] = useState(false);
 
-    return (
-      <>
-        <CameraPickerDialog
-          open={cameraDialogOpen}
-          setOpen={setCameraDialogOpen}
-          cameras={cameras}
-        />
-        <EventDatePickerDialog
-          open={dateDialogOpen}
-          setOpen={setDateDialogOpen}
-          date={date}
-          onChange={(value) => {
-            setDateDialogOpen(false);
-            setDate(value);
-          }}
-        />
-        <ExportDialog open={exportDialogOpen} setOpen={setExportDialogOpen} />
-        <Box sx={{ position: "absolute", bottom: 14, right: 24 }}>
-          <Tooltip title="Select Camera">
-            <Fab
-              size="small"
-              color="primary"
-              onClick={() => setCameraDialogOpen(true)}
-            >
-              <VideocamIcon />
-            </Fab>
-          </Tooltip>
-          <Tooltip title="Select Date">
-            <Fab
-              size="small"
-              color="primary"
-              sx={{ marginLeft: 1 }}
-              onClick={() => setDateDialogOpen(true)}
-            >
-              <CalendarMonthIcon />
-            </Fab>
-          </Tooltip>
-          <Tooltip title="Download">
-            <Fab
-              size="small"
-              color="primary"
-              sx={{ marginLeft: 1 }}
-              onClick={() => setExportDialogOpen(true)}
-            >
-              <FileDownloadIcon />
-            </Fab>
-          </Tooltip>
-        </Box>
-      </>
-    );
-  },
-);
+  return (
+    <>
+      <CameraPickerDialog
+        open={cameraDialogOpen}
+        setOpen={setCameraDialogOpen}
+      />
+      <EventDatePickerDialog
+        open={dateDialogOpen}
+        setOpen={setDateDialogOpen}
+        date={date}
+        onChange={(value) => {
+          setDateDialogOpen(false);
+          setDate(value);
+        }}
+      />
+      <ExportDialog open={exportDialogOpen} setOpen={setExportDialogOpen} />
+      <Box sx={{ position: "absolute", bottom: 14, right: 24 }}>
+        <Tooltip title="Select Camera">
+          <Fab
+            size="small"
+            color="primary"
+            onClick={() => setCameraDialogOpen(true)}
+          >
+            <VideocamIcon />
+          </Fab>
+        </Tooltip>
+        <Tooltip title="Select Date">
+          <Fab
+            size="small"
+            color="primary"
+            sx={{ marginLeft: 1 }}
+            onClick={() => setDateDialogOpen(true)}
+          >
+            <CalendarMonthIcon />
+          </Fab>
+        </Tooltip>
+        <Tooltip title="Download">
+          <Fab
+            size="small"
+            color="primary"
+            sx={{ marginLeft: 1 }}
+            onClick={() => setExportDialogOpen(true)}
+          >
+            <FileDownloadIcon />
+          </Fab>
+        </Tooltip>
+      </Box>
+    </>
+  );
+});

--- a/frontend/src/components/events/Layouts.tsx
+++ b/frontend/src/components/events/Layouts.tsx
@@ -113,7 +113,6 @@ type TabsProps = {
   setSelectedTab: (tab: "events" | "timeline") => void;
   selectedEvent: types.CameraEvent | null;
   setSelectedEvent: (event: types.CameraEvent) => void;
-  setRequestedTimestamp: (timestamp: number | null) => void;
   playerCardGridItemRef: React.MutableRefObject<HTMLDivElement | null>;
 };
 const Tabs = ({
@@ -123,7 +122,6 @@ const Tabs = ({
   setSelectedTab,
   selectedEvent,
   setSelectedEvent,
-  setRequestedTimestamp,
   playerCardGridItemRef,
 }: TabsProps) => {
   const { selectedCameras } = useCameraStore();
@@ -191,7 +189,6 @@ const Tabs = ({
             date={date}
             selectedEvent={selectedEvent}
             setSelectedEvent={setSelectedEvent}
-            setRequestedTimestamp={setRequestedTimestamp}
           />
         ) : (
           <Typography align="center" sx={{ marginTop: "20px" }}>
@@ -217,7 +214,6 @@ const Tabs = ({
             key={`${date?.unix().toString()}`}
             parentRef={timelineRef}
             date={date}
-            setRequestedTimestamp={setRequestedTimestamp}
           />
         ) : (
           <Typography align="center" sx={{ marginTop: "20px" }}>
@@ -235,8 +231,6 @@ type LayoutProps = {
   setSelectedEvent: (event: types.CameraEvent) => void;
   date: Dayjs | null;
   setDate: (date: Dayjs | null) => void;
-  requestedTimestamp: number | null;
-  setRequestedTimestamp: (timestamp: number | null) => void;
   selectedTab: "events" | "timeline";
   setSelectedTab: (tab: "events" | "timeline") => void;
 };
@@ -248,8 +242,6 @@ export const Layout = memo(
     setSelectedEvent,
     date,
     setDate,
-    requestedTimestamp,
-    setRequestedTimestamp,
     selectedTab,
     setSelectedTab,
   }: LayoutProps) => {
@@ -294,7 +286,6 @@ export const Layout = memo(
             <PlayerCard
               cameras={cameras}
               selectedEvent={selectedEvent}
-              requestedTimestamp={requestedTimestamp}
               selectedTab={selectedTab}
             />
           </Grid>
@@ -315,7 +306,6 @@ export const Layout = memo(
                 setSelectedTab={setSelectedTab}
                 selectedEvent={selectedEvent}
                 setSelectedEvent={setSelectedEvent}
-                setRequestedTimestamp={setRequestedTimestamp}
                 playerCardGridItemRef={playerCardGridItemRef}
               />
             </Paper>

--- a/frontend/src/components/events/Layouts.tsx
+++ b/frontend/src/components/events/Layouts.tsx
@@ -107,7 +107,6 @@ const useSetPlayerCardHeight = (
 };
 
 type TabsProps = {
-  cameras: types.CamerasOrFailedCameras;
   date: Dayjs | null;
   selectedTab: "events" | "timeline";
   setSelectedTab: (tab: "events" | "timeline") => void;
@@ -116,7 +115,6 @@ type TabsProps = {
   playerCardGridItemRef: React.MutableRefObject<HTMLDivElement | null>;
 };
 const Tabs = ({
-  cameras,
   date,
   selectedTab,
   setSelectedTab,
@@ -184,7 +182,6 @@ const Tabs = ({
       >
         {Object.keys(filteredCameras).length > 0 ? (
           <EventTable
-            cameras={cameras}
             parentRef={eventsRef}
             date={date}
             selectedEvent={selectedEvent}
@@ -226,7 +223,6 @@ const Tabs = ({
 };
 
 type LayoutProps = {
-  cameras: types.CamerasOrFailedCameras;
   selectedEvent: types.CameraEvent | null;
   setSelectedEvent: (event: types.CameraEvent) => void;
   date: Dayjs | null;
@@ -237,7 +233,6 @@ type LayoutProps = {
 
 export const Layout = memo(
   ({
-    cameras,
     selectedEvent,
     setSelectedEvent,
     date,
@@ -284,7 +279,6 @@ export const Layout = memo(
             }}
           >
             <PlayerCard
-              cameras={cameras}
               selectedEvent={selectedEvent}
               selectedTab={selectedTab}
             />
@@ -300,7 +294,6 @@ export const Layout = memo(
           >
             <Paper variant="outlined">
               <Tabs
-                cameras={cameras}
                 date={date}
                 selectedTab={selectedTab}
                 setSelectedTab={setSelectedTab}
@@ -310,7 +303,7 @@ export const Layout = memo(
               />
             </Paper>
           </Grid>
-          <FloatingMenu cameras={cameras} date={date} setDate={setDate} />
+          <FloatingMenu date={date} setDate={setDate} />
         </Grid>
       </Box>
     );

--- a/frontend/src/components/events/Layouts.tsx
+++ b/frontend/src/components/events/Layouts.tsx
@@ -20,7 +20,7 @@ import {
   COLUMN_HEIGHT,
   COLUMN_HEIGHT_SMALL,
   playerCardSmMaxHeight,
-  useCameraStore,
+  useFilteredCameras,
 } from "components/events/utils";
 import { useResizeObserver } from "hooks/UseResizeObserver";
 import { insertURLParameter } from "lib/helpers";
@@ -124,7 +124,7 @@ const Tabs = ({
   setSelectedEvent,
   playerCardGridItemRef,
 }: TabsProps) => {
-  const { selectedCameras } = useCameraStore();
+  const filteredCameras = useFilteredCameras();
   const tabListRef = useRef<HTMLDivElement | null>(null);
   const eventsRef = useRef<HTMLDivElement | null>(null);
   const timelineRef = useRef<HTMLDivElement | null>(null);
@@ -182,7 +182,7 @@ const Tabs = ({
           boxSizing: "border-box",
         }}
       >
-        {selectedCameras.length > 0 ? (
+        {Object.keys(filteredCameras).length > 0 ? (
           <EventTable
             cameras={cameras}
             parentRef={eventsRef}
@@ -208,7 +208,7 @@ const Tabs = ({
           boxSizing: "border-box",
         }}
       >
-        {selectedCameras.length > 0 ? (
+        {Object.keys(filteredCameras).length > 0 ? (
           <TimelineTable
             // Force re-render when date changes
             key={`${date?.unix().toString()}`}

--- a/frontend/src/components/events/Layouts.tsx
+++ b/frontend/src/components/events/Layouts.tsx
@@ -24,7 +24,6 @@ import {
 } from "components/events/utils";
 import { useResizeObserver } from "hooks/UseResizeObserver";
 import { insertURLParameter } from "lib/helpers";
-import * as types from "lib/types";
 
 const setTableHeight = (
   tabListRef: React.RefObject<HTMLDivElement>,
@@ -110,16 +109,12 @@ type TabsProps = {
   date: Dayjs | null;
   selectedTab: "events" | "timeline";
   setSelectedTab: (tab: "events" | "timeline") => void;
-  selectedEvent: types.CameraEvent | null;
-  setSelectedEvent: (event: types.CameraEvent) => void;
   playerCardGridItemRef: React.MutableRefObject<HTMLDivElement | null>;
 };
 const Tabs = ({
   date,
   selectedTab,
   setSelectedTab,
-  selectedEvent,
-  setSelectedEvent,
   playerCardGridItemRef,
 }: TabsProps) => {
   const filteredCameras = useFilteredCameras();
@@ -181,12 +176,7 @@ const Tabs = ({
         }}
       >
         {Object.keys(filteredCameras).length > 0 ? (
-          <EventTable
-            parentRef={eventsRef}
-            date={date}
-            selectedEvent={selectedEvent}
-            setSelectedEvent={setSelectedEvent}
-          />
+          <EventTable parentRef={eventsRef} date={date} />
         ) : (
           <Typography align="center" sx={{ marginTop: "20px" }}>
             Select at least one camera to load Events
@@ -223,8 +213,6 @@ const Tabs = ({
 };
 
 type LayoutProps = {
-  selectedEvent: types.CameraEvent | null;
-  setSelectedEvent: (event: types.CameraEvent) => void;
   date: Dayjs | null;
   setDate: (date: Dayjs | null) => void;
   selectedTab: "events" | "timeline";
@@ -232,14 +220,7 @@ type LayoutProps = {
 };
 
 export const Layout = memo(
-  ({
-    selectedEvent,
-    setSelectedEvent,
-    date,
-    setDate,
-    selectedTab,
-    setSelectedTab,
-  }: LayoutProps) => {
+  ({ date, setDate, selectedTab, setSelectedTab }: LayoutProps) => {
     const theme = useTheme();
     const smBreakpoint = useMediaQuery(theme.breakpoints.up("sm"));
     const playerCardGridItemRef = useRef<HTMLDivElement | null>(null);
@@ -278,10 +259,7 @@ export const Layout = memo(
               xl: 10,
             }}
           >
-            <PlayerCard
-              selectedEvent={selectedEvent}
-              selectedTab={selectedTab}
-            />
+            <PlayerCard />
           </Grid>
           <Grid
             size={{
@@ -297,8 +275,6 @@ export const Layout = memo(
                 date={date}
                 selectedTab={selectedTab}
                 setSelectedTab={setSelectedTab}
-                selectedEvent={selectedEvent}
-                setSelectedEvent={setSelectedEvent}
                 playerCardGridItemRef={playerCardGridItemRef}
               />
             </Paper>

--- a/frontend/src/components/events/SyncManager.tsx
+++ b/frontend/src/components/events/SyncManager.tsx
@@ -251,7 +251,11 @@ const SyncManager: React.FC<SyncManagerProps> = ({ children }) => {
             return;
           }
 
-          if (data.details === Hls.ErrorDetails.BUFFER_NUDGE_ON_STALL) {
+          if (
+            data.details === Hls.ErrorDetails.BUFFER_NUDGE_ON_STALL ||
+            data.details === Hls.ErrorDetails.BUFFER_STALLED_ERROR ||
+            data.details === Hls.ErrorDetails.LEVEL_LOAD_ERROR
+          ) {
             player.current!.media!.play().catch(() => {
               // Ignore play errors
             });

--- a/frontend/src/components/events/SyncManager.tsx
+++ b/frontend/src/components/events/SyncManager.tsx
@@ -233,7 +233,7 @@ const SyncManager: React.FC<SyncManagerProps> = ({ children }) => {
     setReferencePlayer,
   ]);
 
-  useControlledInterval(syncPlayers, SYNC_INTERVAL);
+  useControlledInterval(syncPlayers, SYNC_INTERVAL, true);
 
   useEffect(() => {
     hlsRefs.forEach((player) => {

--- a/frontend/src/components/events/SyncManager.tsx
+++ b/frontend/src/components/events/SyncManager.tsx
@@ -197,6 +197,19 @@ const SyncManager: React.FC<SyncManagerProps> = ({ children }) => {
 
       if (playerToPlayIndex !== -1) {
         const playerToPlay = playersWithTime[playerToPlayIndex];
+        const fragments =
+          playerToPlay.current.levels[playerToPlay.current.currentLevel].details
+            ?.fragments;
+        if (!fragments || fragments.length === 0) {
+          return;
+        }
+        const closestFragment = findClosestFragment(
+          fragments,
+          playingDateMillis,
+        );
+        if (closestFragment && closestFragment.programDateTime) {
+          playerToPlay.current.media!.currentTime = closestFragment.start;
+        }
         playerToPlay.current
           .media!.play()
           .then(() => {

--- a/frontend/src/components/events/SyncManager.tsx
+++ b/frontend/src/components/events/SyncManager.tsx
@@ -13,7 +13,7 @@ import {
   useReferencePlayerStore,
 } from "components/events/utils";
 import useControlledInterval from "hooks/UseControlledInterval";
-import { dateToTimestamp, dateToTimestampMillis } from "lib/helpers";
+import { dateToTimestamp, dateToTimestampMillis, sleep } from "lib/helpers";
 
 const SYNC_INTERVAL = 100; // Sync interval in milliseconds
 const MAX_DRIFT = 0.5; // Maximum allowed drift in seconds
@@ -89,6 +89,10 @@ const SyncManager: React.FC<SyncManagerProps> = ({ children }) => {
   }, []);
 
   const syncPlayers = useCallback(async () => {
+    if (requestedTimestamp === playingDateRef.current) {
+      await sleep(1000);
+    }
+
     const playersWithTime = hlsRefs.filter(
       (player): player is React.MutableRefObject<Hls> =>
         player.current !== null && player.current.playingDate !== null,

--- a/frontend/src/components/events/timeline/ProgressLine.tsx
+++ b/frontend/src/components/events/timeline/ProgressLine.tsx
@@ -3,11 +3,7 @@ import DOMPurify from "dompurify";
 import Hls from "hls.js";
 import { memo, useEffect, useRef } from "react";
 
-import {
-  TICK_HEIGHT,
-  getYPosition,
-  useReferencePlayerStore,
-} from "components/events/utils";
+import { getYPosition, useReferencePlayerStore } from "components/events/utils";
 import { dateToTimestamp, getTimeFromDate } from "lib/helpers";
 
 const useTimeUpdate = (
@@ -39,8 +35,7 @@ const useTimeUpdate = (
             endRef.current,
             playingTimestamp,
             bounds.height,
-          ) +
-            TICK_HEIGHT / 2,
+          ),
         )}px`;
         const innerHTML = DOMPurify.sanitize(getTimeFromDate(hls.playingDate));
         if (timeRef.current && innerHTML !== timeRef.current.innerHTML) {

--- a/frontend/src/components/events/timeline/TimelinePlayer.tsx
+++ b/frontend/src/components/events/timeline/TimelinePlayer.tsx
@@ -203,7 +203,7 @@ const initializePlayer = (
       case Hls.ErrorDetails.FRAG_GAP:
         break;
       default:
-    setHlsRefsError(hlsRef, data.error.message);
+        setHlsRefsError(hlsRef, data.error.message);
         break;
     }
 

--- a/frontend/src/components/events/timeline/TimelinePlayer.tsx
+++ b/frontend/src/components/events/timeline/TimelinePlayer.tsx
@@ -75,7 +75,7 @@ const onManifestParsed = (
   }
 
   videoRef.current.muted = true;
-  hlsRef.current.startLoad();
+  hlsRef.current.startLoad(0);
 };
 
 const onMediaAttached = (
@@ -127,6 +127,7 @@ const initializePlayer = (
 
   // Create a new hls instance
   hlsRef.current = new Hls({
+    autoStartLoad: false,
     maxBufferLength: 30, // 30 seconds of forward buffer
     backBufferLength: 15, // 15 seconds of back buffer
     liveSyncDurationCount: 1, // Start from the second last segment

--- a/frontend/src/components/events/timeline/TimelineTable.tsx
+++ b/frontend/src/components/events/timeline/TimelineTable.tsx
@@ -120,7 +120,7 @@ export const TimelineTable = memo(({ parentRef, date }: TimelineTableProps) => {
     })),
   );
 
-  const availableTimespans = useTimespans(date);
+  const { availableTimespans } = useTimespans(date);
 
   // Since React Query v5 doesn't support keepPreviousData, and the
   // alternatives does not work for useQueries, we need to use a ref

--- a/frontend/src/components/events/timeline/TimelineTable.tsx
+++ b/frontend/src/components/events/timeline/TimelineTable.tsx
@@ -1,6 +1,7 @@
 import dayjs, { Dayjs } from "dayjs";
 import { memo, useContext, useEffect, useMemo, useRef, useState } from "react";
 import ServerDown from "svg/undraw/server_down.svg?react";
+import { useShallow } from "zustand/react/shallow";
 
 import { ErrorMessage } from "components/error/ErrorMessage";
 import { HoverLine } from "components/events/timeline/HoverLine";
@@ -15,6 +16,7 @@ import {
   getTimelineItems,
   useCameraStore,
   useFilterStore,
+  useReferencePlayerStore,
   useTimespans,
 } from "components/events/utils";
 import { Loading } from "components/loading/Loading";
@@ -90,105 +92,108 @@ const timelineClick = (
 type TimelineTableProps = {
   parentRef: React.MutableRefObject<HTMLDivElement | null>;
   date: Dayjs | null;
-  setRequestedTimestamp: (timestamp: number | null) => void;
 };
-export const TimelineTable = memo(
-  ({ parentRef, date, setRequestedTimestamp }: TimelineTableProps) => {
-    const containerRef = useRef<HTMLDivElement | null>(null);
-    const startRef = useRef<number>(calculateStart(date));
-    const endRef = useRef<number>(calculateEnd(date));
+export const TimelineTable = memo(({ parentRef, date }: TimelineTableProps) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const startRef = useRef<number>(calculateStart(date));
+  const endRef = useRef<number>(calculateEnd(date));
 
-    const firstRender = useRef(true);
-    const eventsData = useRef<types.CameraEvent[] | null>(null);
+  const firstRender = useRef(true);
+  const eventsData = useRef<types.CameraEvent[] | null>(null);
 
-    // Add timeticks every SCALE seconds
-    // Components mostly use startRef.current for performance reasons,
-    // but the state is used to trigger a re-render when the time changes
-    const [start, setStart] = useState<number>(startRef.current);
-    useAddTicks(date, startRef, setStart);
-    startRef.current = start;
+  // Add timeticks every SCALE seconds
+  // Components mostly use startRef.current for performance reasons,
+  // but the state is used to trigger a re-render when the time changes
+  const [start, setStart] = useState<number>(startRef.current);
+  useAddTicks(date, startRef, setStart);
+  startRef.current = start;
 
-    const { selectedCameras } = useCameraStore();
-    const eventsQueries = useEventsMultiple({
-      camera_identifiers: selectedCameras,
-      date: date ? date.format("YYYY-MM-DD") : "",
-      configOptions: { enabled: !!date },
-    });
-    const availableTimespans = useTimespans(date);
+  const { selectedCameras } = useCameraStore();
+  const eventsQueries = useEventsMultiple({
+    camera_identifiers: selectedCameras,
+    date: date ? date.format("YYYY-MM-DD") : "",
+    configOptions: { enabled: !!date },
+  });
+  const { setRequestedTimestamp } = useReferencePlayerStore(
+    useShallow((state) => ({
+      setRequestedTimestamp: state.setRequestedTimestamp,
+    })),
+  );
 
-    // Since React Query v5 doesn't support keepPreviousData, and the
-    // alternatives does not work for useQueries, we need to use a ref
-    // to keep the previous data
-    // https://github.com/TanStack/query/discussions/6521
-    if (eventsQueries.data && objHasValues(eventsQueries.data)) {
-      eventsData.current = eventsQueries.data;
-    }
+  const availableTimespans = useTimespans(date);
 
-    const { filters } = useFilterStore();
-    const timelineItems = useMemo(
-      () =>
-        getTimelineItems(
-          startRef,
-          eventsData.current || [],
-          availableTimespans,
-          filters,
-        ),
-      // False positive, the refs are derived from the data
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [eventsData.current, availableTimespans, filters],
-    );
+  // Since React Query v5 doesn't support keepPreviousData, and the
+  // alternatives does not work for useQueries, we need to use a ref
+  // to keep the previous data
+  // https://github.com/TanStack/query/discussions/6521
+  if (eventsQueries.data && objHasValues(eventsQueries.data)) {
+    eventsData.current = eventsQueries.data;
+  }
 
-    if (eventsQueries.error) {
-      const subtext = eventsQueries.error
-        ? eventsQueries.error.message
-        : "Unknown error";
-      return (
-        <ErrorMessage
-          text={"Error loading events and/or timespans"}
-          subtext={subtext}
-          image={
-            <ServerDown width={150} height={150} role="img" aria-label="Void" />
-          }
-        />
-      );
-    }
-    if (firstRender.current && eventsQueries.isLoading) {
-      return <Loading text="Loading Timeline" fullScreen={false} />;
-    }
+  const { filters } = useFilterStore();
+  const timelineItems = useMemo(
+    () =>
+      getTimelineItems(
+        startRef,
+        eventsData.current || [],
+        availableTimespans,
+        filters,
+      ),
+    // False positive, the refs are derived from the data
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [eventsData.current, availableTimespans, filters],
+  );
 
-    firstRender.current = false;
+  if (eventsQueries.error) {
+    const subtext = eventsQueries.error
+      ? eventsQueries.error.message
+      : "Unknown error";
     return (
-      <div
-        ref={containerRef}
-        onClick={(event) =>
-          timelineClick(
-            event,
-            containerRef,
-            startRef,
-            endRef,
-            setRequestedTimestamp,
-          )
+      <ErrorMessage
+        text={"Error loading events and/or timespans"}
+        subtext={subtext}
+        image={
+          <ServerDown width={150} height={150} role="img" aria-label="Void" />
         }
-      >
-        <div style={{ position: "relative" }}>
-          <ProgressLine
-            containerRef={containerRef}
-            startRef={startRef}
-            endRef={endRef}
-          />
-        </div>
-        <HoverLine
+      />
+    );
+  }
+  if (firstRender.current && eventsQueries.isLoading) {
+    return <Loading text="Loading Timeline" fullScreen={false} />;
+  }
+
+  firstRender.current = false;
+  return (
+    <div
+      ref={containerRef}
+      onClick={(event) =>
+        timelineClick(
+          event,
+          containerRef,
+          startRef,
+          endRef,
+          setRequestedTimestamp,
+        )
+      }
+    >
+      <div style={{ position: "relative" }}>
+        <ProgressLine
           containerRef={containerRef}
           startRef={startRef}
           endRef={endRef}
         />
-        <VirtualList
-          parentRef={parentRef}
-          startRef={startRef}
-          endRef={endRef}
-          timelineItems={timelineItems}
-        />
       </div>
-    );
-  },
-);
+      <HoverLine
+        containerRef={containerRef}
+        startRef={startRef}
+        endRef={endRef}
+      />
+      <VirtualList
+        parentRef={parentRef}
+        startRef={startRef}
+        endRef={endRef}
+        timelineItems={timelineItems}
+      />
+    </div>
+  );
+});

--- a/frontend/src/components/events/timeline/TimelineTable.tsx
+++ b/frontend/src/components/events/timeline/TimelineTable.tsx
@@ -14,8 +14,8 @@ import {
   calculateStart,
   getDateAtPosition,
   getTimelineItems,
-  useCameraStore,
   useFilterStore,
+  useFilteredCameras,
   useReferencePlayerStore,
   useTimespans,
 } from "components/events/utils";
@@ -108,9 +108,9 @@ export const TimelineTable = memo(({ parentRef, date }: TimelineTableProps) => {
   useAddTicks(date, startRef, setStart);
   startRef.current = start;
 
-  const { selectedCameras } = useCameraStore();
+  const filteredCameras = useFilteredCameras();
   const eventsQueries = useEventsMultiple({
-    camera_identifiers: selectedCameras,
+    camera_identifiers: Object.keys(filteredCameras),
     date: date ? date.format("YYYY-MM-DD") : "",
     configOptions: { enabled: !!date },
   });

--- a/frontend/src/components/events/utils.tsx
+++ b/frontend/src/components/events/utils.tsx
@@ -190,7 +190,9 @@ interface ReferencePlayerStore {
   setIsMuted: (muted: boolean) => void;
   playbackSpeed: number;
   setPlaybackSpeed: (speed: number) => void;
-  playingDateRef: React.MutableRefObject<Date | null>;
+  requestedTimestamp: number;
+  setRequestedTimestamp: (timestamp: number) => void;
+  playingDateRef: React.MutableRefObject<number>;
 }
 
 export const useReferencePlayerStore = create<ReferencePlayerStore>((set) => ({
@@ -204,7 +206,13 @@ export const useReferencePlayerStore = create<ReferencePlayerStore>((set) => ({
   setIsMuted: (isMuted) => set({ isMuted }),
   playbackSpeed: 1,
   setPlaybackSpeed: (playbackSpeed) => set({ playbackSpeed }),
-  playingDateRef: { current: null },
+  requestedTimestamp: dayjs().unix() - LIVE_EDGE_DELAY,
+  setRequestedTimestamp: (requestedTimestamp) =>
+    set((state) => {
+      state.playingDateRef.current = requestedTimestamp;
+      return { ...state, requestedTimestamp };
+    }),
+  playingDateRef: { current: dayjs().unix() - LIVE_EDGE_DELAY },
 }));
 
 export const DEFAULT_ITEM: TimelineItem = {

--- a/frontend/src/components/events/utils.tsx
+++ b/frontend/src/components/events/utils.tsx
@@ -266,10 +266,13 @@ export const getYPosition = (
   requestedTimestamp: number,
   timelineHeight: number,
 ): number => {
+  // Calculate the start and end timestamps with a margin of half the SCALE
+  const _start = startTimestamp + SCALE / 2;
+  const _end = endTimestamp - SCALE / 2;
   // Calculate the total time duration from start to end
-  const totalTime = endTimestamp - startTimestamp;
+  const totalTime = _end - _start;
   // Calculate the time elapsed from start to the requested timestamp
-  const elapsedTime = requestedTimestamp - startTimestamp;
+  const elapsedTime = requestedTimestamp - _start;
   // Calculate the proportion of time elapsed relative to the total time
   const timeProportion = elapsedTime / totalTime;
   // Calculate the Y-position of the requested timestamp

--- a/frontend/src/pages/Events.tsx
+++ b/frontend/src/pages/Events.tsx
@@ -16,7 +16,6 @@ import {
   objIsEmpty,
   removeURLParameter,
 } from "lib/helpers";
-import * as types from "lib/types";
 
 const getDefaultTab = (searchParams: URLSearchParams) => {
   if (
@@ -37,9 +36,6 @@ const Events = () => {
 
   const camerasAll = useCamerasAll();
 
-  const [selectedEvent, setSelectedEvent] = useState<types.CameraEvent | null>(
-    null,
-  );
   const [date, setDate] = useState<Dayjs | null>(
     searchParams.has("date")
       ? dayjs(searchParams.get("date") as string)
@@ -93,8 +89,6 @@ const Events = () => {
 
   return (
     <Layout
-      selectedEvent={selectedEvent}
-      setSelectedEvent={setSelectedEvent}
       date={date}
       setDate={setDate}
       selectedTab={selectedTab}

--- a/frontend/src/pages/Events.tsx
+++ b/frontend/src/pages/Events.tsx
@@ -5,7 +5,7 @@ import ServerDown from "svg/undraw/server_down.svg?react";
 
 import { ErrorMessage } from "components/error/ErrorMessage";
 import { Layout } from "components/events/Layouts";
-import { LIVE_EDGE_DELAY, useCameraStore } from "components/events/utils";
+import { useCameraStore } from "components/events/utils";
 import { Loading } from "components/loading/Loading";
 import { useHideScrollbar } from "hooks/UseHideScrollbar";
 import { useTitle } from "hooks/UseTitle";
@@ -55,9 +55,6 @@ const Events = () => {
     searchParams.has("date")
       ? dayjs(searchParams.get("date") as string)
       : dayjs(),
-  );
-  const [requestedTimestamp, setRequestedTimestamp] = useState<number | null>(
-    dayjs().unix() - LIVE_EDGE_DELAY,
   );
   const [selectedTab, setSelectedTab] = useState<"events" | "timeline">(
     getDefaultTab(searchParams),
@@ -111,8 +108,6 @@ const Events = () => {
       setSelectedEvent={setSelectedEvent}
       date={date}
       setDate={setDate}
-      requestedTimestamp={requestedTimestamp}
-      setRequestedTimestamp={setRequestedTimestamp}
       selectedTab={selectedTab}
       setSelectedTab={setSelectedTab}
     />

--- a/tests/components/webserver/api/v1/test_hls.py
+++ b/tests/components/webserver/api/v1/test_hls.py
@@ -45,7 +45,6 @@ class TestHlsApiHandler(TestAppBaseNoAuth, BaseTestWithRecordings):
         assert response.code == 200
         response_string = response.body.decode()
         assert response_string.count("#EXTINF") == 3
-        assert response_string.count("#EXT-X-DISCONTINUITY") == 3
         assert response_string.count("#EXT-X-ENDLIST") == 1
 
     def test_get_recording_hls_playlist_gap_segments(self):
@@ -83,8 +82,7 @@ class TestHlsApiHandler(TestAppBaseNoAuth, BaseTestWithRecordings):
         assert response.code == 200
         response_string = response.body.decode()
         assert response_string.count("#EXTINF") == 11
-        assert response_string.count("#EXT-X-DISCONTINUITY") == 11
-        assert response_string.count("#EXT-X-GAP") == 1
+        assert response_string.count("#EXT-X-DISCONTINUITY") == 1
 
     def test_get_recording_hls_ongoing(self):
         """Test getting a recording HLS playlist for a recording that has not ended."""
@@ -124,7 +122,6 @@ class TestHlsApiHandler(TestAppBaseNoAuth, BaseTestWithRecordings):
         assert response.code == 200
         response_string = response.body.decode()
         assert response_string.count("#EXTINF") == 4
-        assert response_string.count("#EXT-X-DISCONTINUITY") == 4
         assert response_string.count("#EXT-X-ENDLIST") == 0
 
     def test_get_available_timespans(self):

--- a/tests/domains/camera/test_fragmenter.py
+++ b/tests/domains/camera/test_fragmenter.py
@@ -63,11 +63,9 @@ def test_generate_playlist() -> None:
 #EXT-X-TARGETDURATION:6
 #EXT-X-INDEPENDENT-SEGMENTS
 #EXT-X-MAP:URI="/test/init.mp4"
-#EXT-X-DISCONTINUITY
 #EXT-X-PROGRAM-DATE-TIME:{program_date_time}
 #EXTINF:5.1,
 /test/test1.mp4
-#EXT-X-DISCONTINUITY
 #EXT-X-PROGRAM-DATE-TIME:{program_date_time}
 #EXTINF:4.123,
 /test/test2.mp4

--- a/viseron/domains/camera/fragmenter.py
+++ b/viseron/domains/camera/fragmenter.py
@@ -416,8 +416,7 @@ def generate_playlist(
     prev_fragment: Fragment | None = None
     for fragment in fragments:
         if prev_fragment and gap_in_fragments(prev_fragment, fragment):
-            playlist.append("#EXT-X-GAP")
-        playlist.append("#EXT-X-DISCONTINUITY")
+            playlist.append("#EXT-X-DISCONTINUITY")
         program_date_time = fragment.creation_time.replace(
             tzinfo=datetime.timezone.utc
         ).isoformat(timespec="milliseconds")


### PR DESCRIPTION
This PR includes a number of improvements to the Events page and making playback smoother.
- HLS playlists no longer set the EXT-X-GAP tag since HLS.js sometimes freezes when encountering the tag.
It will be reintroduced in a later release since HLS.js has fixed it in its current beta
- Fix a bug with the progress line positioning
- Dont error out when restarting Viseron while viewing the Events page
- Allow clicking on Events in the hover menus to seek to them
