### PR TITLE
Rename /recordings to /event_clips

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -25,7 +25,12 @@ RUN python3 -m pip install -r requirements_test.txt \
     && yes | mypy --install-types || true \
     && rm -rf requirements_test.txt
 
-RUN rm -r /etc/services.d/viseron
+RUN rm -r /etc/services.d/viseron \
+    && mkdir -p /config \
+    && mkdir -p /event_clips \
+    && mkdir -p /segments \
+    && mkdir -p /snapshots\
+    && mkdir -p /thumbnails
 
 # Ensure at least the en_US.UTF-8 UTF-8 locale is available.
 RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment \

--- a/docker/Dockerfile.tests
+++ b/docker/Dockerfile.tests
@@ -10,7 +10,12 @@ ADD requirements_test.txt requirements_test.txt
 RUN \
   python3 -m pip install -r requirements_test.txt
 
-RUN rm -r /etc/services.d/viseron
+RUN rm -r /etc/services.d/viseron \
+  && mkdir -p /config \
+  && mkdir -p /event_clips \
+  && mkdir -p /segments \
+  && mkdir -p /snapshots\
+  && mkdir -p /thumbnails
 
 COPY .coveragerc /src/
 COPY viseron /src/viseron/

--- a/docs/docs/documentation/configuration/recordings.mdx
+++ b/docs/docs/documentation/configuration/recordings.mdx
@@ -175,8 +175,8 @@ ffmpeg: # or any other camera component
       username: !secret camera_one_username
       password: !secret camera_one_password
       // highlight-start
-      recorder:
-        storage: # Store events for 14 days and 10gb of continuous recordings
+      storage: # Store events for 14 days and 10gb of continuous recordings
+        recorder:
           tiers:
             - path: / # Video segments will be stored in the /segments directory
               events:

--- a/docs/docs/documentation/configuration/recordings.mdx
+++ b/docs/docs/documentation/configuration/recordings.mdx
@@ -100,7 +100,7 @@ Example configuration to set retention rules for all cameras:
 storage:
   recorder:
     tiers:
-      - path: / # Files will be stored in the /recordings directory
+      - path: / # Video segments will be stored in the /segments directory
         events:
           max_age:
             days: 14
@@ -178,7 +178,7 @@ ffmpeg: # or any other camera component
       recorder:
         storage: # Store events for 14 days and 10gb of continuous recordings
           tiers:
-            - path: / # Files will be stored in the /recordings directory
+            - path: / # Video segments will be stored in the /segments directory
               events:
                 max_age:
                   days: 14
@@ -261,6 +261,6 @@ ffmpeg: # or any other camera component
 
 This will create `.mp4` files for all event recordings, which will be stored in addition to the `.m4s` files.
 
-THe `.mp4` files will be created in the `/clips` directory, unless you have set a different path in the [storage component](/components-explorer/components/storage).
+THe `.mp4` files will be created in the `/event_clips` directory, unless you have set a different path in the [storage component](/components-explorer/components/storage).
 
 :::

--- a/docs/docs/documentation/installation.mdx
+++ b/docs/docs/documentation/installation.mdx
@@ -51,10 +51,10 @@ You have to change the values between the brackets `{}` to match your setup.
 
 ```shell
 docker run --rm \
-  -v {recordings path}:/recordings \
-  -v {recordings path}:/segments \
-  -v {recordings path}:/snapshots \
-  -v {recordings path}:/thumbnails \
+  -v {segments path}:/segments \
+  -v {snapshots path}:/snapshots \
+  -v {thumbnails path}:/thumbnails \
+  -v {event clips path}:/event_clips \
   -v {config path}:/config \
   -v /etc/localtime:/etc/localtime:ro \
   -p 8888:8888 \
@@ -75,10 +75,10 @@ services:
     container_name: viseron
     shm_size: "1024mb"
     volumes:
-      - {recordings path}:/recordings
-      - {recordings path}:/segments
-      - {recordings path}:/snapshots
-      - {recordings path}:/thumbnails
+      - {segments path}:/segments \
+      - {snapshots path}:/snapshots \
+      - {thumbnails path}:/thumbnails \
+      - {event clips path}:/event_clips \
       - {config path}:/config
       - /etc/localtime:/etc/localtime:ro
     ports:
@@ -97,10 +97,10 @@ services:
 
 ```shell
 docker run --rm \
-  -v {recordings path}:/recordings \
-  -v {recordings path}:/segments \
-  -v {recordings path}:/snapshots \
-  -v {recordings path}:/thumbnails \
+  -v {segments path}:/segments \
+  -v {snapshots path}:/snapshots \
+  -v {thumbnails path}:/thumbnails \
+  -v {event clips path}:/event_clips \
   -v {config path}:/config \
   -v /etc/localtime:/etc/localtime:ro \
   -p 8888:8888 \
@@ -122,10 +122,10 @@ services:
     container_name: viseron
     shm_size: "1024mb"
     volumes:
-      - {recordings path}:/recordings
-      - {recordings path}:/segments
-      - {recordings path}:/snapshots
-      - {recordings path}:/thumbnails
+      - {segments path}:/segments \
+      - {snapshots path}:/snapshots \
+      - {thumbnails path}:/thumbnails \
+      - {event clips path}:/event_clips \
       - {config path}:/config
       - /etc/localtime:/etc/localtime:ro
     ports:
@@ -146,10 +146,10 @@ services:
 
 ```shell
 docker run --rm \
-  -v {recordings path}:/recordings \
-  -v {recordings path}:/segments \
-  -v {recordings path}:/snapshots \
-  -v {recordings path}:/thumbnails \
+  -v {segments path}:/segments \
+  -v {snapshots path}:/snapshots \
+  -v {thumbnails path}:/thumbnails \
+  -v {event clips path}:/event_clips \
   -v {config path}:/config \
   -v /etc/localtime:/etc/localtime:ro \
   -p 8888:8888 \
@@ -171,10 +171,10 @@ services:
     container_name: viseron
     shm_size: "1024mb"
     volumes:
-      - {recordings path}:/recordings
-      - {recordings path}:/segments
-      - {recordings path}:/snapshots
-      - {recordings path}:/thumbnails
+      - {segments path}:/segments \
+      - {snapshots path}:/snapshots \
+      - {thumbnails path}:/thumbnails \
+      - {event clips path}:/event_clips \
       - {config path}:/config
       - /etc/localtime:/etc/localtime:ro
     ports:
@@ -201,10 +201,10 @@ Make sure [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-container-
 
 ```shell
 docker run --rm \
-  -v {recordings path}:/recordings \
-  -v {recordings path}:/segments \
-  -v {recordings path}:/snapshots \
-  -v {recordings path}:/thumbnails \
+  -v {segments path}:/segments \
+  -v {snapshots path}:/snapshots \
+  -v {thumbnails path}:/thumbnails \
+  -v {event clips path}:/event_clips \
   -v {config path}:/config \
   -v /etc/localtime:/etc/localtime:ro \
   -p 8888:8888 \
@@ -234,10 +234,10 @@ services:
     container_name: viseron
     shm_size: "1024mb"
     volumes:
-      - {recordings path}:/recordings
-      - {recordings path}:/segments
-      - {recordings path}:/snapshots
-      - {recordings path}:/thumbnails
+      - {segments path}:/segments \
+      - {snapshots path}:/snapshots \
+      - {thumbnails path}:/thumbnails \
+      - {event clips path}:/event_clips \
       - {config path}:/config
       - /etc/localtime:/etc/localtime:ro
     ports:
@@ -266,10 +266,10 @@ You can probably get around this by manually mounting all the needed devices but
 ```shell
 docker run --rm \
   --privileged \
-  -v {recordings path}:/recordings \
-  -v {recordings path}:/segments \
-  -v {recordings path}:/snapshots \
-  -v {recordings path}:/thumbnails \
+  -v {segments path}:/segments \
+  -v {snapshots path}:/snapshots \
+  -v {thumbnails path}:/thumbnails \
+  -v {event clips path}:/event_clips \
   -v {config path}:/config \
   -v /etc/localtime:/etc/localtime:ro \
   -v /dev/bus/usb:/dev/bus/usb \
@@ -295,10 +295,10 @@ services:
     container_name: viseron
     shm_size: "1024mb"
     volumes:
-      - {recordings path}:/recordings
-      - {recordings path}:/segments
-      - {recordings path}:/snapshots
-      - {recordings path}:/thumbnails
+      - {segments path}:/segments \
+      - {snapshots path}:/snapshots \
+      - {thumbnails path}:/thumbnails \
+      - {event clips path}:/event_clips \
       - {config path}:/config
       - /etc/localtime:/etc/localtime:ro
     devices:
@@ -338,10 +338,10 @@ Configure a substream if you plan on running Viseron on an RPi.
 ```shell
 docker run --rm \
   --privileged \
-  -v {recordings path}:/recordings \
-  -v {recordings path}:/segments \
-  -v {recordings path}:/snapshots \
-  -v {recordings path}:/thumbnails \
+  -v {segments path}:/segments \
+  -v {snapshots path}:/snapshots \
+  -v {thumbnails path}:/thumbnails \
+  -v {event clips path}:/event_clips \
   -v {config path}:/config \
   -v /etc/localtime:/etc/localtime:ro \
   -v /opt/vc/lib:/opt/vc/lib \
@@ -365,10 +365,10 @@ services:
     container_name: viseron
     shm_size: "1024mb"
     volumes:
-      - {recordings path}:/recordings
-      - {recordings path}:/segments
-      - {recordings path}:/snapshots
-      - {recordings path}:/thumbnails
+      - {segments path}:/segments \
+      - {snapshots path}:/snapshots \
+      - {thumbnails path}:/thumbnails \
+      - {event clips path}:/event_clips \
       - {config path}:/config
       - /etc/localtime:/etc/localtime:ro
       - /opt/vc/lib:/opt/vc/lib
@@ -409,6 +409,16 @@ Configure a substream if you plan on running Viseron on an RPi.
 Viseron will start up immediately and serve the Web UI on port `8888`.<br />
 Please proceed to the next chapter on [how to configure Viseron.](configuration)
 
+:::info Mounted Volumes
+
+- `/config` - Where the configuration file, database, etc is stored
+- `/segments` - Where the recordings (video segments) are stored
+- `/snapshots` - Where the snapshots from object detection, motion detection, etc are stored
+- `/thumbnails` - Where the thumbnails for recordings triggered by `trigger_event_recording` are stored
+- `/event_clips` - Where the event clips created by `create_event_clip` are stored
+
+:::
+
 :::tip VAAPI
 
 VAAPI hardware acceleration support is built into every `amd64` container.<br />
