### PR TITLE
deprecate trigger_recorder in favor of trigger_event_recording

### DIFF
--- a/docs/docs/documentation/configuration.md
+++ b/docs/docs/documentation/configuration.md
@@ -108,19 +108,19 @@ darknet:
         labels:
           - label: person
             confidence: 0.8
-            trigger_recorder: true
+            trigger_event_recording: true
       viseron_camera2:
         fps: 1
         labels:
           - label: person
             confidence: 0.8
-            trigger_recorder: true
+            trigger_event_recording: true
       viseron_camera3:
         fps: 1
         labels:
           - label: person
             confidence: 0.8
-            trigger_recorder: true
+            trigger_event_recording: true
 
 nvr:
   viseron_camera:

--- a/docs/docs/documentation/configuration/snapshots.md
+++ b/docs/docs/documentation/configuration/snapshots.md
@@ -23,7 +23,7 @@ codeprojectai:
         labels:
           - label: person
             confidence: 0.8
-            trigger_recorder: true
+            trigger_event_recording: true
             // highlight-start
             store: true
             store_interval: 300 # Only store a snapshot of this label every 300 seconds

--- a/docs/src/pages/components-explorer/_domains/motion_detector/index.mdx
+++ b/docs/src/pages/components-explorer/_domains/motion_detector/index.mdx
@@ -13,7 +13,7 @@ This is good because object detection uses far more resources compared to motion
 
 :::tip Recorder
 
-A motion detector can start the recorder if `trigger_recorder` is set to `true`, meaning an object detector is not strictly needed.<br />
+A motion detector can start the recorder if `trigger_event_recording` is set to `true`, meaning an object detector is not strictly needed.<br />
 
 :::
 

--- a/docs/src/pages/components-explorer/_domains/object_detector/zones.mdx
+++ b/docs/src/pages/components-explorer/_domains/object_detector/zones.mdx
@@ -34,7 +34,7 @@ actually interested in, excluding the sidewalk.
             labels:
               - label: person
                 confidence: 0.8
-                trigger_recorder: true
+                trigger_event_recording: true
         // highlight-end`}
 
 </CodeBlock>