@@ -433,10 +443,10 @@ To solve this, you can specify the user `PUID` and group `PGID` as environment v
 
 ```shell
 docker run --rm \
-  -v {recordings path}:/recordings \
-  -v {recordings path}:/segments \
-  -v {recordings path}:/snapshots \
-  -v {recordings path}:/thumbnails \
+  -v {segments path}:/segments \
+  -v {snapshots path}:/snapshots \
+  -v {thumbnails path}:/thumbnails \
+  -v {event clips path}:/event_clips \
   -v {config path}:/config \
   -v /etc/localtime:/etc/localtime:ro \
   -p 8888:8888 \
@@ -463,10 +473,10 @@ services:
     container_name: viseron
     shm_size: "1024mb"
     volumes:
-      - {recordings path}:/recordings
-      - {recordings path}:/segments
-      - {recordings path}:/snapshots
-      - {recordings path}:/thumbnails
+      - {segments path}:/segments \
+      - {snapshots path}:/snapshots \
+      - {thumbnails path}:/thumbnails \
+      - {event clips path}:/event_clips \
       - {config path}:/config
       - /etc/localtime:/etc/localtime:ro
     ports:

--- a/docs/src/pages/components-explorer/components/ffmpeg/config.json
+++ b/docs/src/pages/components-explorer/components/ffmpeg/config.json
@@ -192,6 +192,1289 @@
                 "default": null
               },
               {
+                "type": "map",
+                "value": [
+                  {
+                    "type": "map",
+                    "value": [
+                      {
+                        "type": "list",
+                        "values": [
+                          [
+                            {
+                              "type": "string",
+                              "name": "path",
+                              "description": "Path to store files in. Cannot be <code>/tmp</code> or <code>/tmp/viseron</code>.",
+                              "required": true,
+                              "default": null
+                            },
+                            {
+                              "type": "boolean",
+                              "name": "poll",
+                              "description": "Poll the file system for new files. Much slower than non-polling but required for some file systems like NTFS mounts.",
+                              "optional": true,
+                              "default": false
+                            },
+                            {
+                              "type": "boolean",
+                              "name": "move_on_shutdown",
+                              "description": "Move/delete files to the next tier when Viseron shuts down. Useful to not lose files when shutting down Viseron if using a RAM disk.",
+                              "optional": true,
+                              "default": false
+                            },
+                            {
+                              "type": "map",
+                              "value": [
+                                {
+                                  "type": "integer",
+                                  "valueMin": 0,
+                                  "name": "days",
+                                  "description": "Days between checks for files to move/delete.",
+                                  "optional": true,
+                                  "default": 0
+                                },
+                                {
+                                  "type": "integer",
+                                  "valueMin": 0,
+                                  "name": "hours",
+                                  "description": "Hours between checks for files to move/delete.",
+                                  "optional": true,
+                                  "default": 0
+                                },
+                                {
+                                  "type": "integer",
+                                  "valueMin": 0,
+                                  "name": "minutes",
+                                  "description": "Minutes between checks for files to move/delete.",
+                                  "optional": true,
+                                  "default": 1
+                                },
+                                {
+                                  "type": "integer",
+                                  "valueMin": 0,
+                                  "name": "seconds",
+                                  "description": "Seconds between checks for files to move/delete.",
+                                  "optional": true,
+                                  "default": 0
+                                }
+                              ],
+                              "name": "check_interval",
+                              "description": "How often to check for files to move to the next tier.",
+                              "optional": true,
+                              "default": null
+                            },
+                            {
+                              "type": "map",
+                              "value": [
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Min size in GB. Added together with <code>min_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Min size in MB. Added together with <code>min_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_size",
+                                  "description": "Minimum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Max size in GB. Added together with <code>max_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Max size in MB. Added together with <code>max_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_size",
+                                  "description": "Maximum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Max age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Max age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Max age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_age",
+                                  "description": "Maximum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Min age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Min age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Min age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_age",
+                                  "description": "Minimum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                }
+                              ],
+                              "name": "continuous",
+                              "description": "Retention rules for continuous recordings.",
+                              "optional": true,
+                              "default": null
+                            },
+                            {
+                              "type": "map",
+                              "value": [
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Min size in GB. Added together with <code>min_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Min size in MB. Added together with <code>min_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_size",
+                                  "description": "Minimum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Max size in GB. Added together with <code>max_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Max size in MB. Added together with <code>max_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_size",
+                                  "description": "Maximum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Max age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Max age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Max age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_age",
+                                  "description": "Maximum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Min age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Min age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Min age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_age",
+                                  "description": "Minimum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                }
+                              ],
+                              "name": "events",
+                              "description": "Retention rules for event recordings.",
+                              "optional": true,
+                              "default": null
+                            }
+                          ]
+                        ],
+                        "lengthMin": 1,
+                        "name": "tiers",
+                        "description": "Tiers are used to move files between different storage locations. When a file reaches the max age or max size of a tier, it will be moved to the next tier. If the file is already in the last tier, it will be deleted. ",
+                        "optional": true,
+                        "default": [
+                          {
+                            "path": "/",
+                            "events": {
+                              "max_age": {
+                                "days": 7
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "name": "recorder",
+                    "description": "Configuration for recordings.",
+                    "optional": true,
+                    "default": {}
+                  },
+                  {
+                    "type": "map",
+                    "value": [
+                      {
+                        "type": "list",
+                        "values": [
+                          [
+                            {
+                              "type": "map",
+                              "value": [
+                                {
+                                  "type": "float",
+                                  "name": "gb",
+                                  "description": "Min size in GB. Added together with <code>min_mb</code>.",
+                                  "optional": true,
+                                  "default": null
+                                },
+                                {
+                                  "type": "float",
+                                  "name": "mb",
+                                  "description": "Min size in MB. Added together with <code>min_gb</code>.",
+                                  "optional": true,
+                                  "default": null
+                                }
+                              ],
+                              "name": "min_size",
+                              "description": "Minimum size of files to keep in this tier.",
+                              "optional": true,
+                              "default": {}
+                            },
+                            {
+                              "type": "map",
+                              "value": [
+                                {
+                                  "type": "float",
+                                  "name": "gb",
+                                  "description": "Max size in GB. Added together with <code>max_mb</code>.",
+                                  "optional": true,
+                                  "default": null
+                                },
+                                {
+                                  "type": "float",
+                                  "name": "mb",
+                                  "description": "Max size in MB. Added together with <code>max_gb</code>.",
+                                  "optional": true,
+                                  "default": null
+                                }
+                              ],
+                              "name": "max_size",
+                              "description": "Maximum size of files to keep in this tier.",
+                              "optional": true,
+                              "default": {}
+                            },
+                            {
+                              "type": "map",
+                              "value": [
+                                {
+                                  "type": "integer",
+                                  "name": "days",
+                                  "description": "Max age in days.",
+                                  "optional": true,
+                                  "default": null
+                                },
+                                {
+                                  "type": "integer",
+                                  "name": "hours",
+                                  "description": "Max age in hours.",
+                                  "optional": true,
+                                  "default": null
+                                },
+                                {
+                                  "type": "integer",
+                                  "name": "minutes",
+                                  "description": "Max age in minutes.",
+                                  "optional": true,
+                                  "default": null
+                                }
+                              ],
+                              "name": "max_age",
+                              "description": "Maximum age of files to keep in this tier.",
+                              "optional": true,
+                              "default": {}
+                            },
+                            {
+                              "type": "map",
+                              "value": [
+                                {
+                                  "type": "integer",
+                                  "name": "days",
+                                  "description": "Min age in days.",
+                                  "optional": true,
+                                  "default": null
+                                },
+                                {
+                                  "type": "integer",
+                                  "name": "hours",
+                                  "description": "Min age in hours.",
+                                  "optional": true,
+                                  "default": null
+                                },
+                                {
+                                  "type": "integer",
+                                  "name": "minutes",
+                                  "description": "Min age in minutes.",
+                                  "optional": true,
+                                  "default": null
+                                }
+                              ],
+                              "name": "min_age",
+                              "description": "Minimum age of files to keep in this tier.",
+                              "optional": true,
+                              "default": {}
+                            },
+                            {
+                              "type": "string",
+                              "name": "path",
+                              "description": "Path to store files in. Cannot be <code>/tmp</code> or <code>/tmp/viseron</code>.",
+                              "required": true,
+                              "default": null
+                            },
+                            {
+                              "type": "boolean",
+                              "name": "poll",
+                              "description": "Poll the file system for new files. Much slower than non-polling but required for some file systems like NTFS mounts.",
+                              "optional": true,
+                              "default": false
+                            },
+                            {
+                              "type": "boolean",
+                              "name": "move_on_shutdown",
+                              "description": "Move/delete files to the next tier when Viseron shuts down. Useful to not lose files when shutting down Viseron if using a RAM disk.",
+                              "optional": true,
+                              "default": false
+                            },
+                            {
+                              "type": "map",
+                              "value": [
+                                {
+                                  "type": "integer",
+                                  "valueMin": 0,
+                                  "name": "days",
+                                  "description": "Days between checks for files to move/delete.",
+                                  "optional": true,
+                                  "default": 0
+                                },
+                                {
+                                  "type": "integer",
+                                  "valueMin": 0,
+                                  "name": "hours",
+                                  "description": "Hours between checks for files to move/delete.",
+                                  "optional": true,
+                                  "default": 0
+                                },
+                                {
+                                  "type": "integer",
+                                  "valueMin": 0,
+                                  "name": "minutes",
+                                  "description": "Minutes between checks for files to move/delete.",
+                                  "optional": true,
+                                  "default": 1
+                                },
+                                {
+                                  "type": "integer",
+                                  "valueMin": 0,
+                                  "name": "seconds",
+                                  "description": "Seconds between checks for files to move/delete.",
+                                  "optional": true,
+                                  "default": 0
+                                }
+                              ],
+                              "name": "check_interval",
+                              "description": "How often to check for files to move to the next tier.",
+                              "optional": true,
+                              "default": null
+                            }
+                          ]
+                        ],
+                        "lengthMin": 1,
+                        "name": "tiers",
+                        "description": "Default tiers for all domains, unless overridden in the domain configuration.<br>Tiers are used to move files between different storage locations. When a file reaches the max age or max size of a tier, it will be moved to the next tier. If the file is already in the last tier, it will be deleted.  ",
+                        "optional": true,
+                        "default": [
+                          {
+                            "path": "/",
+                            "max_age": {
+                              "days": 7
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "map",
+                        "value": [
+                          {
+                            "type": "list",
+                            "values": [
+                              [
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Min size in GB. Added together with <code>min_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Min size in MB. Added together with <code>min_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_size",
+                                  "description": "Minimum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Max size in GB. Added together with <code>max_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Max size in MB. Added together with <code>max_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_size",
+                                  "description": "Maximum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Max age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Max age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Max age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_age",
+                                  "description": "Maximum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Min age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Min age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Min age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_age",
+                                  "description": "Minimum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "string",
+                                  "name": "path",
+                                  "description": "Path to store files in. Cannot be <code>/tmp</code> or <code>/tmp/viseron</code>.",
+                                  "required": true,
+                                  "default": null
+                                },
+                                {
+                                  "type": "boolean",
+                                  "name": "poll",
+                                  "description": "Poll the file system for new files. Much slower than non-polling but required for some file systems like NTFS mounts.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
+                                  "type": "boolean",
+                                  "name": "move_on_shutdown",
+                                  "description": "Move/delete files to the next tier when Viseron shuts down. Useful to not lose files when shutting down Viseron if using a RAM disk.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "days",
+                                      "description": "Days between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "hours",
+                                      "description": "Hours between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "minutes",
+                                      "description": "Minutes between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 1
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "seconds",
+                                      "description": "Seconds between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    }
+                                  ],
+                                  "name": "check_interval",
+                                  "description": "How often to check for files to move to the next tier.",
+                                  "optional": true,
+                                  "default": null
+                                }
+                              ]
+                            ],
+                            "lengthMin": 1,
+                            "name": "tiers",
+                            "description": "Tiers are used to move files between different storage locations. When a file reaches the max age or max size of a tier, it will be moved to the next tier. If the file is already in the last tier, it will be deleted. ",
+                            "required": true,
+                            "default": null
+                          }
+                        ],
+                        "name": "face_recognition",
+                        "description": "Override the default snapshot tiers for face recognition. If not set, the default tiers will be used.",
+                        "optional": true,
+                        "default": null
+                      },
+                      {
+                        "type": "map",
+                        "value": [
+                          {
+                            "type": "list",
+                            "values": [
+                              [
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Min size in GB. Added together with <code>min_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Min size in MB. Added together with <code>min_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_size",
+                                  "description": "Minimum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Max size in GB. Added together with <code>max_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Max size in MB. Added together with <code>max_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_size",
+                                  "description": "Maximum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Max age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Max age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Max age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_age",
+                                  "description": "Maximum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Min age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Min age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Min age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_age",
+                                  "description": "Minimum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "string",
+                                  "name": "path",
+                                  "description": "Path to store files in. Cannot be <code>/tmp</code> or <code>/tmp/viseron</code>.",
+                                  "required": true,
+                                  "default": null
+                                },
+                                {
+                                  "type": "boolean",
+                                  "name": "poll",
+                                  "description": "Poll the file system for new files. Much slower than non-polling but required for some file systems like NTFS mounts.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
+                                  "type": "boolean",
+                                  "name": "move_on_shutdown",
+                                  "description": "Move/delete files to the next tier when Viseron shuts down. Useful to not lose files when shutting down Viseron if using a RAM disk.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "days",
+                                      "description": "Days between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "hours",
+                                      "description": "Hours between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "minutes",
+                                      "description": "Minutes between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 1
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "seconds",
+                                      "description": "Seconds between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    }
+                                  ],
+                                  "name": "check_interval",
+                                  "description": "How often to check for files to move to the next tier.",
+                                  "optional": true,
+                                  "default": null
+                                }
+                              ]
+                            ],
+                            "lengthMin": 1,
+                            "name": "tiers",
+                            "description": "Tiers are used to move files between different storage locations. When a file reaches the max age or max size of a tier, it will be moved to the next tier. If the file is already in the last tier, it will be deleted. ",
+                            "required": true,
+                            "default": null
+                          }
+                        ],
+                        "name": "object_detector",
+                        "description": "Override the default snapshot tiers for object detection. If not set, the default tiers will be used.",
+                        "optional": true,
+                        "default": null
+                      },
+                      {
+                        "type": "map",
+                        "value": [
+                          {
+                            "type": "list",
+                            "values": [
+                              [
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Min size in GB. Added together with <code>min_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Min size in MB. Added together with <code>min_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_size",
+                                  "description": "Minimum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Max size in GB. Added together with <code>max_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Max size in MB. Added together with <code>max_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_size",
+                                  "description": "Maximum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Max age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Max age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Max age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_age",
+                                  "description": "Maximum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Min age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Min age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Min age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_age",
+                                  "description": "Minimum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "string",
+                                  "name": "path",
+                                  "description": "Path to store files in. Cannot be <code>/tmp</code> or <code>/tmp/viseron</code>.",
+                                  "required": true,
+                                  "default": null
+                                },
+                                {
+                                  "type": "boolean",
+                                  "name": "poll",
+                                  "description": "Poll the file system for new files. Much slower than non-polling but required for some file systems like NTFS mounts.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
+                                  "type": "boolean",
+                                  "name": "move_on_shutdown",
+                                  "description": "Move/delete files to the next tier when Viseron shuts down. Useful to not lose files when shutting down Viseron if using a RAM disk.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "days",
+                                      "description": "Days between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "hours",
+                                      "description": "Hours between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "minutes",
+                                      "description": "Minutes between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 1
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "seconds",
+                                      "description": "Seconds between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    }
+                                  ],
+                                  "name": "check_interval",
+                                  "description": "How often to check for files to move to the next tier.",
+                                  "optional": true,
+                                  "default": null
+                                }
+                              ]
+                            ],
+                            "lengthMin": 1,
+                            "name": "tiers",
+                            "description": "Tiers are used to move files between different storage locations. When a file reaches the max age or max size of a tier, it will be moved to the next tier. If the file is already in the last tier, it will be deleted. ",
+                            "required": true,
+                            "default": null
+                          }
+                        ],
+                        "name": "license_plate_recognition",
+                        "description": "Override the default snapshot tiers for license plate recognition. If not set, the default tiers will be used.",
+                        "optional": true,
+                        "default": null
+                      },
+                      {
+                        "type": "map",
+                        "value": [
+                          {
+                            "type": "list",
+                            "values": [
+                              [
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Min size in GB. Added together with <code>min_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Min size in MB. Added together with <code>min_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_size",
+                                  "description": "Minimum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Max size in GB. Added together with <code>max_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Max size in MB. Added together with <code>max_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_size",
+                                  "description": "Maximum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Max age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Max age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Max age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_age",
+                                  "description": "Maximum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Min age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Min age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Min age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_age",
+                                  "description": "Minimum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "string",
+                                  "name": "path",
+                                  "description": "Path to store files in. Cannot be <code>/tmp</code> or <code>/tmp/viseron</code>.",
+                                  "required": true,
+                                  "default": null
+                                },
+                                {
+                                  "type": "boolean",
+                                  "name": "poll",
+                                  "description": "Poll the file system for new files. Much slower than non-polling but required for some file systems like NTFS mounts.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
+                                  "type": "boolean",
+                                  "name": "move_on_shutdown",
+                                  "description": "Move/delete files to the next tier when Viseron shuts down. Useful to not lose files when shutting down Viseron if using a RAM disk.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "days",
+                                      "description": "Days between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "hours",
+                                      "description": "Hours between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "minutes",
+                                      "description": "Minutes between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 1
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "seconds",
+                                      "description": "Seconds between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    }
+                                  ],
+                                  "name": "check_interval",
+                                  "description": "How often to check for files to move to the next tier.",
+                                  "optional": true,
+                                  "default": null
+                                }
+                              ]
+                            ],
+                            "lengthMin": 1,
+                            "name": "tiers",
+                            "description": "Tiers are used to move files between different storage locations. When a file reaches the max age or max size of a tier, it will be moved to the next tier. If the file is already in the last tier, it will be deleted. ",
+                            "required": true,
+                            "default": null
+                          }
+                        ],
+                        "name": "motion_detector",
+                        "description": "Override the default snapshot tiers for motion detection. If not set, the default tiers will be used.",
+                        "optional": true,
+                        "default": null
+                      }
+                    ],
+                    "name": "snapshots",
+                    "description": "Snapshots are images taken when events are triggered or post processors finds anything. Snapshots will be taken for object detection, motion detection, and any post processor that scans the image, for example face and license plate recognition.",
+                    "optional": true,
+                    "default": {}
+                  }
+                ],
+                "name": "storage",
+                "description": "Storage options for the camera.<br>Overrides the configuration in the <a href=/components-explorer/components/storage>storage component</a>.",
+                "optional": true,
+                "default": null
+              },
+              {
                 "type": "select",
                 "options": [
                   {
@@ -771,319 +2054,6 @@
                     ],
                     "name": "thumbnail",
                     "description": "Options for the thumbnail created on start of a recording.",
-                    "optional": true,
-                    "default": null
-                  },
-                  {
-                    "type": "map",
-                    "value": [
-                      {
-                        "type": "list",
-                        "values": [
-                          [
-                            {
-                              "type": "string",
-                              "name": "path",
-                              "description": "Path to store files in. Cannot be <code>/tmp</code> or <code>/tmp/viseron</code>.",
-                              "required": true,
-                              "default": null
-                            },
-                            {
-                              "type": "boolean",
-                              "name": "poll",
-                              "description": "Poll the file system for new files. Much slower than non-polling but required for some file systems like NTFS mounts.",
-                              "optional": true,
-                              "default": false
-                            },
-                            {
-                              "type": "boolean",
-                              "name": "move_on_shutdown",
-                              "description": "Move/delete files to the next tier when Viseron shuts down. Useful to not lose files when shutting down Viseron if using a RAM disk.",
-                              "optional": true,
-                              "default": false
-                            },
-                            {
-                              "type": "map",
-                              "value": [
-                                {
-                                  "type": "integer",
-                                  "valueMin": 0,
-                                  "name": "days",
-                                  "description": "Days between checks for files to move/delete.",
-                                  "optional": true,
-                                  "default": 0
-                                },
-                                {
-                                  "type": "integer",
-                                  "valueMin": 0,
-                                  "name": "hours",
-                                  "description": "Hours between checks for files to move/delete.",
-                                  "optional": true,
-                                  "default": 0
-                                },
-                                {
-                                  "type": "integer",
-                                  "valueMin": 0,
-                                  "name": "minutes",
-                                  "description": "Minutes between checks for files to move/delete.",
-                                  "optional": true,
-                                  "default": 1
-                                },
-                                {
-                                  "type": "integer",
-                                  "valueMin": 0,
-                                  "name": "seconds",
-                                  "description": "Seconds between checks for files to move/delete.",
-                                  "optional": true,
-                                  "default": 0
-                                }
-                              ],
-                              "name": "check_interval",
-                              "description": "How often to check for files to move to the next tier.",
-                              "optional": true,
-                              "default": null
-                            },
-                            {
-                              "type": "map",
-                              "value": [
-                                {
-                                  "type": "map",
-                                  "value": [
-                                    {
-                                      "type": "float",
-                                      "name": "gb",
-                                      "description": "Min size in GB. Added together with <code>min_mb</code>.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "float",
-                                      "name": "mb",
-                                      "description": "Min size in MB. Added together with <code>min_gb</code>.",
-                                      "optional": true,
-                                      "default": null
-                                    }
-                                  ],
-                                  "name": "min_size",
-                                  "description": "Minimum size of files to keep in this tier.",
-                                  "optional": true,
-                                  "default": {}
-                                },
-                                {
-                                  "type": "map",
-                                  "value": [
-                                    {
-                                      "type": "float",
-                                      "name": "gb",
-                                      "description": "Max size in GB. Added together with <code>max_mb</code>.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "float",
-                                      "name": "mb",
-                                      "description": "Max size in MB. Added together with <code>max_gb</code>.",
-                                      "optional": true,
-                                      "default": null
-                                    }
-                                  ],
-                                  "name": "max_size",
-                                  "description": "Maximum size of files to keep in this tier.",
-                                  "optional": true,
-                                  "default": {}
-                                },
-                                {
-                                  "type": "map",
-                                  "value": [
-                                    {
-                                      "type": "integer",
-                                      "name": "days",
-                                      "description": "Max age in days.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "integer",
-                                      "name": "hours",
-                                      "description": "Max age in hours.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "integer",
-                                      "name": "minutes",
-                                      "description": "Max age in minutes.",
-                                      "optional": true,
-                                      "default": null
-                                    }
-                                  ],
-                                  "name": "max_age",
-                                  "description": "Maximum age of files to keep in this tier.",
-                                  "optional": true,
-                                  "default": {}
-                                },
-                                {
-                                  "type": "map",
-                                  "value": [
-                                    {
-                                      "type": "integer",
-                                      "name": "days",
-                                      "description": "Min age in days.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "integer",
-                                      "name": "hours",
-                                      "description": "Min age in hours.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "integer",
-                                      "name": "minutes",
-                                      "description": "Min age in minutes.",
-                                      "optional": true,
-                                      "default": null
-                                    }
-                                  ],
-                                  "name": "min_age",
-                                  "description": "Minimum age of files to keep in this tier.",
-                                  "optional": true,
-                                  "default": {}
-                                }
-                              ],
-                              "name": "continuous",
-                              "description": "Retention rules for continuous recordings.",
-                              "optional": true,
-                              "default": null
-                            },
-                            {
-                              "type": "map",
-                              "value": [
-                                {
-                                  "type": "map",
-                                  "value": [
-                                    {
-                                      "type": "float",
-                                      "name": "gb",
-                                      "description": "Min size in GB. Added together with <code>min_mb</code>.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "float",
-                                      "name": "mb",
-                                      "description": "Min size in MB. Added together with <code>min_gb</code>.",
-                                      "optional": true,
-                                      "default": null
-                                    }
-                                  ],
-                                  "name": "min_size",
-                                  "description": "Minimum size of files to keep in this tier.",
-                                  "optional": true,
-                                  "default": {}
-                                },
-                                {
-                                  "type": "map",
-                                  "value": [
-                                    {
-                                      "type": "float",
-                                      "name": "gb",
-                                      "description": "Max size in GB. Added together with <code>max_mb</code>.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "float",
-                                      "name": "mb",
-                                      "description": "Max size in MB. Added together with <code>max_gb</code>.",
-                                      "optional": true,
-                                      "default": null
-                                    }
-                                  ],
-                                  "name": "max_size",
-                                  "description": "Maximum size of files to keep in this tier.",
-                                  "optional": true,
-                                  "default": {}
-                                },
-                                {
-                                  "type": "map",
-                                  "value": [
-                                    {
-                                      "type": "integer",
-                                      "name": "days",
-                                      "description": "Max age in days.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "integer",
-                                      "name": "hours",
-                                      "description": "Max age in hours.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "integer",
-                                      "name": "minutes",
-                                      "description": "Max age in minutes.",
-                                      "optional": true,
-                                      "default": null
-                                    }
-                                  ],
-                                  "name": "max_age",
-                                  "description": "Maximum age of files to keep in this tier.",
-                                  "optional": true,
-                                  "default": {}
-                                },
-                                {
-                                  "type": "map",
-                                  "value": [
-                                    {
-                                      "type": "integer",
-                                      "name": "days",
-                                      "description": "Min age in days.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "integer",
-                                      "name": "hours",
-                                      "description": "Min age in hours.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "integer",
-                                      "name": "minutes",
-                                      "description": "Min age in minutes.",
-                                      "optional": true,
-                                      "default": null
-                                    }
-                                  ],
-                                  "name": "min_age",
-                                  "description": "Minimum age of files to keep in this tier.",
-                                  "optional": true,
-                                  "default": {}
-                                }
-                              ],
-                              "name": "events",
-                              "description": "Retention rules for event recordings.",
-                              "optional": true,
-                              "default": null
-                            }
-                          ]
-                        ],
-                        "lengthMin": 1,
-                        "name": "tiers",
-                        "description": "Tiers are used to move files between different storage locations. When a file reaches the max age or max size of a tier, it will be moved to the next tier. If the file is already in the last tier, it will be deleted. ",
-                        "required": true,
-                        "default": null
-                      }
-                    ],
-                    "name": "storage",
-                    "description": "Storage options for the camera.<br>Overrides the configuration in the <a href=/components-explorer/components/storage>storage component</a>.",
                     "optional": true,
                     "default": null
                   },

--- a/docs/src/pages/components-explorer/components/ffmpeg/index.mdx
+++ b/docs/src/pages/components-explorer/components/ffmpeg/index.mdx
@@ -195,9 +195,9 @@ FFmpeg will write small 5 second segments of the stream to disk.<br />
 The reason for using segments instead of just starting the recorder on an event, is to support the `lookback` feature which makes it possible to record _before_ an event actually happened.
 It also makes it possible to have continuous recordings.
 
-### Store segments in memory
+### Store video segments in memory
 
-To place the segments in memory instead of writing to disk, you can mount a tmpfs disk in the container.
+To place the video segments in memory instead of writing to disk, you can mount a tmpfs disk in the container.
 This will use more memory but reduce the load on your harddrives.
 
 <details>
@@ -207,10 +207,10 @@ Example Docker command
 
 ```shell
 docker run --rm \