--- a/docs/src/pages/components-explorer/components/background_subtractor/config.json
+++ b/docs/src/pages/components-explorer/components/background_subtractor/config.json
@@ -13,8 +13,19 @@
                 "value": [
                   {
                     "type": "boolean",
-                    "name": "trigger_recorder",
+                    "name": {
+                      "type": "deprecated",
+                      "name": "trigger_recorder",
+                      "value": "Use <code>trigger_event_recording</code> instead."
+                    },
                     "description": "If true, detected motion will start the recorder.",
+                    "deprecated": true,
+                    "default": null
+                  },
+                  {
+                    "type": "boolean",
+                    "name": "trigger_event_recording",
+                    "description": "If true, detected motion will trigger an event recording.",
                     "optional": true,
                     "default": false
                   },

--- a/docs/src/pages/components-explorer/components/background_subtractor/index.mdx
+++ b/docs/src/pages/components-explorer/components/background_subtractor/index.mdx
@@ -38,7 +38,7 @@ background_subtractor:
                 y: 750
       camera_two:
         fps: 2
-        trigger_recorder: true
+        trigger_event_recording: true
 ```
 
 </details>

--- a/docs/src/pages/components-explorer/components/codeprojectai/config.json
+++ b/docs/src/pages/components-explorer/components/codeprojectai/config.json
@@ -107,15 +107,26 @@
                         },
                         {
                           "type": "boolean",
-                          "name": "trigger_recorder",
+                          "name": {
+                            "type": "deprecated",
+                            "name": "trigger_recorder",
+                            "value": "Use <code>trigger_event_recording</code> instead."
+                          },
                           "description": "If set to <code>true</code>, objects matching this filter will start the recorder.",
+                          "deprecated": true,
+                          "default": null
+                        },
+                        {
+                          "type": "boolean",
+                          "name": "trigger_event_recording",
+                          "description": "If set to <code>true</code>, objects matching this filter will trigger an event recording.",
                           "optional": true,
                           "default": true
                         },
                         {
                           "type": "boolean",
                           "name": "store",
-                          "description": "If set to <code>true</code>, objects matching this filter will be stored in the database, as well as having a snapshot saved. Labels with <code>trigger_recorder</code> set to <code>true</code> will always be stored when a recording starts, regardless of this setting.",
+                          "description": "If set to <code>true</code>, objects matching this filter will be stored in the database, as well as having a snapshot saved. Labels with <code>trigger_event_recording</code> set to <code>true</code> will always be stored when a recording starts, regardless of this setting.",
                           "optional": true,
                           "default": true
                         },
@@ -287,15 +298,26 @@
                               },
                               {
                                 "type": "boolean",
-                                "name": "trigger_recorder",
+                                "name": {
+                                  "type": "deprecated",
+                                  "name": "trigger_recorder",
+                                  "value": "Use <code>trigger_event_recording</code> instead."
+                                },
                                 "description": "If set to <code>true</code>, objects matching this filter will start the recorder.",
+                                "deprecated": true,
+                                "default": null
+                              },
+                              {
+                                "type": "boolean",
+                                "name": "trigger_event_recording",
+                                "description": "If set to <code>true</code>, objects matching this filter will trigger an event recording.",
                                 "optional": true,
                                 "default": true
                               },
                               {
                                 "type": "boolean",
                                 "name": "store",
-                                "description": "If set to <code>true</code>, objects matching this filter will be stored in the database, as well as having a snapshot saved. Labels with <code>trigger_recorder</code> set to <code>true</code> will always be stored when a recording starts, regardless of this setting.",
+                                "description": "If set to <code>true</code>, objects matching this filter will be stored in the database, as well as having a snapshot saved. Labels with <code>trigger_event_recording</code> set to <code>true</code> will always be stored when a recording starts, regardless of this setting.",
                                 "optional": true,
                                 "default": true
                               },

--- a/docs/src/pages/components-explorer/components/codeprojectai/index.mdx
+++ b/docs/src/pages/components-explorer/components/codeprojectai/index.mdx
@@ -36,7 +36,7 @@ codeprojectai:
         labels:
           - label: person
             confidence: 0.8
-            trigger_recorder: true
+            trigger_event_recording: true
           - label: cat
             confidence: 0.8
         zones:
@@ -53,7 +53,7 @@ codeprojectai:
             labels:
               - label: person
                 confidence: 0.8
-                trigger_recorder: true
+                trigger_event_recording: true
         mask:
           - coordinates:
               - x: 400
@@ -69,10 +69,10 @@ codeprojectai:
         labels:
           - label: person
             confidence: 0.7
-            trigger_recorder: true
+            trigger_event_recording: true
           - label: cat
             confidence: 0.8
-            trigger_recorder: false
+            trigger_event_recording: false
   face_recognition:
     save_unknown_faces: true
     cameras:

--- a/docs/src/pages/components-explorer/components/darknet/config.json
+++ b/docs/src/pages/components-explorer/components/darknet/config.json
@@ -84,15 +84,26 @@
                         },
                         {
                           "type": "boolean",
-                          "name": "trigger_recorder",
+                          "name": {
+                            "type": "deprecated",
+                            "name": "trigger_recorder",
+                            "value": "Use <code>trigger_event_recording</code> instead."
+                          },
                           "description": "If set to <code>true</code>, objects matching this filter will start the recorder.",
+                          "deprecated": true,
+                          "default": null
+                        },
+                        {
+                          "type": "boolean",
+                          "name": "trigger_event_recording",
+                          "description": "If set to <code>true</code>, objects matching this filter will trigger an event recording.",
                           "optional": true,
                           "default": true
                         },
                         {
                           "type": "boolean",
                           "name": "store",
-                          "description": "If set to <code>true</code>, objects matching this filter will be stored in the database, as well as having a snapshot saved. Labels with <code>trigger_recorder</code> set to <code>true</code> will always be stored when a recording starts, regardless of this setting.",
+                          "description": "If set to <code>true</code>, objects matching this filter will be stored in the database, as well as having a snapshot saved. Labels with <code>trigger_event_recording</code> set to <code>true</code> will always be stored when a recording starts, regardless of this setting.",
                           "optional": true,
                           "default": true
                         },
@@ -264,15 +275,26 @@
                               },
                               {
                                 "type": "boolean",
-                                "name": "trigger_recorder",
+                                "name": {
+                                  "type": "deprecated",
+                                  "name": "trigger_recorder",
+                                  "value": "Use <code>trigger_event_recording</code> instead."
+                                },
                                 "description": "If set to <code>true</code>, objects matching this filter will start the recorder.",
+                                "deprecated": true,
+                                "default": null
+                              },
+                              {
+                                "type": "boolean",
+                                "name": "trigger_event_recording",
+                                "description": "If set to <code>true</code>, objects matching this filter will trigger an event recording.",
                                 "optional": true,
                                 "default": true
                               },
                               {
                                 "type": "boolean",
                                 "name": "store",
-                                "description": "If set to <code>true</code>, objects matching this filter will be stored in the database, as well as having a snapshot saved. Labels with <code>trigger_recorder</code> set to <code>true</code> will always be stored when a recording starts, regardless of this setting.",
+                                "description": "If set to <code>true</code>, objects matching this filter will be stored in the database, as well as having a snapshot saved. Labels with <code>trigger_event_recording</code> set to <code>true</code> will always be stored when a recording starts, regardless of this setting.",
                                 "optional": true,
                                 "default": true
                               },

--- a/docs/src/pages/components-explorer/components/darknet/index.mdx
+++ b/docs/src/pages/components-explorer/components/darknet/index.mdx
@@ -48,7 +48,7 @@ darknet:
         labels:
           - label: dog
             confidence: 0.7
-            trigger_recorder: false
+            trigger_event_recording: false
           - label: cat
             confidence: 0.8
         zones:
@@ -65,7 +65,7 @@ darknet:
             labels:
               - label: person
                 confidence: 0.8
-                trigger_recorder: true
+                trigger_event_recording: true
         mask:
           - coordinates:
               - x: 400

--- a/docs/src/pages/components-explorer/components/deepstack/config.json
+++ b/docs/src/pages/components-explorer/components/deepstack/config.json
@@ -114,15 +114,26 @@
                         },
                         {
                           "type": "boolean",
-                          "name": "trigger_recorder",
+                          "name": {
+                            "type": "deprecated",
+                            "name": "trigger_recorder",
+                            "value": "Use <code>trigger_event_recording</code> instead."
+                          },
                           "description": "If set to <code>true</code>, objects matching this filter will start the recorder.",
+                          "deprecated": true,
+                          "default": null
+                        },
+                        {
+                          "type": "boolean",
+                          "name": "trigger_event_recording",
+                          "description": "If set to <code>true</code>, objects matching this filter will trigger an event recording.",
                           "optional": true,
                           "default": true
                         },
                         {
                           "type": "boolean",
                           "name": "store",
-                          "description": "If set to <code>true</code>, objects matching this filter will be stored in the database, as well as having a snapshot saved. Labels with <code>trigger_recorder</code> set to <code>true</code> will always be stored when a recording starts, regardless of this setting.",
+                          "description": "If set to <code>true</code>, objects matching this filter will be stored in the database, as well as having a snapshot saved. Labels with <code>trigger_event_recording</code> set to <code>true</code> will always be stored when a recording starts, regardless of this setting.",
                           "optional": true,
                           "default": true
                         },
@@ -294,15 +305,26 @@
                               },
                               {
                                 "type": "boolean",
-                                "name": "trigger_recorder",
+                                "name": {
+                                  "type": "deprecated",
+                                  "name": "trigger_recorder",
+                                  "value": "Use <code>trigger_event_recording</code> instead."
+                                },
                                 "description": "If set to <code>true</code>, objects matching this filter will start the recorder.",
+                                "deprecated": true,
+                                "default": null
+                              },
+                              {
+                                "type": "boolean",
+                                "name": "trigger_event_recording",
+                                "description": "If set to <code>true</code>, objects matching this filter will trigger an event recording.",
                                 "optional": true,
                                 "default": true
                               },
                               {
                                 "type": "boolean",
                                 "name": "store",
-                                "description": "If set to <code>true</code>, objects matching this filter will be stored in the database, as well as having a snapshot saved. Labels with <code>trigger_recorder</code> set to <code>true</code> will always be stored when a recording starts, regardless of this setting.",
+                                "description": "If set to <code>true</code>, objects matching this filter will be stored in the database, as well as having a snapshot saved. Labels with <code>trigger_event_recording</code> set to <code>true</code> will always be stored when a recording starts, regardless of this setting.",
                                 "optional": true,
                                 "default": true
                               },

--- a/docs/src/pages/components-explorer/components/edgetpu/config.json
+++ b/docs/src/pages/components-explorer/components/edgetpu/config.json
@@ -84,15 +84,26 @@
                         },
                         {
                           "type": "boolean",
-                          "name": "trigger_recorder",
+                          "name": {
+                            "type": "deprecated",
+                            "name": "trigger_recorder",
+                            "value": "Use <code>trigger_event_recording</code> instead."
+                          },
                           "description": "If set to <code>true</code>, objects matching this filter will start the recorder.",
+                          "deprecated": true,
+                          "default": null
+                        },
+                        {
+                          "type": "boolean",
+                          "name": "trigger_event_recording",
+                          "description": "If set to <code>true</code>, objects matching this filter will trigger an event recording.",
                           "optional": true,
                           "default": true
                         },
                         {
                           "type": "boolean",
                           "name": "store",
-                          "description": "If set to <code>true</code>, objects matching this filter will be stored in the database, as well as having a snapshot saved. Labels with <code>trigger_recorder</code> set to <code>true</code> will always be stored when a recording starts, regardless of this setting.",
+                          "description": "If set to <code>true</code>, objects matching this filter will be stored in the database, as well as having a snapshot saved. Labels with <code>trigger_event_recording</code> set to <code>true</code> will always be stored when a recording starts, regardless of this setting.",
                           "optional": true,
                           "default": true
                         },
@@ -264,15 +275,26 @@
                               },
                               {
                                 "type": "boolean",
-                                "name": "trigger_recorder",
+                                "name": {
+                                  "type": "deprecated",
+                                  "name": "trigger_recorder",
+                                  "value": "Use <code>trigger_event_recording</code> instead."
+                                },
                                 "description": "If set to <code>true</code>, objects matching this filter will start the recorder.",
+                                "deprecated": true,
+                                "default": null
+                              },
+                              {
+                                "type": "boolean",
+                                "name": "trigger_event_recording",
+                                "description": "If set to <code>true</code>, objects matching this filter will trigger an event recording.",
                                 "optional": true,
                                 "default": true
                               },
                               {
                                 "type": "boolean",
                                 "name": "store",
-                                "description": "If set to <code>true</code>, objects matching this filter will be stored in the database, as well as having a snapshot saved. Labels with <code>trigger_recorder</code> set to <code>true</code> will always be stored when a recording starts, regardless of this setting.",
+                                "description": "If set to <code>true</code>, objects matching this filter will be stored in the database, as well as having a snapshot saved. Labels with <code>trigger_event_recording</code> set to <code>true</code> will always be stored when a recording starts, regardless of this setting.",
                                 "optional": true,
                                 "default": true
                               },

--- a/docs/src/pages/components-explorer/components/edgetpu/index.mdx
+++ b/docs/src/pages/components-explorer/components/edgetpu/index.mdx
@@ -39,7 +39,7 @@ edgetpu:
         labels:
           - label: dog
             confidence: 0.8
-            trigger_recorder: false
+            trigger_event_recording: false
   image_classification:
     device: cpu
     cameras:

--- a/docs/src/pages/components-explorer/components/mog2/config.json
+++ b/docs/src/pages/components-explorer/components/mog2/config.json
@@ -13,8 +13,19 @@
                 "value": [
                   {
                     "type": "boolean",
-                    "name": "trigger_recorder",
+                    "name": {
+                      "type": "deprecated",
+                      "name": "trigger_recorder",
+                      "value": "Use <code>trigger_event_recording</code> instead."
+                    },
                     "description": "If true, detected motion will start the recorder.",
+                    "deprecated": true,
+                    "default": null
+                  },
+                  {
+                    "type": "boolean",
+                    "name": "trigger_event_recording",
+                    "description": "If true, detected motion will trigger an event recording.",
                     "optional": true,
                     "default": false
                   },

--- a/docs/src/pages/components-explorer/components/mog2/index.mdx
+++ b/docs/src/pages/components-explorer/components/mog2/index.mdx
@@ -37,7 +37,7 @@ mog2:
                 y: 750
       camera_two:
         fps: 2
-        trigger_recorder: true
+        trigger_event_recording: true
         threshold: 25
 ```
 

--- a/tests/components/codeprojectai/test_object_detector.py
+++ b/tests/components/codeprojectai/test_object_detector.py
@@ -50,7 +50,7 @@ def config():
                                 {
                                     "label": "person",
                                     "confidence": 0.8,
-                                    "trigger_recorder": True,
+                                    "trigger_event_recording": True,
                                 }
                             ],
                         }