-  -v {recordings path}:/recordings \
-  -v {recordings path}:/segments \
-  -v {recordings path}:/snapshots \
-  -v {recordings path}:/thumbnails \
+  -v {segments path}:/segments \
+  -v {snapshots path}:/snapshots \
+  -v {thumbnails path}:/thumbnails \
+  -v {event clips path}:/event_clips \
   -v {config path}:/config \
   -v /etc/localtime:/etc/localtime:ro \
   -p 8888:8888 \
@@ -231,10 +231,10 @@ services:
     container_name: viseron
     shm_size: "1024mb"
     volumes:
-      - {recordings path}:/recordings
-      - {recordings path}:/segments
-      - {recordings path}:/snapshots
-      - {recordings path}:/thumbnails
+      - {segments path}:/segments \
+      - {snapshots path}:/snapshots \
+      - {thumbnails path}:/thumbnails \
+      - {event clips path}:/event_clips \
       - {config path}:/config
       - /etc/localtime:/etc/localtime:ro
     ports:

--- a/docs/src/pages/components-explorer/components/gstreamer/config.json
+++ b/docs/src/pages/components-explorer/components/gstreamer/config.json
@@ -192,6 +192,1289 @@
                 "default": null
               },
               {
+                "type": "map",
+                "value": [
+                  {
+                    "type": "map",
+                    "value": [
+                      {
+                        "type": "list",
+                        "values": [
+                          [
+                            {
+                              "type": "string",
+                              "name": "path",
+                              "description": "Path to store files in. Cannot be <code>/tmp</code> or <code>/tmp/viseron</code>.",
+                              "required": true,
+                              "default": null
+                            },
+                            {
+                              "type": "boolean",
+                              "name": "poll",
+                              "description": "Poll the file system for new files. Much slower than non-polling but required for some file systems like NTFS mounts.",
+                              "optional": true,
+                              "default": false
+                            },
+                            {
+                              "type": "boolean",
+                              "name": "move_on_shutdown",
+                              "description": "Move/delete files to the next tier when Viseron shuts down. Useful to not lose files when shutting down Viseron if using a RAM disk.",
+                              "optional": true,
+                              "default": false
+                            },
+                            {
+                              "type": "map",
+                              "value": [
+                                {
+                                  "type": "integer",
+                                  "valueMin": 0,
+                                  "name": "days",
+                                  "description": "Days between checks for files to move/delete.",
+                                  "optional": true,
+                                  "default": 0
+                                },
+                                {
+                                  "type": "integer",
+                                  "valueMin": 0,
+                                  "name": "hours",
+                                  "description": "Hours between checks for files to move/delete.",
+                                  "optional": true,
+                                  "default": 0
+                                },
+                                {
+                                  "type": "integer",
+                                  "valueMin": 0,
+                                  "name": "minutes",
+                                  "description": "Minutes between checks for files to move/delete.",
+                                  "optional": true,
+                                  "default": 1
+                                },
+                                {
+                                  "type": "integer",
+                                  "valueMin": 0,
+                                  "name": "seconds",
+                                  "description": "Seconds between checks for files to move/delete.",
+                                  "optional": true,
+                                  "default": 0
+                                }
+                              ],
+                              "name": "check_interval",
+                              "description": "How often to check for files to move to the next tier.",
+                              "optional": true,
+                              "default": null
+                            },
+                            {
+                              "type": "map",
+                              "value": [
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Min size in GB. Added together with <code>min_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Min size in MB. Added together with <code>min_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_size",
+                                  "description": "Minimum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Max size in GB. Added together with <code>max_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Max size in MB. Added together with <code>max_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_size",
+                                  "description": "Maximum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Max age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Max age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Max age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_age",
+                                  "description": "Maximum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Min age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Min age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Min age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_age",
+                                  "description": "Minimum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                }
+                              ],
+                              "name": "continuous",
+                              "description": "Retention rules for continuous recordings.",
+                              "optional": true,
+                              "default": null
+                            },
+                            {
+                              "type": "map",
+                              "value": [
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Min size in GB. Added together with <code>min_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Min size in MB. Added together with <code>min_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_size",
+                                  "description": "Minimum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Max size in GB. Added together with <code>max_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Max size in MB. Added together with <code>max_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_size",
+                                  "description": "Maximum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Max age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Max age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Max age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_age",
+                                  "description": "Maximum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Min age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Min age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Min age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_age",
+                                  "description": "Minimum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                }
+                              ],
+                              "name": "events",
+                              "description": "Retention rules for event recordings.",
+                              "optional": true,
+                              "default": null
+                            }
+                          ]
+                        ],
+                        "lengthMin": 1,
+                        "name": "tiers",
+                        "description": "Tiers are used to move files between different storage locations. When a file reaches the max age or max size of a tier, it will be moved to the next tier. If the file is already in the last tier, it will be deleted. ",
+                        "optional": true,
+                        "default": [
+                          {
+                            "path": "/",
+                            "events": {
+                              "max_age": {
+                                "days": 7
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "name": "recorder",
+                    "description": "Configuration for recordings.",
+                    "optional": true,
+                    "default": {}
+                  },
+                  {
+                    "type": "map",
+                    "value": [
+                      {
+                        "type": "list",
+                        "values": [
+                          [
+                            {
+                              "type": "map",
+                              "value": [
+                                {
+                                  "type": "float",
+                                  "name": "gb",
+                                  "description": "Min size in GB. Added together with <code>min_mb</code>.",
+                                  "optional": true,
+                                  "default": null
+                                },
+                                {
+                                  "type": "float",
+                                  "name": "mb",
+                                  "description": "Min size in MB. Added together with <code>min_gb</code>.",
+                                  "optional": true,
+                                  "default": null
+                                }
+                              ],
+                              "name": "min_size",
+                              "description": "Minimum size of files to keep in this tier.",
+                              "optional": true,
+                              "default": {}
+                            },
+                            {
+                              "type": "map",
+                              "value": [
+                                {
+                                  "type": "float",
+                                  "name": "gb",
+                                  "description": "Max size in GB. Added together with <code>max_mb</code>.",
+                                  "optional": true,
+                                  "default": null
+                                },
+                                {
+                                  "type": "float",
+                                  "name": "mb",
+                                  "description": "Max size in MB. Added together with <code>max_gb</code>.",
+                                  "optional": true,
+                                  "default": null
+                                }
+                              ],
+                              "name": "max_size",
+                              "description": "Maximum size of files to keep in this tier.",
+                              "optional": true,
+                              "default": {}
+                            },
+                            {
+                              "type": "map",
+                              "value": [
+                                {
+                                  "type": "integer",
+                                  "name": "days",
+                                  "description": "Max age in days.",
+                                  "optional": true,
+                                  "default": null
+                                },
+                                {
+                                  "type": "integer",
+                                  "name": "hours",
+                                  "description": "Max age in hours.",
+                                  "optional": true,
+                                  "default": null
+                                },
+                                {
+                                  "type": "integer",
+                                  "name": "minutes",
+                                  "description": "Max age in minutes.",
+                                  "optional": true,
+                                  "default": null
+                                }
+                              ],
+                              "name": "max_age",
+                              "description": "Maximum age of files to keep in this tier.",
+                              "optional": true,
+                              "default": {}
+                            },
+                            {
+                              "type": "map",
+                              "value": [
+                                {
+                                  "type": "integer",
+                                  "name": "days",
+                                  "description": "Min age in days.",
+                                  "optional": true,
+                                  "default": null
+                                },
+                                {
+                                  "type": "integer",
+                                  "name": "hours",
+                                  "description": "Min age in hours.",
+                                  "optional": true,
+                                  "default": null
+                                },
+                                {
+                                  "type": "integer",
+                                  "name": "minutes",
+                                  "description": "Min age in minutes.",
+                                  "optional": true,
+                                  "default": null
+                                }
+                              ],
+                              "name": "min_age",
+                              "description": "Minimum age of files to keep in this tier.",
+                              "optional": true,
+                              "default": {}
+                            },
+                            {
+                              "type": "string",
+                              "name": "path",
+                              "description": "Path to store files in. Cannot be <code>/tmp</code> or <code>/tmp/viseron</code>.",
+                              "required": true,
+                              "default": null
+                            },
+                            {
+                              "type": "boolean",
+                              "name": "poll",
+                              "description": "Poll the file system for new files. Much slower than non-polling but required for some file systems like NTFS mounts.",
+                              "optional": true,
+                              "default": false
+                            },
+                            {
+                              "type": "boolean",
+                              "name": "move_on_shutdown",
+                              "description": "Move/delete files to the next tier when Viseron shuts down. Useful to not lose files when shutting down Viseron if using a RAM disk.",
+                              "optional": true,
+                              "default": false
+                            },
+                            {
+                              "type": "map",
+                              "value": [
+                                {
+                                  "type": "integer",
+                                  "valueMin": 0,
+                                  "name": "days",
+                                  "description": "Days between checks for files to move/delete.",
+                                  "optional": true,
+                                  "default": 0
+                                },
+                                {
+                                  "type": "integer",
+                                  "valueMin": 0,
+                                  "name": "hours",
+                                  "description": "Hours between checks for files to move/delete.",
+                                  "optional": true,
+                                  "default": 0
+                                },
+                                {
+                                  "type": "integer",
+                                  "valueMin": 0,
+                                  "name": "minutes",
+                                  "description": "Minutes between checks for files to move/delete.",
+                                  "optional": true,
+                                  "default": 1
+                                },
+                                {
+                                  "type": "integer",
+                                  "valueMin": 0,
+                                  "name": "seconds",
+                                  "description": "Seconds between checks for files to move/delete.",
+                                  "optional": true,
+                                  "default": 0
+                                }
+                              ],
+                              "name": "check_interval",
+                              "description": "How often to check for files to move to the next tier.",
+                              "optional": true,
+                              "default": null
+                            }
+                          ]
+                        ],
+                        "lengthMin": 1,
+                        "name": "tiers",
+                        "description": "Default tiers for all domains, unless overridden in the domain configuration.<br>Tiers are used to move files between different storage locations. When a file reaches the max age or max size of a tier, it will be moved to the next tier. If the file is already in the last tier, it will be deleted.  ",
+                        "optional": true,
+                        "default": [
+                          {
+                            "path": "/",
+                            "max_age": {
+                              "days": 7
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "map",
+                        "value": [
+                          {
+                            "type": "list",
+                            "values": [
+                              [
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Min size in GB. Added together with <code>min_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Min size in MB. Added together with <code>min_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_size",
+                                  "description": "Minimum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Max size in GB. Added together with <code>max_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Max size in MB. Added together with <code>max_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_size",
+                                  "description": "Maximum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Max age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Max age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Max age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_age",
+                                  "description": "Maximum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Min age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Min age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Min age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_age",
+                                  "description": "Minimum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "string",
+                                  "name": "path",
+                                  "description": "Path to store files in. Cannot be <code>/tmp</code> or <code>/tmp/viseron</code>.",
+                                  "required": true,
+                                  "default": null
+                                },
+                                {
+                                  "type": "boolean",
+                                  "name": "poll",
+                                  "description": "Poll the file system for new files. Much slower than non-polling but required for some file systems like NTFS mounts.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
+                                  "type": "boolean",
+                                  "name": "move_on_shutdown",
+                                  "description": "Move/delete files to the next tier when Viseron shuts down. Useful to not lose files when shutting down Viseron if using a RAM disk.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "days",
+                                      "description": "Days between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "hours",
+                                      "description": "Hours between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "minutes",
+                                      "description": "Minutes between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 1
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "seconds",
+                                      "description": "Seconds between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    }
+                                  ],
+                                  "name": "check_interval",
+                                  "description": "How often to check for files to move to the next tier.",
+                                  "optional": true,
+                                  "default": null
+                                }
+                              ]
+                            ],
+                            "lengthMin": 1,
+                            "name": "tiers",
+                            "description": "Tiers are used to move files between different storage locations. When a file reaches the max age or max size of a tier, it will be moved to the next tier. If the file is already in the last tier, it will be deleted. ",
+                            "required": true,
+                            "default": null
+                          }
+                        ],
+                        "name": "face_recognition",
+                        "description": "Override the default snapshot tiers for face recognition. If not set, the default tiers will be used.",
+                        "optional": true,
+                        "default": null
+                      },
+                      {
+                        "type": "map",
+                        "value": [
+                          {
+                            "type": "list",
+                            "values": [
+                              [
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Min size in GB. Added together with <code>min_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Min size in MB. Added together with <code>min_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_size",
+                                  "description": "Minimum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Max size in GB. Added together with <code>max_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Max size in MB. Added together with <code>max_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_size",
+                                  "description": "Maximum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Max age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Max age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Max age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_age",
+                                  "description": "Maximum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Min age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Min age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Min age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_age",
+                                  "description": "Minimum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "string",
+                                  "name": "path",
+                                  "description": "Path to store files in. Cannot be <code>/tmp</code> or <code>/tmp/viseron</code>.",
+                                  "required": true,
+                                  "default": null
+                                },
+                                {
+                                  "type": "boolean",
+                                  "name": "poll",
+                                  "description": "Poll the file system for new files. Much slower than non-polling but required for some file systems like NTFS mounts.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
+                                  "type": "boolean",
+                                  "name": "move_on_shutdown",
+                                  "description": "Move/delete files to the next tier when Viseron shuts down. Useful to not lose files when shutting down Viseron if using a RAM disk.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "days",
+                                      "description": "Days between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "hours",
+                                      "description": "Hours between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "minutes",
+                                      "description": "Minutes between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 1
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "seconds",
+                                      "description": "Seconds between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    }
+                                  ],
+                                  "name": "check_interval",
+                                  "description": "How often to check for files to move to the next tier.",
+                                  "optional": true,
+                                  "default": null
+                                }
+                              ]
+                            ],
+                            "lengthMin": 1,
+                            "name": "tiers",
+                            "description": "Tiers are used to move files between different storage locations. When a file reaches the max age or max size of a tier, it will be moved to the next tier. If the file is already in the last tier, it will be deleted. ",
+                            "required": true,
+                            "default": null
+                          }
+                        ],
+                        "name": "object_detector",
+                        "description": "Override the default snapshot tiers for object detection. If not set, the default tiers will be used.",
+                        "optional": true,
+                        "default": null
+                      },
+                      {
+                        "type": "map",
+                        "value": [
+                          {
+                            "type": "list",
+                            "values": [
+                              [
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Min size in GB. Added together with <code>min_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Min size in MB. Added together with <code>min_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_size",
+                                  "description": "Minimum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Max size in GB. Added together with <code>max_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Max size in MB. Added together with <code>max_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_size",
+                                  "description": "Maximum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Max age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Max age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Max age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_age",
+                                  "description": "Maximum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Min age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Min age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Min age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_age",
+                                  "description": "Minimum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "string",
+                                  "name": "path",
+                                  "description": "Path to store files in. Cannot be <code>/tmp</code> or <code>/tmp/viseron</code>.",
+                                  "required": true,
+                                  "default": null
+                                },
+                                {
+                                  "type": "boolean",
+                                  "name": "poll",
+                                  "description": "Poll the file system for new files. Much slower than non-polling but required for some file systems like NTFS mounts.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
+                                  "type": "boolean",
+                                  "name": "move_on_shutdown",
+                                  "description": "Move/delete files to the next tier when Viseron shuts down. Useful to not lose files when shutting down Viseron if using a RAM disk.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "days",
+                                      "description": "Days between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "hours",
+                                      "description": "Hours between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "minutes",
+                                      "description": "Minutes between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 1
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "seconds",
+                                      "description": "Seconds between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    }
+                                  ],
+                                  "name": "check_interval",
+                                  "description": "How often to check for files to move to the next tier.",
+                                  "optional": true,
+                                  "default": null
+                                }
+                              ]
+                            ],
+                            "lengthMin": 1,
+                            "name": "tiers",
+                            "description": "Tiers are used to move files between different storage locations. When a file reaches the max age or max size of a tier, it will be moved to the next tier. If the file is already in the last tier, it will be deleted. ",
+                            "required": true,
+                            "default": null
+                          }
+                        ],
+                        "name": "license_plate_recognition",
+                        "description": "Override the default snapshot tiers for license plate recognition. If not set, the default tiers will be used.",
+                        "optional": true,
+                        "default": null
+                      },
+                      {
+                        "type": "map",
+                        "value": [
+                          {
+                            "type": "list",
+                            "values": [
+                              [
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Min size in GB. Added together with <code>min_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Min size in MB. Added together with <code>min_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_size",
+                                  "description": "Minimum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "float",
+                                      "name": "gb",
+                                      "description": "Max size in GB. Added together with <code>max_mb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "float",
+                                      "name": "mb",
+                                      "description": "Max size in MB. Added together with <code>max_gb</code>.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_size",
+                                  "description": "Maximum size of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Max age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Max age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Max age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "max_age",
+                                  "description": "Maximum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "name": "days",
+                                      "description": "Min age in days.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "hours",
+                                      "description": "Min age in hours.",
+                                      "optional": true,
+                                      "default": null
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "name": "minutes",
+                                      "description": "Min age in minutes.",
+                                      "optional": true,
+                                      "default": null
+                                    }
+                                  ],
+                                  "name": "min_age",
+                                  "description": "Minimum age of files to keep in this tier.",
+                                  "optional": true,
+                                  "default": {}
+                                },
+                                {
+                                  "type": "string",
+                                  "name": "path",
+                                  "description": "Path to store files in. Cannot be <code>/tmp</code> or <code>/tmp/viseron</code>.",
+                                  "required": true,
+                                  "default": null
+                                },
+                                {
+                                  "type": "boolean",
+                                  "name": "poll",
+                                  "description": "Poll the file system for new files. Much slower than non-polling but required for some file systems like NTFS mounts.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
+                                  "type": "boolean",
+                                  "name": "move_on_shutdown",
+                                  "description": "Move/delete files to the next tier when Viseron shuts down. Useful to not lose files when shutting down Viseron if using a RAM disk.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
+                                  "type": "map",
+                                  "value": [
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "days",
+                                      "description": "Days between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "hours",
+                                      "description": "Hours between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "minutes",
+                                      "description": "Minutes between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 1
+                                    },
+                                    {
+                                      "type": "integer",
+                                      "valueMin": 0,
+                                      "name": "seconds",
+                                      "description": "Seconds between checks for files to move/delete.",
+                                      "optional": true,
+                                      "default": 0
+                                    }
+                                  ],
+                                  "name": "check_interval",
+                                  "description": "How often to check for files to move to the next tier.",
+                                  "optional": true,
+                                  "default": null
+                                }
+                              ]
+                            ],
+                            "lengthMin": 1,
+                            "name": "tiers",
+                            "description": "Tiers are used to move files between different storage locations. When a file reaches the max age or max size of a tier, it will be moved to the next tier. If the file is already in the last tier, it will be deleted. ",
+                            "required": true,
+                            "default": null
+                          }
+                        ],
+                        "name": "motion_detector",
+                        "description": "Override the default snapshot tiers for motion detection. If not set, the default tiers will be used.",
+                        "optional": true,
+                        "default": null
+                      }
+                    ],
+                    "name": "snapshots",
+                    "description": "Snapshots are images taken when events are triggered or post processors finds anything. Snapshots will be taken for object detection, motion detection, and any post processor that scans the image, for example face and license plate recognition.",
+                    "optional": true,
+                    "default": {}
+                  }
+                ],
+                "name": "storage",
+                "description": "Storage options for the camera.<br>Overrides the configuration in the <a href=/components-explorer/components/storage>storage component</a>.",
+                "optional": true,
+                "default": null
+              },
+              {
                 "type": "select",
                 "options": [
                   {
@@ -513,319 +1796,6 @@
                     ],
                     "name": "thumbnail",
                     "description": "Options for the thumbnail created on start of a recording.",
-                    "optional": true,
-                    "default": null
-                  },
-                  {
-                    "type": "map",
-                    "value": [
-                      {
-                        "type": "list",
-                        "values": [
-                          [
-                            {
-                              "type": "string",
-                              "name": "path",
-                              "description": "Path to store files in. Cannot be <code>/tmp</code> or <code>/tmp/viseron</code>.",
-                              "required": true,
-                              "default": null
-                            },
-                            {
-                              "type": "boolean",
-                              "name": "poll",
-                              "description": "Poll the file system for new files. Much slower than non-polling but required for some file systems like NTFS mounts.",
-                              "optional": true,
-                              "default": false
-                            },
-                            {
-                              "type": "boolean",
-                              "name": "move_on_shutdown",
-                              "description": "Move/delete files to the next tier when Viseron shuts down. Useful to not lose files when shutting down Viseron if using a RAM disk.",
-                              "optional": true,
-                              "default": false
-                            },
-                            {
-                              "type": "map",
-                              "value": [
-                                {
-                                  "type": "integer",
-                                  "valueMin": 0,
-                                  "name": "days",
-                                  "description": "Days between checks for files to move/delete.",
-                                  "optional": true,
-                                  "default": 0
-                                },
-                                {
-                                  "type": "integer",
-                                  "valueMin": 0,
-                                  "name": "hours",
-                                  "description": "Hours between checks for files to move/delete.",
-                                  "optional": true,
-                                  "default": 0
-                                },
-                                {
-                                  "type": "integer",
-                                  "valueMin": 0,
-                                  "name": "minutes",
-                                  "description": "Minutes between checks for files to move/delete.",
-                                  "optional": true,
-                                  "default": 1
-                                },
-                                {
-                                  "type": "integer",
-                                  "valueMin": 0,
-                                  "name": "seconds",
-                                  "description": "Seconds between checks for files to move/delete.",
-                                  "optional": true,
-                                  "default": 0
-                                }
-                              ],
-                              "name": "check_interval",
-                              "description": "How often to check for files to move to the next tier.",
-                              "optional": true,
-                              "default": null
-                            },
-                            {
-                              "type": "map",
-                              "value": [
-                                {
-                                  "type": "map",
-                                  "value": [
-                                    {
-                                      "type": "float",
-                                      "name": "gb",
-                                      "description": "Min size in GB. Added together with <code>min_mb</code>.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "float",
-                                      "name": "mb",
-                                      "description": "Min size in MB. Added together with <code>min_gb</code>.",
-                                      "optional": true,
-                                      "default": null
-                                    }
-                                  ],
-                                  "name": "min_size",
-                                  "description": "Minimum size of files to keep in this tier.",
-                                  "optional": true,
-                                  "default": {}
-                                },
-                                {
-                                  "type": "map",
-                                  "value": [
-                                    {
-                                      "type": "float",
-                                      "name": "gb",
-                                      "description": "Max size in GB. Added together with <code>max_mb</code>.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "float",
-                                      "name": "mb",
-                                      "description": "Max size in MB. Added together with <code>max_gb</code>.",
-                                      "optional": true,
-                                      "default": null
-                                    }
-                                  ],
-                                  "name": "max_size",
-                                  "description": "Maximum size of files to keep in this tier.",
-                                  "optional": true,
-                                  "default": {}
-                                },
-                                {
-                                  "type": "map",
-                                  "value": [
-                                    {
-                                      "type": "integer",
-                                      "name": "days",
-                                      "description": "Max age in days.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "integer",
-                                      "name": "hours",
-                                      "description": "Max age in hours.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "integer",
-                                      "name": "minutes",
-                                      "description": "Max age in minutes.",
-                                      "optional": true,
-                                      "default": null
-                                    }
-                                  ],
-                                  "name": "max_age",
-                                  "description": "Maximum age of files to keep in this tier.",
-                                  "optional": true,
-                                  "default": {}
-                                },
-                                {
-                                  "type": "map",
-                                  "value": [
-                                    {
-                                      "type": "integer",
-                                      "name": "days",
-                                      "description": "Min age in days.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "integer",
-                                      "name": "hours",
-                                      "description": "Min age in hours.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "integer",
-                                      "name": "minutes",
-                                      "description": "Min age in minutes.",
-                                      "optional": true,
-                                      "default": null
-                                    }
-                                  ],
-                                  "name": "min_age",
-                                  "description": "Minimum age of files to keep in this tier.",
-                                  "optional": true,
-                                  "default": {}
-                                }
-                              ],
-                              "name": "continuous",
-                              "description": "Retention rules for continuous recordings.",
-                              "optional": true,
-                              "default": null
-                            },
-                            {
-                              "type": "map",
-                              "value": [
-                                {
-                                  "type": "map",
-                                  "value": [
-                                    {
-                                      "type": "float",
-                                      "name": "gb",
-                                      "description": "Min size in GB. Added together with <code>min_mb</code>.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "float",
-                                      "name": "mb",
-                                      "description": "Min size in MB. Added together with <code>min_gb</code>.",
-                                      "optional": true,
-                                      "default": null
-                                    }
-                                  ],
-                                  "name": "min_size",
-                                  "description": "Minimum size of files to keep in this tier.",
-                                  "optional": true,
-                                  "default": {}
-                                },
-                                {
-                                  "type": "map",
-                                  "value": [
-                                    {
-                                      "type": "float",
-                                      "name": "gb",
-                                      "description": "Max size in GB. Added together with <code>max_mb</code>.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "float",
-                                      "name": "mb",
-                                      "description": "Max size in MB. Added together with <code>max_gb</code>.",
-                                      "optional": true,
-                                      "default": null
-                                    }
-                                  ],
-                                  "name": "max_size",
-                                  "description": "Maximum size of files to keep in this tier.",
-                                  "optional": true,
-                                  "default": {}
-                                },
-                                {
-                                  "type": "map",
-                                  "value": [
-                                    {
-                                      "type": "integer",
-                                      "name": "days",
-                                      "description": "Max age in days.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "integer",
-                                      "name": "hours",
-                                      "description": "Max age in hours.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "integer",
-                                      "name": "minutes",
-                                      "description": "Max age in minutes.",
-                                      "optional": true,
-                                      "default": null
-                                    }
-                                  ],
-                                  "name": "max_age",
-                                  "description": "Maximum age of files to keep in this tier.",
-                                  "optional": true,
-                                  "default": {}
-                                },
-                                {
-                                  "type": "map",
-                                  "value": [
-                                    {
-                                      "type": "integer",
-                                      "name": "days",
-                                      "description": "Min age in days.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "integer",
-                                      "name": "hours",
-                                      "description": "Min age in hours.",
-                                      "optional": true,
-                                      "default": null
-                                    },
-                                    {
-                                      "type": "integer",
-                                      "name": "minutes",
-                                      "description": "Min age in minutes.",
-                                      "optional": true,
-                                      "default": null
-                                    }
-                                  ],
-                                  "name": "min_age",
-                                  "description": "Minimum age of files to keep in this tier.",
-                                  "optional": true,
-                                  "default": {}
-                                }
-                              ],
-                              "name": "events",
-                              "description": "Retention rules for event recordings.",
-                              "optional": true,
-                              "default": null
-                            }
-                          ]
-                        ],
-                        "lengthMin": 1,
-                        "name": "tiers",
-                        "description": "Tiers are used to move files between different storage locations. When a file reaches the max age or max size of a tier, it will be moved to the next tier. If the file is already in the last tier, it will be deleted. ",
-                        "required": true,
-                        "default": null
-                      }
-                    ],
-                    "name": "storage",
-                    "description": "Storage options for the camera.<br>Overrides the configuration in the <a href=/components-explorer/components/storage>storage component</a>.",
                     "optional": true,
                     "default": null
                   },

--- a/docs/src/pages/components-explorer/components/logger/index.mdx
+++ b/docs/src/pages/components-explorer/components/logger/index.mdx
@@ -64,10 +64,10 @@ If you want to rotate the log file based on size and also keep a certain number 
 
 ```shell
 docker run --rm \
-  -v {recordings path}:/recordings \
-  -v {recordings path}:/segments \
-  -v {recordings path}:/snapshots \
-  -v {recordings path}:/thumbnails \
+  -v {segments path}:/segments \
+  -v {snapshots path}:/snapshots \
+  -v {thumbnails path}:/thumbnails \
+  -v {event clips path}:/event_clips \
   -v {config path}:/config \
   -v /etc/localtime:/etc/localtime:ro \
   -p 8888:8888 \
@@ -92,10 +92,10 @@ services:
     container_name: viseron
     shm_size: "1024mb"
     volumes:
-      - {recordings path}:/recordings
-      - {recordings path}:/segments
-      - {recordings path}:/snapshots
-      - {recordings path}:/thumbnails
+      - {segments path}:/segments \
+      - {snapshots path}:/snapshots \
+      - {thumbnails path}:/thumbnails \
+      - {event clips path}:/event_clips \
       - {config path}:/config
       - /etc/localtime:/etc/localtime:ro
     ports:

--- a/rootfs/etc/cont-init.d/10-adduser
+++ b/rootfs/etc/cont-init.d/10-adduser
@@ -8,15 +8,11 @@ PGID=${PGID:-0}
 groupmod -o -g "$PGID" abc
 usermod -o -u "$PUID" abc
 
-mkdir -p /config
-mkdir -p /recordings
-mkdir -p /segments
-mkdir -p /snapshots
-mkdir -p /thumbnails
-
 chown -R abc:abc /home/abc/bin
 chown -R --silent abc:abc /config || :
+# Remove /recordings in a future release, it's deprecated in favor of /event_clips
 chown -R --silent abc:abc /recordings || :
+chown -R --silent abc:abc /event_clips || :
 chown -R --silent abc:abc /segments || :
 chown -R --silent abc:abc /snapshots || :
 chown -R --silent abc:abc /thumbnails || :

--- a/tests/components/storage/test__init__.py
+++ b/tests/components/storage/test__init__.py
@@ -16,7 +16,13 @@ from viseron.components.storage.const import (
     CONFIG_CONTINUOUS,
     CONFIG_DAYS,
     CONFIG_EVENTS,
+    CONFIG_GB,
     CONFIG_HOURS,
+    CONFIG_MAX_AGE,
+    CONFIG_MAX_SIZE,
+    CONFIG_MB,
+    CONFIG_MIN_AGE,
+    CONFIG_MIN_SIZE,
     CONFIG_MINUTES,
     CONFIG_MOVE_ON_SHUTDOWN,
     CONFIG_PATH,
@@ -34,7 +40,7 @@ from tests.common import MockCamera
 if TYPE_CHECKING:
     from viseron import Viseron
 
-CONFIG = {
+TIER_CONFIG = {
     CONFIG_RECORDER: {CONFIG_TIERS: DEFAULT_RECORDER_TIERS},
     CONFIG_SNAPSHOTS: {"test": "test"},
 }
@@ -44,80 +50,142 @@ CONFIG = {
     "config, camera_config, expected",
     [
         (  # Test default config
-            CONFIG,
+            TIER_CONFIG,
             {
                 CONFIG_RECORDER: {
                     CONFIG_CONTINUOUS: {},
                     CONFIG_EVENTS: {},
-                    CONFIG_STORAGE: {},
                 },
+                CONFIG_STORAGE: None,
             },
-            CONFIG,
+            TIER_CONFIG,
         ),
         (  # Test overriding using events/continuous
-            CONFIG,
+            TIER_CONFIG,
             {
                 CONFIG_RECORDER: {
-                    CONFIG_CONTINUOUS: {"test": 123},
-                    CONFIG_EVENTS: {"test": 456},
-                    CONFIG_STORAGE: {},
-                }
+                    CONFIG_CONTINUOUS: {CONFIG_MAX_AGE: {CONFIG_DAYS: 123}},
+                    CONFIG_EVENTS: {CONFIG_MAX_AGE: {CONFIG_DAYS: 456}},
+                },
+                CONFIG_STORAGE: None,
             },
             {
                 CONFIG_RECORDER: {
                     CONFIG_TIERS: [
                         {
-                            CONFIG_PATH: "/",
-                            CONFIG_CONTINUOUS: {"test": 123},
-                            CONFIG_EVENTS: {"test": 456},
+                            CONFIG_CHECK_INTERVAL: {
+                                CONFIG_DAYS: 0,
+                                CONFIG_HOURS: 0,
+                                CONFIG_MINUTES: 1,
+                                CONFIG_SECONDS: 0,
+                            },
+                            CONFIG_CONTINUOUS: {
+                                CONFIG_MAX_AGE: {
+                                    CONFIG_DAYS: 123,
+                                    CONFIG_HOURS: None,
+                                    CONFIG_MINUTES: None,
+                                },
+                                CONFIG_MAX_SIZE: {CONFIG_GB: None, CONFIG_MB: None},
+                                CONFIG_MIN_AGE: {
+                                    CONFIG_DAYS: None,
+                                    CONFIG_HOURS: None,
+                                    CONFIG_MINUTES: None,
+                                },
+                                CONFIG_MIN_SIZE: {CONFIG_GB: None, CONFIG_MB: None},
+                            },
+                            CONFIG_EVENTS: {
+                                CONFIG_MAX_AGE: {
+                                    CONFIG_DAYS: 456,
+                                    CONFIG_HOURS: None,
+                                    CONFIG_MINUTES: None,
+                                },
+                                CONFIG_MAX_SIZE: {CONFIG_GB: None, CONFIG_MB: None},
+                                CONFIG_MIN_AGE: {
+                                    CONFIG_DAYS: None,
+                                    CONFIG_HOURS: None,
+                                    CONFIG_MINUTES: None,
+                                },
+                                CONFIG_MIN_SIZE: {CONFIG_GB: None, CONFIG_MB: None},
+                            },
                             CONFIG_MOVE_ON_SHUTDOWN: False,
+                            CONFIG_PATH: "/",
                             CONFIG_POLL: False,
-                        },
+                        }
                     ]
                 },
-                CONFIG_SNAPSHOTS: CONFIG[CONFIG_SNAPSHOTS],
+                CONFIG_SNAPSHOTS: TIER_CONFIG[CONFIG_SNAPSHOTS],
             },
         ),
         (  # Test overriding using tiers
-            CONFIG,
+            TIER_CONFIG,
             {
                 CONFIG_RECORDER: {
                     CONFIG_CONTINUOUS: {},
                     CONFIG_EVENTS: {},
-                    CONFIG_STORAGE: {
+                },
+                CONFIG_STORAGE: {
+                    CONFIG_RECORDER: {
                         CONFIG_TIERS: [
                             {
                                 CONFIG_PATH: "/test",
-                                CONFIG_CONTINUOUS: {"test": 123},
-                                CONFIG_EVENTS: {"test": 456},
+                                CONFIG_CONTINUOUS: {CONFIG_MAX_AGE: {CONFIG_DAYS: 123}},
+                                CONFIG_EVENTS: {CONFIG_MAX_AGE: {CONFIG_DAYS: 456}},
                                 CONFIG_CHECK_INTERVAL: {
                                     CONFIG_DAYS: 0,
                                     CONFIG_HOURS: 0,
                                     CONFIG_MINUTES: 0,
-                                    CONFIG_SECONDS: 0,
+                                    CONFIG_SECONDS: 5,
                                 },
                             },
                         ]
-                    },
-                }
+                    }
+                },
             },
             {
                 CONFIG_RECORDER: {
                     CONFIG_TIERS: [
                         {
-                            CONFIG_PATH: "/test",
-                            CONFIG_CONTINUOUS: {"test": 123},
-                            CONFIG_EVENTS: {"test": 456},
                             CONFIG_CHECK_INTERVAL: {
                                 CONFIG_DAYS: 0,
                                 CONFIG_HOURS: 0,
                                 CONFIG_MINUTES: 0,
-                                CONFIG_SECONDS: 0,
+                                CONFIG_SECONDS: 5,
                             },
-                        },
+                            CONFIG_CONTINUOUS: {
+                                CONFIG_MAX_AGE: {
+                                    CONFIG_DAYS: 123,
+                                    CONFIG_HOURS: None,
+                                    CONFIG_MINUTES: None,
+                                },
+                                CONFIG_MAX_SIZE: {CONFIG_GB: None, CONFIG_MB: None},
+                                CONFIG_MIN_AGE: {
+                                    CONFIG_DAYS: None,
+                                    CONFIG_HOURS: None,
+                                    CONFIG_MINUTES: None,
+                                },
+                                CONFIG_MIN_SIZE: {CONFIG_GB: None, CONFIG_MB: None},
+                            },
+                            CONFIG_EVENTS: {
+                                CONFIG_MAX_AGE: {
+                                    CONFIG_DAYS: 456,
+                                    CONFIG_HOURS: None,
+                                    CONFIG_MINUTES: None,
+                                },
+                                CONFIG_MAX_SIZE: {CONFIG_GB: None, CONFIG_MB: None},
+                                CONFIG_MIN_AGE: {
+                                    CONFIG_DAYS: None,
+                                    CONFIG_HOURS: None,
+                                    CONFIG_MINUTES: None,
+                                },
+                                CONFIG_MIN_SIZE: {CONFIG_GB: None, CONFIG_MB: None},
+                            },
+                            CONFIG_MOVE_ON_SHUTDOWN: False,
+                            CONFIG_PATH: "/test/",
+                            CONFIG_POLL: False,
+                        }
                     ]
                 },
-                CONFIG_SNAPSHOTS: CONFIG[CONFIG_SNAPSHOTS],
+                CONFIG_SNAPSHOTS: TIER_CONFIG[CONFIG_SNAPSHOTS],
             },
         ),
     ],

--- a/tests/components/storage/test_config.py
+++ b/tests/components/storage/test_config.py
@@ -1,11 +1,13 @@
 """Test storage component config."""
 
 from contextlib import nullcontext
+from unittest.mock import Mock, patch
 
 import pytest
 import voluptuous as vol
 
 from viseron.components.storage import CONFIG_SCHEMA, validate_tiers
+from viseron.components.storage.config import _check_path_exists
 
 
 def create_time_config(days=None, hours=None, minutes=None):
@@ -290,11 +292,72 @@ TEST_CASES = [
 def test_validate_tiers(config, raises, error_message):
     """Test validate_tiers."""
     _config = None
-    with raises as exc_info:
-        _config = validate_tiers(config)
+    # Patch the _check_path_exists function
+    with patch("viseron.components.storage.config._check_path_exists"):
+        with raises as exc_info:
+            _config = validate_tiers(config)
 
     if error_message and exc_info:
         assert str(exc_info.value) == error_message
 
     if _config:
         assert _config == config
+
+
+def test_check_path_exists():
+    """Test _check_path_exists."""
+    with patch("os.path.exists", return_value=True) as mock_exists:
+        _check_path_exists(
+            create_tier(
+                path="/tier1",
+                events={"max_age": {"days": 7}},
+            ),
+            "recorder",
+        )
+
+        mock_exists.reset_mock()
+
+        # Test recorder with custom path
+        tier = create_tier(path="/custom/path/")
+        _check_path_exists(tier, "recorder")
+        mock_exists.assert_called_once_with("/custom/path/")
+        mock_exists.reset_mock()
+
+        # Test snapshots with root path
+        tier = create_tier_snapshots(path="/")
+        _check_path_exists(tier, "snapshots")
+        mock_exists.assert_called_once_with("/snapshots")
+        mock_exists.reset_mock()
+
+        # Test snapshots with custom path
+        tier = create_tier_snapshots(path="/custom/snapshots/")
+        _check_path_exists(tier, "snapshots")
+        mock_exists.assert_called_once_with("/custom/snapshots/")
+        mock_exists.reset_mock()
+
+    # Test error cases when paths don't exist
+    mock_exists = Mock(return_value=False)
+    with patch("os.path.exists", mock_exists):
+        # Test recorder root path error
+        tier = create_tier(path="/")
+        with pytest.raises(vol.Invalid, match="The /segments folder does not exist"):
+            _check_path_exists(tier, "recorder")
+
+        # Test recorder custom path error
+        tier = create_tier(path="/custom/path/")
+        with pytest.raises(
+            vol.Invalid, match="The /custom/path/ folder does not exist"
+        ):
+            _check_path_exists(tier, "recorder")
+
+        # Test snapshots root path error
+        tier = create_tier_snapshots(path="/")
+        with pytest.raises(vol.Invalid, match="The /snapshots folder does not exist"):
+            _check_path_exists(tier, "snapshots")
+
+        # Test snapshots custom path error
+        tier = create_tier_snapshots(path="/custom/snapshots/")
+        with pytest.raises(
+            vol.Invalid, match="The /custom/snapshots/ folder does not exist"
+        ):
+            _check_path_exists(tier, "snapshots")

--- a/tests/components/storage/test_tier_handler.py
+++ b/tests/components/storage/test_tier_handler.py
@@ -14,7 +14,7 @@ from viseron.components.storage.const import (
 )
 from viseron.components.storage.models import Recordings
 from viseron.components.storage.tier_handler import (
-    RecordingsTierHandler,
+    EventClipTierHandler,
     SegmentsTierHandler,
     ThumbnailTierHandler,
     find_next_tier_segments,
@@ -283,7 +283,7 @@ class TestSegmentsTierHandler(BaseTestWithRecordings):
                 None,
             )
             tier_handlers.append(tier_handler)
-        recordings_tier_handler = MagicMock(spec=RecordingsTierHandler)
+        recordings_tier_handler = MagicMock(spec=EventClipTierHandler)
         thumbnail_tier_handler = MagicMock(spec=ThumbnailTierHandler)
         vis.data[STORAGE_COMPONENT].camera_tier_handlers = {
             "test": {
@@ -291,7 +291,7 @@ class TestSegmentsTierHandler(BaseTestWithRecordings):
                     {
                         "segments": tier_handler,
                         "thumbnails": thumbnail_tier_handler,
-                        "recordings": recordings_tier_handler,
+                        "event_clips": recordings_tier_handler,
                     }
                     for tier_handler in tier_handlers
                 ]

--- a/tests/components/webserver/test_tiered_file_handler.py
+++ b/tests/components/webserver/test_tiered_file_handler.py
@@ -31,8 +31,8 @@ class TestTieredFileHandler(TestAppBaseNoAuth):
 
         tier1 = "/tmp/viseron/test/tier1"
         tier2 = "/tmp/viseron/test/tier2"
-        os.makedirs("/tmp/viseron/test/tier1", exist_ok=False)
-        os.makedirs("/tmp/viseron/test/tier2", exist_ok=False)
+        os.makedirs("/tmp/viseron/test/tier1", exist_ok=True)
+        os.makedirs("/tmp/viseron/test/tier2", exist_ok=True)
 
         self._app.add_handlers(
             r".*",

--- a/viseron/components/storage/__init__.py
+++ b/viseron/components/storage/__init__.py
@@ -33,18 +33,28 @@ from viseron.components.storage.const import (
     DATABASE_URL,
     DEFAULT_COMPONENT,
     DESC_COMPONENT,
+    TIER_CATEGORY_RECORDER,
+    TIER_CATEGORY_SNAPSHOTS,
+    TIER_SUBCATEGORY_EVENT_CLIPS,
+    TIER_SUBCATEGORY_FACE_RECOGNITION,
+    TIER_SUBCATEGORY_LICENSE_PLATE_RECOGNITION,
+    TIER_SUBCATEGORY_MOTION_DETECTOR,
+    TIER_SUBCATEGORY_OBJECT_DETECTOR,
+    TIER_SUBCATEGORY_SEGMENTS,
+    TIER_SUBCATEGORY_THUMBNAILS,
 )
 from viseron.components.storage.jobs import CleanupManager
 from viseron.components.storage.models import Base, FilesMeta, Motion, Recordings
 from viseron.components.storage.tier_handler import (
-    RecordingsTierHandler,
+    EventClipTierHandler,
     SegmentsTierHandler,
     SnapshotTierHandler,
     ThumbnailTierHandler,
 )
 from viseron.components.storage.util import (
     RequestedFilesCount,
-    get_recorder_path,
+    get_event_clips_path,
+    get_segments_path,
     get_snapshots_path,
     get_thumbnails_path,
 )
@@ -82,7 +92,7 @@ class TierSubcategory(TypedDict):
         SnapshotTierHandler
         | SegmentsTierHandler
         | ThumbnailTierHandler
-        | RecordingsTierHandler
+        | EventClipTierHandler
     ]
 
 
@@ -94,35 +104,35 @@ class TierCategories(TypedDict):
 
 
 TIER_CATEGORIES: TierCategories = {
-    "recorder": [
+    TIER_CATEGORY_RECORDER: [
         {
-            "subcategory": "segments",
+            "subcategory": TIER_SUBCATEGORY_SEGMENTS,
             "tier_handler": SegmentsTierHandler,
         },
         {
-            "subcategory": "recordings",
-            "tier_handler": RecordingsTierHandler,
+            "subcategory": TIER_SUBCATEGORY_EVENT_CLIPS,
+            "tier_handler": EventClipTierHandler,
         },
         {
-            "subcategory": "thumbnails",
+            "subcategory": TIER_SUBCATEGORY_THUMBNAILS,
             "tier_handler": ThumbnailTierHandler,
         },
     ],
-    "snapshots": [
+    TIER_CATEGORY_SNAPSHOTS: [
         {
-            "subcategory": "face_recognition",
+            "subcategory": TIER_SUBCATEGORY_FACE_RECOGNITION,
             "tier_handler": SnapshotTierHandler,
         },
         {
-            "subcategory": "object_detector",
+            "subcategory": TIER_SUBCATEGORY_OBJECT_DETECTOR,
             "tier_handler": SnapshotTierHandler,
         },
         {
-            "subcategory": "license_plate_recognition",
+            "subcategory": TIER_SUBCATEGORY_LICENSE_PLATE_RECOGNITION,
             "tier_handler": SnapshotTierHandler,
         },
         {
-            "subcategory": "motion_detector",
+            "subcategory": TIER_SUBCATEGORY_MOTION_DETECTOR,
             "tier_handler": SnapshotTierHandler,
         },
     ],
@@ -273,26 +283,24 @@ class Storage:
             return self._get_session_expire()
         return self._get_session()
 
-    def get_recordings_path(self, camera: AbstractCamera) -> str:
-        """Get recordings path for camera."""
+    def get_event_clips_path(self, camera: AbstractCamera) -> str:
+        """Get event clips path for camera."""
         self.create_tier_handlers(camera)
-        return get_recorder_path(
-            self._camera_tier_handlers[camera.identifier]["recorder"][0][
-                "recordings"
+        return get_event_clips_path(
+            self._camera_tier_handlers[camera.identifier][TIER_CATEGORY_RECORDER][0][
+                TIER_SUBCATEGORY_EVENT_CLIPS
             ].tier,
             camera,
-            "recordings",
         )
 
     def get_segments_path(self, camera: AbstractCamera) -> str:
         """Get segments path for camera."""
         self.create_tier_handlers(camera)
-        return get_recorder_path(
-            self._camera_tier_handlers[camera.identifier]["recorder"][0][
-                "segments"
+        return get_segments_path(
+            self._camera_tier_handlers[camera.identifier][TIER_CATEGORY_RECORDER][0][
+                TIER_SUBCATEGORY_SEGMENTS
             ].tier,
             camera,
-            "segments",
         )
 
     def get_thumbnails_path(self, camera: AbstractCamera) -> str:
@@ -304,8 +312,8 @@ class Storage:
         """
         self.create_tier_handlers(camera)
         return get_thumbnails_path(
-            self._camera_tier_handlers[camera.identifier]["recorder"][0][
-                "recordings"
+            self._camera_tier_handlers[camera.identifier][TIER_CATEGORY_RECORDER][0][
+                TIER_SUBCATEGORY_EVENT_CLIPS
             ].tier,
             camera,
         )

--- a/viseron/components/storage/alembic/versions/7b1f82f2ec39_move_clips_to_new_folder.py
+++ b/viseron/components/storage/alembic/versions/7b1f82f2ec39_move_clips_to_new_folder.py
@@ -1,0 +1,88 @@
+# pylint: disable=invalid-name
+"""Move event clips to /event_clips.
+
+Revision ID: 7b1f82f2ec39
+Revises: 620b4d1e5736
+Create Date: 2025-02-06 07:11:12.890722
+
+"""
+from __future__ import annotations
+
+import os
+import shutil
+
+import sqlalchemy as sa
+from alembic import op
+
+from viseron.components.storage.models import Files, Recordings
+from viseron.helpers import create_directory
+
+# revision identifiers, used by Alembic.
+revision: str | None = "7b1f82f2ec39"
+down_revision: str | None = "620b4d1e5736"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def move_clip_to_new_folder(
+    connection: sa.Connection,
+    old_subcategory: str,
+    new_subcategory: str,
+    file_record: Files,
+) -> None:
+    """Move a clip to the new folder."""
+    new_path = file_record.path.replace(old_subcategory, new_subcategory)
+    new_dir = os.path.dirname(new_path)
+    create_directory(new_dir)
+    shutil.move(file_record.path, new_path)
+
+    connection.execute(
+        sa.update(Files)
+        .where(Files.id == file_record.id)
+        .values(path=new_path)
+        .values(directory=new_dir)
+        .values(subcategory=new_subcategory)
+    )
+    connection.execute(
+        sa.update(Recordings)
+        .where(Recordings.clip_path == file_record.path)
+        .values(clip_path=new_path)
+    )
+
+
+def process_clip(old_subcategory: str, new_subcategory: str):
+    """Move clips from old_subcategory to new_subcategory."""
+    connection = op.get_bind()
+    files = connection.execute(
+        sa.select(Files)
+        .where(Files.category == "recorder")
+        .where(Files.subcategory == old_subcategory)
+    )
+    for file in files:
+        if file.path.startswith(f"/{old_subcategory}"):
+            if not os.path.exists(f"/{new_subcategory}"):
+                raise ValueError(
+                    f"The /{new_subcategory} folder does not exist. "
+                    "Please mount it to the container."
+                )
+
+        try:
+            move_clip_to_new_folder(
+                connection,
+                old_subcategory,
+                new_subcategory,
+                file,  # type: ignore[arg-type]
+            )
+        except Exception as e:  # pylint: disable=broad-except
+            print(f"Failed to move {file.path} to {new_subcategory}. Error: {e}")
+            print("Skipping this file, database will not be updated.")
+
+
+def upgrade() -> None:
+    """Run the upgrade migrations."""
+    process_clip("recordings", "event_clips")
+
+
+def downgrade() -> None:
+    """Run the downgrade migrations."""
+    process_clip("event_clips", "recordings")

--- a/viseron/components/storage/const.py
+++ b/viseron/components/storage/const.py
@@ -14,6 +14,20 @@ EVENT_FILE_DELETED = (
     "file_deleted/{camera_identifier}/{category}/{subcategory}/{file_name}"
 )
 
+# Tier categories
+TIER_CATEGORY_RECORDER: Final = "recorder"
+TIER_CATEGORY_SNAPSHOTS: Final = "snapshots"
+
+# Tier subcategories
+TIER_SUBCATEGORY_SEGMENTS: Final = "segments"
+TIER_SUBCATEGORY_EVENT_CLIPS: Final = "event_clips"
+TIER_SUBCATEGORY_THUMBNAILS: Final = "thumbnails"
+TIER_SUBCATEGORY_FACE_RECOGNITION: Final = "face_recognition"
+TIER_SUBCATEGORY_OBJECT_DETECTOR: Final = "object_detector"
+TIER_SUBCATEGORY_LICENSE_PLATE_RECOGNITION: Final = "license_plate_recognition"
+TIER_SUBCATEGORY_MOTION_DETECTOR: Final = "motion_detector"
+
+
 # Storage configuration
 DESC_COMPONENT = "Storage configuration."
 DEFAULT_COMPONENT: dict[str, Any] = {}

--- a/viseron/components/storage/queries.py
+++ b/viseron/components/storage/queries.py
@@ -20,6 +20,10 @@ from sqlalchemy import (
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.functions import coalesce
 
+from viseron.components.storage.const import (
+    TIER_CATEGORY_RECORDER,
+    TIER_SUBCATEGORY_SEGMENTS,
+)
 from viseron.components.storage.models import Files, Recordings
 from viseron.helpers import utcnow
 
@@ -259,8 +263,8 @@ def get_recording_fragments(
         .add_columns(row_number)
         .join(Recordings, Files.camera_identifier == Recordings.camera_identifier)
         .where(Recordings.id == recording_id)
-        .where(Files.category == "recorder")
-        .where(Files.subcategory == "segments")
+        .where(Files.category == TIER_CATEGORY_RECORDER)
+        .where(Files.subcategory == TIER_SUBCATEGORY_SEGMENTS)
         .where(Files.duration.isnot(None))
         .where(
             or_(
@@ -324,8 +328,8 @@ def get_time_period_fragments(
         select(Files)
         .add_columns(row_number)
         .where(Files.camera_identifier.in_(camera_identifiers))
-        .where(Files.category == "recorder")
-        .where(Files.subcategory == "segments")
+        .where(Files.category == TIER_CATEGORY_RECORDER)
+        .where(Files.subcategory == TIER_SUBCATEGORY_SEGMENTS)
         .where(Files.duration.isnot(None))
         .where(
             or_(

--- a/viseron/components/storage/util.py
+++ b/viseron/components/storage/util.py
@@ -15,6 +15,10 @@ from viseron.components.storage.const import (
     CONFIG_MB,
     CONFIG_MINUTES,
     CONFIG_PATH,
+    TIER_CATEGORY_SNAPSHOTS,
+    TIER_SUBCATEGORY_EVENT_CLIPS,
+    TIER_SUBCATEGORY_SEGMENTS,
+    TIER_SUBCATEGORY_THUMBNAILS,
 )
 from viseron.events import EventData
 from viseron.types import SnapshotDomain
@@ -55,18 +59,29 @@ def convert_gb_to_bytes(gb: int) -> int:
     return gb * 1024 * 1024 * 1024
 
 
-def get_recorder_path(
-    tier: dict[str, Any], camera: AbstractCamera | FailedCamera, subcategory: str
+def get_segments_path(
+    tier: dict[str, Any], camera: AbstractCamera | FailedCamera
 ) -> str:
-    """Get recorder path for camera."""
-    return os.path.join(tier[CONFIG_PATH], subcategory, camera.identifier)
+    """Get segments path for camera."""
+    return os.path.join(tier[CONFIG_PATH], TIER_SUBCATEGORY_SEGMENTS, camera.identifier)
+
+
+def get_event_clips_path(
+    tier: dict[str, Any], camera: AbstractCamera | FailedCamera
+) -> str:
+    """Get event clips path for camera."""
+    return os.path.join(
+        tier[CONFIG_PATH], TIER_SUBCATEGORY_EVENT_CLIPS, camera.identifier
+    )
 
 
 def get_thumbnails_path(
     tier: dict[str, Any], camera: AbstractCamera | FailedCamera
 ) -> str:
     """Get thumbnails path for camera."""
-    return os.path.join(tier[CONFIG_PATH], "thumbnails", camera.identifier)
+    return os.path.join(
+        tier[CONFIG_PATH], TIER_SUBCATEGORY_THUMBNAILS, camera.identifier
+    )
 
 
 def get_snapshots_path(
@@ -75,7 +90,9 @@ def get_snapshots_path(
     domain: SnapshotDomain,
 ) -> str:
     """Get snapshots path for camera."""
-    return os.path.join(tier[CONFIG_PATH], "snapshots", domain.value, camera.identifier)
+    return os.path.join(
+        tier[CONFIG_PATH], TIER_CATEGORY_SNAPSHOTS, domain.value, camera.identifier
+    )
 
 
 def files_to_move_overlap(events_file_ids, continuous_file_ids):

--- a/viseron/components/webserver/api/v1/hls.py
+++ b/viseron/components/webserver/api/v1/hls.py
@@ -12,6 +12,10 @@ from typing import TYPE_CHECKING
 import voluptuous as vol
 from sqlalchemy import select
 
+from viseron.components.storage.const import (
+    TIER_CATEGORY_RECORDER,
+    TIER_SUBCATEGORY_SEGMENTS,
+)
 from viseron.components.storage.models import Files, Recordings
 from viseron.components.storage.queries import get_time_period_fragments
 from viseron.components.webserver.api.handlers import BaseAPIHandler
@@ -215,8 +219,8 @@ def _get_init_file(
             select(Files)
             .distinct(Files.directory)
             .where(Files.camera_identifier == camera.identifier)
-            .where(Files.category == "recorder")
-            .where(Files.subcategory == "segments")
+            .where(Files.category == TIER_CATEGORY_RECORDER)
+            .where(Files.subcategory == TIER_SUBCATEGORY_SEGMENTS)
             .order_by(Files.directory, Files.created_at.desc())
         )
         files = session.execute(stmt).scalars().all()

--- a/viseron/components/webserver/websocket_api/commands.py
+++ b/viseron/components/webserver/websocket_api/commands.py
@@ -20,7 +20,12 @@ from debouncer import DebounceOptions, debounce
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 
-from viseron.components.storage.const import EVENT_FILE_CREATED, EVENT_FILE_DELETED
+from viseron.components.storage.const import (
+    EVENT_FILE_CREATED,
+    EVENT_FILE_DELETED,
+    TIER_CATEGORY_RECORDER,
+    TIER_SUBCATEGORY_SEGMENTS,
+)
 from viseron.components.storage.models import (
     Motion,
     Objects,
@@ -402,8 +407,8 @@ async def subscribe_timespans(connection: WebSocketHandler, message) -> None:
             connection.vis.listen_event(
                 EVENT_FILE_CREATED.format(
                     camera_identifier=camera_identifier,
-                    category="recorder",
-                    subcategory="segments",
+                    category=TIER_CATEGORY_RECORDER,
+                    subcategory=TIER_SUBCATEGORY_SEGMENTS,
                     file_name="*",
                 ),
                 forward_timespans,
@@ -414,8 +419,8 @@ async def subscribe_timespans(connection: WebSocketHandler, message) -> None:
             connection.vis.listen_event(
                 EVENT_FILE_DELETED.format(
                     camera_identifier=camera_identifier,
-                    category="recorder",
-                    subcategory="segments",
+                    category=TIER_CATEGORY_RECORDER,
+                    subcategory=TIER_SUBCATEGORY_SEGMENTS,
                     file_name="*",
                 ),
                 forward_timespans,

--- a/viseron/domains/camera/__init__.py
+++ b/viseron/domains/camera/__init__.py
@@ -22,6 +22,7 @@ from viseron.components.data_stream import (
     COMPONENT as DATA_STREAM_COMPONENT,
     DataStream,
 )
+from viseron.components.storage.config import validate_tiers
 from viseron.components.storage.const import (
     COMPONENT as STORAGE_COMPONENT,
     TIER_CATEGORY_RECORDER,
@@ -56,6 +57,7 @@ from .const import (
     CONFIG_STILL_IMAGE,
     CONFIG_STILL_IMAGE_HEIGHT,
     CONFIG_STILL_IMAGE_WIDTH,
+    CONFIG_STORAGE,
     CONFIG_URL,
     EVENT_CAMERA_STARTED,
     EVENT_CAMERA_STATUS,
@@ -114,6 +116,9 @@ class AbstractCamera(ABC):
         self._identifier = identifier
 
         self._logger = logging.getLogger(f"{self.__module__}.{self.identifier}")
+
+        if self._config[CONFIG_STORAGE]:
+            validate_tiers(self._config)
 
         self._connected: bool = False
         self._still_image_available: bool = False

--- a/viseron/domains/camera/config.py
+++ b/viseron/domains/camera/config.py
@@ -1,16 +1,14 @@
 """Camera domain config."""
 import voluptuous as vol
 
-from viseron.components.storage.config import TIER_SCHEMA_BASE, TIER_SCHEMA_RECORDER
+from viseron.components.storage.config import STORAGE_SCHEMA, TIER_SCHEMA_BASE
 from viseron.components.storage.const import (
     CONFIG_CONTINUOUS,
     CONFIG_EVENTS,
-    CONFIG_TIERS,
     DEFAULT_CONTINUOUS,
     DEFAULT_EVENTS,
     DESC_CONTINUOUS,
     DESC_EVENTS,
-    DESC_RECORDER_TIERS,
 )
 from viseron.helpers.validators import CoerceNoneToDict, Deprecated, Maybe, Slug
 
@@ -232,18 +230,6 @@ RECORDER_SCHEMA = vol.Schema(
             CONFIG_THUMBNAIL, default=DEFAULT_THUMBNAIL, description=DESC_THUMBNAIL
         ): vol.All(CoerceNoneToDict(), THUMBNAIL_SCHEMA),
         vol.Optional(
-            CONFIG_STORAGE,
-            default=DEFAULT_STORAGE,
-            description=DESC_STORAGE,
-        ): Maybe(
-            {
-                vol.Required(CONFIG_TIERS, description=DESC_RECORDER_TIERS,): vol.All(
-                    [TIER_SCHEMA_RECORDER],
-                    vol.Length(min=1),
-                )
-            },
-        ),
-        vol.Optional(
             CONFIG_CONTINUOUS,
             default=DEFAULT_CONTINUOUS,
             description=DESC_CONTINUOUS,
@@ -329,5 +315,10 @@ BASE_CONFIG_SCHEMA = vol.Schema(
             default=DEFAULT_STILL_IMAGE,
             description=DESC_STILL_IMAGE,
         ): vol.All(CoerceNoneToDict(), STILL_IMAGE_SCHEMA),
+        vol.Optional(
+            CONFIG_STORAGE,
+            default=DEFAULT_STORAGE,
+            description=DESC_STORAGE,
+        ): Maybe(STORAGE_SCHEMA),
     }
 )

--- a/viseron/domains/camera/recorder.py
+++ b/viseron/domains/camera/recorder.py
@@ -197,7 +197,7 @@ class AbstractRecorder(ABC, RecorderBase):
         self.is_recording = False
         self._active_recording: Recording | None = None
 
-        create_directory(self._camera.recordings_folder)
+        create_directory(self._camera.event_clips_folder)
         create_directory(self._camera.segments_folder)
         create_directory(self._camera.temp_segments_folder)
         create_directory(self._camera.thumbnails_folder)
@@ -379,7 +379,7 @@ class AbstractRecorder(ABC, RecorderBase):
 
         # Create foldername
         full_path = os.path.join(
-            self._camera.recordings_folder, recording.start_time.date().isoformat()
+            self._camera.event_clips_folder, recording.start_time.date().isoformat()
         )
 
         clip_path = os.path.join(full_path, video_name)


### PR DESCRIPTION
This PR changes the location of clips created by `create_event_clip: true` to `/event_clips`.
Mounting `/recordings` is therefore not necessarry any longer.

The configuration for specifying camera specific storage options has changed from
```yaml
ffmpeg: # or any other camera component
  camera:
    camera_one:
      name: Camera 1
      ...
      recorder:
        storage:
          tiers:
```

to:
```yaml
ffmpeg: # or any other camera component
  camera:
    camera_one:
      name: Camera 1
      ...
      storage:
        recorder:
          tiers:
```

making it identical to that of the `storage` component