--- a/tests/helpers/test_filter.py
+++ b/tests/helpers/test_filter.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 
-from viseron.domains.motion_detector.const import CONFIG_TRIGGER_RECORDER
+from viseron.domains.motion_detector.const import CONFIG_TRIGGER_EVENT_RECORDING
 from viseron.domains.object_detector.const import (
     CONFIG_LABEL_CONFIDENCE,
     CONFIG_LABEL_HEIGHT_MAX,
@@ -32,7 +32,7 @@ def test_should_store() -> None:
             CONFIG_LABEL_WIDTH_MAX: 1,
             CONFIG_LABEL_HEIGHT_MIN: 0,
             CONFIG_LABEL_HEIGHT_MAX: 1,
-            CONFIG_TRIGGER_RECORDER: True,
+            CONFIG_TRIGGER_EVENT_RECORDING: True,
             CONFIG_LABEL_REQUIRE_MOTION: False,
             CONFIG_LABEL_STORE: True,
             CONFIG_LABEL_STORE_INTERVAL: 10,

--- a/viseron/components/storage/const.py
+++ b/viseron/components/storage/const.py
@@ -90,8 +90,8 @@ DESC_RECORDER = "Configuration for recordings."
 DESC_TYPE = (
     "<code>continuous</code>: Will save everything but highlight Events.<br>"
     "<code>events</code>: Will only save Events.<br>"
-    "Events are started by <code>trigger_recorder</code>, and ends when either no "
-    "objects or no motion (or both) is detected, depending on the configuration."
+    "Events are started by <code>trigger_event_recording</code>, and ends when either "
+    "no objects or no motion (or both) is detected, depending on the configuration."
 )
 DESC_RECORDER_TIERS = (
     "Tiers are used to move files between different storage locations. "

--- a/viseron/const.py
+++ b/viseron/const.py
@@ -44,14 +44,14 @@ darknet:
         labels:
           - label: person
             confidence: 0.75
-            trigger_recorder: true
+            trigger_event_recording: true
 
       camera_2:  # Attach detector to the configured camera_2 above
         fps: 1
         labels:
           - label: person
             confidence: 0.75
-            trigger_recorder: true
+            trigger_event_recording: true
 
 
 ## You can also use motion detection

--- a/viseron/domains/motion_detector/const.py
+++ b/viseron/domains/motion_detector/const.py
@@ -23,6 +23,7 @@ CONFIG_HEIGHT = "height"
 CONFIG_MASK = "mask"
 CONFIG_COORDINATES = "coordinates"
 CONFIG_TRIGGER_RECORDER = "trigger_recorder"
+CONFIG_TRIGGER_EVENT_RECORDING = "trigger_event_recording"
 CONFIG_RECORDER_KEEPALIVE = "recorder_keepalive"
 CONFIG_MAX_RECORDER_KEEPALIVE = "max_recorder_keepalive"
 
@@ -31,7 +32,7 @@ DEFAULT_AREA = 0.08
 DEFAULT_WIDTH = 300
 DEFAULT_HEIGHT = 300
 DEFAULT_MASK: list[dict[str, int]] = []
-DEFAULT_TRIGGER_RECORDER = False
+DEFAULT_TRIGGER_EVENT_RECORDING = False
 DEFAULT_RECORDER_KEEPALIVE = True
 DEFAULT_MAX_RECORDER_KEEPALIVE = 30
 
@@ -56,7 +57,16 @@ DESC_MASK = (
     "A mask is used to exclude certain areas in the image from motion detection. "
 )
 DESC_COORDINATES = "List of X and Y coordinates to form a polygon"
+DESC_TRIGGER_EVENT_RECORDING = (
+    "If true, detected motion will trigger an event recording."
+)
 DESC_TRIGGER_RECORDER = "If true, detected motion will start the recorder."
+DEPRECATED_TRIGGER_RECORDER = "Use <code>trigger_event_recording</code> instead."
+WARNING_TRIGGER_RECORDER = (
+    "Config option 'trigger_recorder' is deprecated and will be removed in a future "
+    "version. Use 'trigger_event_recording' instead"
+)
+
 DESC_RECORDER_KEEPALIVE = (
     "If true, recording will continue until no motion is detected."
 )

--- a/viseron/domains/object_detector/__init__.py
+++ b/viseron/domains/object_detector/__init__.py
@@ -31,7 +31,7 @@ from viseron.helpers.schemas import (
     FLOAT_MIN_ZERO,
     FLOAT_MIN_ZERO_MAX_ONE,
 )
-from viseron.helpers.validators import CameraIdentifier
+from viseron.helpers.validators import CameraIdentifier, Deprecated
 from viseron.types import SnapshotDomain
 from viseron.watchdog.thread_watchdog import RestartableThread
 
@@ -50,6 +50,7 @@ from .const import (
     CONFIG_LABEL_REQUIRE_MOTION,
     CONFIG_LABEL_STORE,
     CONFIG_LABEL_STORE_INTERVAL,
+    CONFIG_LABEL_TRIGGER_EVENT_RECORDING,
     CONFIG_LABEL_TRIGGER_RECORDER,
     CONFIG_LABEL_WIDTH_MAX,
     CONFIG_LABEL_WIDTH_MIN,
@@ -69,7 +70,7 @@ from .const import (
     DEFAULT_LABEL_REQUIRE_MOTION,
     DEFAULT_LABEL_STORE,
     DEFAULT_LABEL_STORE_INTERVAL,
-    DEFAULT_LABEL_TRIGGER_RECORDER,
+    DEFAULT_LABEL_TRIGGER_EVENT_RECORDING,
     DEFAULT_LABEL_WIDTH_MAX,
     DEFAULT_LABEL_WIDTH_MIN,
     DEFAULT_LABELS,
@@ -78,6 +79,7 @@ from .const import (
     DEFAULT_MAX_FRAME_AGE,
     DEFAULT_SCAN_ON_MOTION_ONLY,
     DEFAULT_ZONES,
+    DEPRECATED_LABEL_TRIGGER_RECORDER,
     DESC_CAMERAS,
     DESC_COORDINATES,
     DESC_FPS,
@@ -88,6 +90,7 @@ from .const import (
     DESC_LABEL_REQUIRE_MOTION,
     DESC_LABEL_STORE,
     DESC_LABEL_STORE_INTERVAL,
+    DESC_LABEL_TRIGGER_EVENT_RECORDING,
     DESC_LABEL_TRIGGER_RECORDER,
     DESC_LABEL_WIDTH_MAX,
     DESC_LABEL_WIDTH_MIN,
@@ -100,6 +103,7 @@ from .const import (
     DESC_ZONES,
     DOMAIN,
     EVENT_OBJECTS_IN_FOV,
+    WARNING_LABEL_TRIGGER_RECORDER,
 )
 from .detected_object import DetectedObject, EventDetectedObjectsData
 from .sensor import ObjectDetectorFPSSensor
@@ -153,10 +157,16 @@ LABEL_SCHEMA = vol.Schema(
                 default=DEFAULT_LABEL_WIDTH_MAX,
                 description=DESC_LABEL_WIDTH_MAX,
             ): FLOAT_MIN_ZERO_MAX_ONE,
-            vol.Optional(
+            Deprecated(
                 CONFIG_LABEL_TRIGGER_RECORDER,
-                default=DEFAULT_LABEL_TRIGGER_RECORDER,
                 description=DESC_LABEL_TRIGGER_RECORDER,
+                message=DEPRECATED_LABEL_TRIGGER_RECORDER,
+                warning=WARNING_LABEL_TRIGGER_RECORDER,
+            ): bool,
+            vol.Optional(
+                CONFIG_LABEL_TRIGGER_EVENT_RECORDING,
+                default=DEFAULT_LABEL_TRIGGER_EVENT_RECORDING,
+                description=DESC_LABEL_TRIGGER_EVENT_RECORDING,
             ): bool,
             vol.Optional(
                 CONFIG_LABEL_STORE,
@@ -358,8 +368,8 @@ class AbstractObjectDetector(ABC):
                 obj.relevant = True
                 objects_in_fov.append(obj)
 
-                if self.object_filters[obj.label].trigger_recorder:
-                    obj.trigger_recorder = True
+                if self.object_filters[obj.label].trigger_event_recording:
+                    obj.trigger_event_recording = True
                 self.object_filters[obj.label].should_store(obj)
 
         self._objects_in_fov_setter(shared_frame, objects_in_fov)

--- a/viseron/domains/object_detector/const.py
+++ b/viseron/domains/object_detector/const.py
@@ -22,6 +22,7 @@ CONFIG_LABEL_HEIGHT_MAX = "height_max"
 CONFIG_LABEL_WIDTH_MIN = "width_min"
 CONFIG_LABEL_WIDTH_MAX = "width_max"
 CONFIG_LABEL_TRIGGER_RECORDER = "trigger_recorder"
+CONFIG_LABEL_TRIGGER_EVENT_RECORDING = "trigger_event_recording"
 CONFIG_LABEL_STORE = "store"
 CONFIG_LABEL_STORE_INTERVAL = "store_interval"
 CONFIG_LABEL_REQUIRE_MOTION = "require_motion"
@@ -32,6 +33,7 @@ DEFAULT_LABEL_HEIGHT_MAX = 1
 DEFAULT_LABEL_WIDTH_MIN = 0
 DEFAULT_LABEL_WIDTH_MAX = 1
 DEFAULT_LABEL_TRIGGER_RECORDER = True
+DEFAULT_LABEL_TRIGGER_EVENT_RECORDING = True
 DEFAULT_LABEL_STORE = True
 DEFAULT_LABEL_STORE_INTERVAL = 60
 DEFAULT_LABEL_REQUIRE_MOTION = False
@@ -54,8 +56,17 @@ DESC_LABEL_WIDTH_MIN = (
 DESC_LABEL_WIDTH_MAX = (
     "Maximum width allowed for detected objects, relative to stream width."
 )
+DESC_LABEL_TRIGGER_EVENT_RECORDING = (
+    "If set to <code>true</code>, objects matching this filter will trigger an event "
+    "recording."
+)
 DESC_LABEL_TRIGGER_RECORDER = (
     "If set to <code>true</code>, objects matching this filter will start the recorder."
+)
+DEPRECATED_LABEL_TRIGGER_RECORDER = "Use <code>trigger_event_recording</code> instead."
+WARNING_LABEL_TRIGGER_RECORDER = (
+    "Config option 'trigger_recorder' is deprecated and will be removed in a future "
+    "version. Use 'trigger_event_recording' instead"
 )
 DESC_LABEL_REQUIRE_MOTION = (
     "If set to <code>true</code>, the recorder will stop as soon as motion is no "
@@ -65,8 +76,8 @@ DESC_LABEL_REQUIRE_MOTION = (
 DESC_LABEL_STORE = (
     "If set to <code>true</code>, objects matching this filter will be stored "
     "in the database, as well as having a snapshot saved. "
-    "Labels with <code>trigger_recorder</code> set to <code>true</code> will always "
-    "be stored when a recording starts, regardless of this setting."
+    "Labels with <code>trigger_event_recording</code> set to <code>true</code> will "
+    "always be stored when a recording starts, regardless of this setting."
 )
 DESC_LABEL_STORE_INTERVAL = (
     "The interval at which the label should be stored in the database, in seconds. "

--- a/viseron/domains/object_detector/detected_object.py
+++ b/viseron/domains/object_detector/detected_object.py
@@ -48,7 +48,7 @@ class DetectedObject:
             (self._rel_x1, self._rel_y1, self._rel_x2, self._rel_y2), frame_res
         )
 
-        self._trigger_recorder = False
+        self._trigger_event_recording = False
         self._store = False
         self._relevant = False
         self._filter_hit = None
@@ -222,13 +222,13 @@ class DetectedObject:
         return payload
 
     @property
-    def trigger_recorder(self):
+    def trigger_event_recording(self):
         """Return if object should trigger the recorder."""
-        return self._trigger_recorder
+        return self._trigger_event_recording
 
-    @trigger_recorder.setter
-    def trigger_recorder(self, value) -> None:
-        self._trigger_recorder = value
+    @trigger_event_recording.setter
+    def trigger_event_recording(self, value) -> None:
+        self._trigger_event_recording = value
 
     @property
     def store(self):

--- a/viseron/domains/object_detector/zone.py
+++ b/viseron/domains/object_detector/zone.py
@@ -37,10 +37,10 @@ class Zone:
     def __init__(
         self,
         vis: Viseron,
-        component,
-        camera_identifier,
-        zone_config,
-        mask,
+        component: str,
+        camera_identifier: str,
+        zone_config: dict[str, Any],
+        mask: list,
     ) -> None:
         self._vis = vis
         self._camera = vis.get_registered_domain(CAMERA_DOMAIN, camera_identifier)
@@ -92,8 +92,8 @@ class Zone:
                     obj.relevant = True
                     objects_in_zone.append(obj)
 
-                    if self._object_filters[obj.label].trigger_recorder:
-                        obj.trigger_recorder = True
+                    if self._object_filters[obj.label].trigger_event_recording:
+                        obj.trigger_event_recording = True
                     self._object_filters[obj.label].should_store(obj)
 
         self.objects_in_zone_setter(shared_frame, objects_in_zone)

--- a/viseron/helpers/filter.py
+++ b/viseron/helpers/filter.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from viseron.domains.object_detector.const import (
     CONFIG_LABEL_CONFIDENCE,
@@ -12,6 +12,7 @@ from viseron.domains.object_detector.const import (
     CONFIG_LABEL_REQUIRE_MOTION,
     CONFIG_LABEL_STORE,
     CONFIG_LABEL_STORE_INTERVAL,
+    CONFIG_LABEL_TRIGGER_EVENT_RECORDING,
     CONFIG_LABEL_TRIGGER_RECORDER,
     CONFIG_LABEL_WIDTH_MAX,
     CONFIG_LABEL_WIDTH_MIN,
@@ -25,7 +26,12 @@ if TYPE_CHECKING:
 class Filter:
     """Filter a recorded object against a configured label."""
 
-    def __init__(self, camera_resolution, object_filter, mask) -> None:
+    def __init__(
+        self,
+        camera_resolution: tuple[int, int],
+        object_filter: dict[str, Any],
+        mask: list,
+    ) -> None:
         self._camera_resolution = camera_resolution
         self._mask = mask
         self._label = object_filter[CONFIG_LABEL_LABEL]
@@ -34,7 +40,10 @@ class Filter:
         self._width_max = object_filter[CONFIG_LABEL_WIDTH_MAX]
         self._height_min = object_filter[CONFIG_LABEL_HEIGHT_MIN]
         self._height_max = object_filter[CONFIG_LABEL_HEIGHT_MAX]
-        self._trigger_recorder = object_filter[CONFIG_LABEL_TRIGGER_RECORDER]
+        self._trigger_event_recording = object_filter.get(
+            CONFIG_LABEL_TRIGGER_RECORDER,
+            object_filter[CONFIG_LABEL_TRIGGER_EVENT_RECORDING],
+        )
         self._store = object_filter[CONFIG_LABEL_STORE]
         self._store_interval = timedelta(
             seconds=object_filter[CONFIG_LABEL_STORE_INTERVAL]
@@ -89,9 +98,9 @@ class Filter:
         return self._confidence
 
     @property
-    def trigger_recorder(self) -> bool:
+    def trigger_event_recording(self) -> bool:
         """Return if label triggers recorder."""
-        return self._trigger_recorder
+        return self._trigger_event_recording
 
     @property
     def store(self) -> bool:


### PR DESCRIPTION
Changes the name from `trigger_recorder` to `trigger_event_recording` for clarity.
Functionality remains the same