### PR TITLE
Add Gotify notification component

### DIFF
--- a/docs/src/pages/components-explorer/components/gotify/_meta.tsx
+++ b/docs/src/pages/components-explorer/components/gotify/_meta.tsx
@@ -1,0 +1,12 @@
+import { Component } from "@site/src/types";
+
+const ComponentMetadata: Component = {
+  title: "<ENTER VALUE>",
+  name: "gotify",
+  description: "<ENTER VALUE>",
+  image: "<ENTER VALUE>",
+  tags: [],
+};
+
+export default ComponentMetadata;
+

--- a/docs/src/pages/components-explorer/components/gotify/_meta.tsx
+++ b/docs/src/pages/components-explorer/components/gotify/_meta.tsx
@@ -1,12 +1,11 @@
 import { Component } from "@site/src/types";
 
 const ComponentMetadata: Component = {
-  title: "<ENTER VALUE>",
+  title: "Gotify",
   name: "gotify",
-  description: "<ENTER VALUE>",
-  image: "<ENTER VALUE>",
-  tags: [],
+  description: "Send notifications to a Gotify server when recordings start",
+  image: "https://gotify.net/img/logo.png",
+  tags: ["system"],
 };
 
 export default ComponentMetadata;
-

--- a/docs/src/pages/components-explorer/components/gotify/_meta.tsx
+++ b/docs/src/pages/components-explorer/components/gotify/_meta.tsx
@@ -5,7 +5,7 @@ const ComponentMetadata: Component = {
   name: "gotify",
   description: "Send notifications to a Gotify server when recordings start",
   image: "https://gotify.net/img/logo.png",
-  tags: ["system"],
+  tags: ["notification"],
 };
 
 export default ComponentMetadata;

--- a/docs/src/pages/components-explorer/components/gotify/config.json
+++ b/docs/src/pages/components-explorer/components/gotify/config.json
@@ -1,0 +1,84 @@
+[
+  {
+    "type": "map",
+    "value": [
+      {
+        "type": "string",
+        "name": "gotify_url",
+        "description": "Gotify server URL (e.g., https://gotify.example.com).",
+        "required": true,
+        "default": null
+      },
+      {
+        "type": "string",
+        "name": "gotify_token",
+        "description": "Gotify application token.",
+        "required": true,
+        "default": null
+      },
+      {
+        "type": "map",
+        "value": [
+          {
+            "type": "map",
+            "value": [
+              {
+                "type": "string",
+                "name": "detection_label",
+                "description": "Label(s) of the object(s) to send notifications for this camera (comma-separated for multiple labels).",
+                "optional": true,
+                "default": null
+              },
+              {
+                "type": "boolean",
+                "name": "send_thumbnail",
+                "description": "Send a thumbnail of the detected object for this camera.",
+                "optional": true,
+                "default": null
+              }
+            ],
+            "name": {
+              "type": "select",
+              "options": [
+                {
+                  "type": "string"
+                }
+              ]
+            }
+          }
+        ],
+        "name": "cameras",
+        "description": "Cameras to get notifications from.",
+        "required": true,
+        "default": null
+      },
+      {
+        "type": "integer",
+        "valueMin": 1,
+        "valueMax": 10,
+        "name": "priority",
+        "description": "Priority of the notification (1-10).",
+        "optional": true,
+        "default": 5
+      },
+      {
+        "type": "string",
+        "name": "detection_label",
+        "description": "Label(s) of the object(s) to send notifications for (comma-separated for multiple labels, e.g., 'person,cat').",
+        "optional": true,
+        "default": "person"
+      },
+      {
+        "type": "boolean",
+        "name": "send_thumbnail",
+        "description": "Send a thumbnail of the detected object.",
+        "optional": true,
+        "default": false
+      }
+    ],
+    "name": "gotify",
+    "description": "Gotify server to send notifications for events.",
+    "required": true,
+    "default": null
+  }
+]

--- a/docs/src/pages/components-explorer/components/gotify/config.json
+++ b/docs/src/pages/components-explorer/components/gotify/config.json
@@ -38,13 +38,11 @@
               }
             ],
             "name": {
-              "type": "select",
-              "options": [
-                {
-                  "type": "string"
-                }
-              ]
-            }
+              "type": "CAMERA_IDENTIFIER"
+            },
+            "description": "Camera identifier. Valid characters are lowercase a-z, numbers and underscores.",
+            "cameraidentifier": true,
+            "default": null
           }
         ],
         "name": "cameras",

--- a/docs/src/pages/components-explorer/components/gotify/index.mdx
+++ b/docs/src/pages/components-explorer/components/gotify/index.mdx
@@ -7,7 +7,31 @@ import config from "./config.json";
 
 <ComponentHeader meta={ComponentMetadata} />
 
--- Provide short summary here --
+The Gotify component allows Viseron to send notifications to a [Gotify](https://gotify.net/) server when recordings start. Gotify is a simple server for sending and receiving push notifications. It's self-hosted, open-source, and provides a simple way to send notifications to your devices.
+
+## Features
+
+- Send notifications to Gotify when recordings start
+- Include thumbnails of detected objects in notifications (when enabled)
+- Configure notification priority
+- Filter notifications by object type
+- Only send notifications for objects that trigger recordings
+
+## How It Works
+
+The Gotify component listens for the `EVENT_RECORDER_START` event, which is triggered when a recording starts. When this event occurs, the component:
+
+1. Checks if the recording contains objects
+2. Filters objects based on the configured detection labels
+3. Sends a notification to the Gotify server with:
+   - A text message
+   - A thumbnail image (if `send_thumbnail` is enabled and a thumbnail is available)
+
+## Installation
+
+1. Set up a Gotify server if you don't already have one. You can follow the [official documentation](https://gotify.net/docs/install).
+2. Create an application in Gotify and get the application token.
+3. Configure the Gotify component in your Viseron configuration file.
 
 ## Configuration
 
@@ -15,12 +39,33 @@ import config from "./config.json";
   <summary>Configuration example</summary>
 
 ```yaml
-Config example here
+gotify:
+  gotify_url: "https://gotify.example.com" # URL to your Gotify server
+  gotify_token: "YOUR_APPLICATION_TOKEN" # Application token from Gotify
+  priority: 5 # Priority of the notifications (1-10)
+  detection_label: "person,cat" # Labels of objects to send notifications for
+  send_thumbnail: false # Send a thumbnail of the detected object
+  cameras:
+    camera1: # Camera identifier with empty config
+    camera2: # Another camera identifier
+      detection_label: "car,truck" # Override detection labels for this camera
+      send_thumbnail: true # Override thumbnail setting for this camera
 ```
 
 </details>
 
 <ComponentConfiguration meta={ComponentMetadata} config={config} />
 
+## Limitations
+
+- Gotify doesn't support direct video uploads, so the component only sends a notification that a video was recorded
+- Image thumbnails are sent as base64-encoded images in markdown format, which requires a Gotify client that supports this format
+
 <ComponentTroubleshooting meta={ComponentMetadata} />
 
+### Common Issues
+
+- **No notifications are being sent**: Ensure your Gotify server is accessible from the device running Viseron
+- **Authentication errors**: Check that the application token has the correct permissions
+- **Connection issues**: Verify that the URL is correct and includes the protocol (http:// or https://)
+- **Missing thumbnails**: Make sure the `send_thumbnail` option is enabled and that the recording contains a thumbnail

--- a/docs/src/pages/components-explorer/components/gotify/index.mdx
+++ b/docs/src/pages/components-explorer/components/gotify/index.mdx
@@ -1,0 +1,26 @@
+import ComponentConfiguration from "@site/src/pages/components-explorer/_components/ComponentConfiguration";
+import ComponentHeader from "@site/src/pages/components-explorer/_components/ComponentHeader";
+import ComponentTroubleshooting from "@site/src/pages/components-explorer/_components/ComponentTroubleshooting/index.mdx";
+
+import ComponentMetadata from "./_meta";
+import config from "./config.json";
+
+<ComponentHeader meta={ComponentMetadata} />
+
+-- Provide short summary here --
+
+## Configuration
+
+<details>
+  <summary>Configuration example</summary>
+
+```yaml
+Config example here
+```
+
+</details>
+
+<ComponentConfiguration meta={ComponentMetadata} config={config} />
+
+<ComponentTroubleshooting meta={ComponentMetadata} />
+

--- a/scripts/gen_docs/__main__.py
+++ b/scripts/gen_docs/__main__.py
@@ -74,7 +74,10 @@ def convert(schema, custom_convert=None):  # noqa: C901
                 pval["name"] = convert(key, custom_convert=custom_convert)
             else:
                 pval["name"] = pkey
-            pval["description"] = description
+
+            # Ne pas ajouter la description si elle est None
+            if description is not None:
+                pval["description"] = description
 
             if isinstance(key, (vol.Required, vol.Optional, Deprecated)):
                 pval[key.__class__.__name__.lower()] = True
@@ -83,7 +86,10 @@ def convert(schema, custom_convert=None):  # noqa: C901
                     pval["default"] = key.default()
                 else:
                     pval["default"] = None
-                pval["description"] = description
+
+                # Ne pas écraser la description déjà définie si elle est None
+                if description is not None:
+                    pval["description"] = description
 
             val.append(pval)
 

--- a/scripts/gen_docs/__main__.py
+++ b/scripts/gen_docs/__main__.py
@@ -74,10 +74,7 @@ def convert(schema, custom_convert=None):  # noqa: C901
                 pval["name"] = convert(key, custom_convert=custom_convert)
             else:
                 pval["name"] = pkey
-
-            # Ne pas ajouter la description si elle est None
-            if description is not None:
-                pval["description"] = description
+            pval["description"] = description
 
             if isinstance(key, (vol.Required, vol.Optional, Deprecated)):
                 pval[key.__class__.__name__.lower()] = True
@@ -86,10 +83,7 @@ def convert(schema, custom_convert=None):  # noqa: C901
                     pval["default"] = key.default()
                 else:
                     pval["default"] = None
-
-                # Ne pas écraser la description déjà définie si elle est None
-                if description is not None:
-                    pval["description"] = description
+                pval["description"] = description
 
             val.append(pval)
 

--- a/viseron/components/gotify/__init__.py
+++ b/viseron/components/gotify/__init__.py
@@ -1,0 +1,319 @@
+"""Gotify notifications for Viseron."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+from threading import Thread
+from typing import TYPE_CHECKING
+
+import cv2
+import requests
+import voluptuous as vol
+
+from viseron.const import VISERON_SIGNAL_SHUTDOWN
+from viseron.domains.camera.const import EVENT_RECORDER_START
+from viseron.domains.camera.recorder import EventRecorderData
+from viseron.helpers import escape_string
+from viseron.helpers.logs import SensitiveInformationFilter
+from viseron.helpers.validators import CoerceNoneToDict
+
+from .const import (
+    COMPONENT,
+    CONFIG_CAMERAS,
+    CONFIG_DETECTION_LABEL,
+    CONFIG_DETECTION_LABEL_DEFAULT,
+    CONFIG_GOTIFY_PRIORITY,
+    CONFIG_GOTIFY_PRIORITY_DEFAULT,
+    CONFIG_GOTIFY_TOKEN,
+    CONFIG_GOTIFY_URL,
+    CONFIG_SEND_THUMBNAIL,
+    DESC_CAMERA_DETECTION_LABEL,
+    DESC_CAMERA_SEND_THUMBNAIL,
+    DESC_CAMERAS,
+    DESC_COMPONENT,
+    DESC_DETECTION_LABEL,
+    DESC_GOTIFY_PRIORITY,
+    DESC_GOTIFY_TOKEN,
+    DESC_GOTIFY_URL,
+    DESC_SEND_THUMBNAIL,
+)
+
+if TYPE_CHECKING:
+    from viseron import Event, Viseron
+
+LOGGER = logging.getLogger(__name__)
+
+CAMERA_SCHEMA = vol.Schema(
+    {
+        vol.Optional(
+            "detection_label",
+            description=DESC_CAMERA_DETECTION_LABEL,
+        ): str,
+        vol.Optional(
+            "send_thumbnail",
+            description=DESC_CAMERA_SEND_THUMBNAIL,
+        ): bool,
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+CONFIG_SCHEMA: vol.Schema = vol.Schema(
+    {
+        vol.Required(COMPONENT, description=DESC_COMPONENT): {
+            vol.Required(CONFIG_GOTIFY_URL, description=DESC_GOTIFY_URL): str,
+            vol.Required(CONFIG_GOTIFY_TOKEN, description=DESC_GOTIFY_TOKEN): str,
+            vol.Optional(
+                CONFIG_GOTIFY_PRIORITY,
+                description=DESC_GOTIFY_PRIORITY,
+                default=CONFIG_GOTIFY_PRIORITY_DEFAULT,
+            ): vol.All(vol.Coerce(int), vol.Range(min=1, max=10)),
+            vol.Optional(
+                CONFIG_DETECTION_LABEL,
+                description=DESC_DETECTION_LABEL,
+                default=CONFIG_DETECTION_LABEL_DEFAULT,
+            ): str,
+            vol.Optional(
+                CONFIG_SEND_THUMBNAIL, description=DESC_SEND_THUMBNAIL, default=False
+            ): bool,
+            vol.Required(CONFIG_CAMERAS, description=DESC_CAMERAS): {
+                vol.Any(str): vol.All(CoerceNoneToDict(), CAMERA_SCHEMA),
+            },
+        }
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+def setup(vis: Viseron, config) -> bool:
+    """Set up the Gotify component."""
+    component_config = config[COMPONENT]
+
+    gotify_notifier = GotifyEventNotifier(vis, component_config)
+    Thread(target=gotify_notifier.run_async).start()
+
+    vis.register_signal_handler(VISERON_SIGNAL_SHUTDOWN, gotify_notifier.stop)
+    return True
+
+
+class GotifyEventNotifier:
+    """Gotify event notifier class that sends notifications to a Gotify server."""
+
+    def __init__(self, vis, config) -> None:
+        self._vis = vis
+        self._config = config
+        SensitiveInformationFilter.add_sensitive_string(
+            self._config[CONFIG_GOTIFY_TOKEN]
+        )
+        SensitiveInformationFilter.add_sensitive_string(
+            escape_string(self._config[CONFIG_GOTIFY_TOKEN])
+        )
+        self._gotify_url = self._config[CONFIG_GOTIFY_URL].rstrip("/")
+        self._gotify_token = self._config[CONFIG_GOTIFY_TOKEN]
+        self._priority = self._config[CONFIG_GOTIFY_PRIORITY]
+        self._loop = asyncio.new_event_loop()
+        self._stop_event = asyncio.Event()
+
+        for camera_identifier in self._config[CONFIG_CAMERAS]:
+            # Listen for recording start events
+            self._vis.listen_event(
+                EVENT_RECORDER_START.format(camera_identifier=camera_identifier),
+                self._recording_start_event_handler,
+            )
+        vis.data[COMPONENT] = self
+
+    def _recording_start_event_handler(
+        self, event_data: Event[EventRecorderData]
+    ) -> None:
+        """Handle recording start events."""
+        camera = event_data.data.camera
+        recording = event_data.data.recording
+        camera_identifier = camera.identifier
+
+        # Get camera-specific configuration or fall back to global configuration
+        camera_config = self._config[CONFIG_CAMERAS].get(camera_identifier, {})
+
+        # Get detected objects from the recording
+        objects = recording.objects
+
+        if not objects:
+            # Skip if no objects
+            return
+
+        # Check if we should filter by detection label
+        # First check camera setting, then fall back to global setting, then to default
+        camera_detection_label = camera_config.get("detection_label")
+        global_detection_label = self._config.get(
+            CONFIG_DETECTION_LABEL, CONFIG_DETECTION_LABEL_DEFAULT
+        )
+        detection_labels = (
+            camera_detection_label
+            if camera_detection_label is not None
+            else global_detection_label
+        )
+
+        # Find matching objects
+        matching_object = None
+        if detection_labels:
+            # Support comma-separated list of labels
+            allowed_labels = [label.strip() for label in detection_labels.split(",")]
+
+            # Check if any object has a label that matches the allowed labels
+            for obj in objects:
+                if obj.label in allowed_labels:
+                    matching_object = obj
+                    break
+
+            if not matching_object:
+                # Skip if no object with allowed label was found
+                return
+        else:
+            # If no detection labels are specified, use the first object
+            matching_object = objects[0]
+
+        # Create notification message
+        title = f"{camera_identifier} recording started: {matching_object.label}"
+        message = f"Recording started for {matching_object.label}"
+
+        # Get the thumbnail from the recording
+        thumbnail = recording.thumbnail
+
+        # Check if thumbnail is enabled for this camera
+        # First check camera-specific setting, then fall back to global setting
+        camera_send_thumbnail = camera_config.get("send_thumbnail")
+        global_send_thumbnail = self._config.get(CONFIG_SEND_THUMBNAIL, False)
+        send_thumbnail = (
+            camera_send_thumbnail
+            if camera_send_thumbnail is not None
+            else global_send_thumbnail
+        )
+
+        # Send notification with image if thumbnail is enabled and available
+        if send_thumbnail and thumbnail is not None:
+            try:
+                # Resize the thumbnail if needed
+                height, width = thumbnail.shape[:2]
+                max_size = 800
+                if width > height:
+                    new_width = min(width, max_size)
+                    new_height = int((new_width / width) * height)
+                else:
+                    new_height = min(height, max_size)
+                    new_width = int((new_height / height) * width)
+
+                resized_thumbnail = cv2.resize(
+                    thumbnail, (new_width, new_height), interpolation=cv2.INTER_AREA
+                )
+
+                # Send notification with image
+                asyncio.run_coroutine_threadsafe(
+                    self._send_notification_with_image(
+                        title, message, resized_thumbnail
+                    ),
+                    self._loop,
+                )
+            except (cv2.error, TypeError, ValueError) as exc:
+                LOGGER.error("Failed to prepare image notification: %s", exc)
+                # Fall back to text-only notification
+                asyncio.run_coroutine_threadsafe(
+                    self._send_text_notification(title, message), self._loop
+                )
+        # Send text-only notification if image is not enabled or not available
+        else:
+            asyncio.run_coroutine_threadsafe(
+                self._send_text_notification(title, message), self._loop
+            )
+
+    async def _send_text_notification(self, title, message):
+        """Send a text-only notification to Gotify."""
+        try:
+            self._send_gotify_message(title, message)
+        except requests.RequestException as exc:
+            LOGGER.error("Failed to send Gotify message: %s", exc)
+
+    async def _send_notification_with_image(self, title, message, image):
+        """Send a notification with image to Gotify."""
+        if image is None:
+            LOGGER.error("Cannot send image notification: image is None")
+            # Fall back to text-only notification
+            await self._send_text_notification(title, message)
+            return
+
+        try:
+            self._send_gotify_message_with_image(title, message, image)
+        except requests.RequestException as exc:
+            LOGGER.error("Failed to send Gotify message with image: %s", exc)
+            # Fall back to text-only notification
+            await self._send_text_notification(title, message)
+
+    def _send_gotify_message(self, title, message):
+        """Send a simple text message to Gotify."""
+        url = f"{self._gotify_url}/message"
+        headers = {"X-Gotify-Key": self._gotify_token}
+        data = {
+            "title": title,
+            "message": message,
+            "priority": self._priority,
+        }
+
+        response = requests.post(url, headers=headers, json=data, timeout=10)
+        if response.status_code != 200:
+            LOGGER.error(
+                "Failed to send Gotify message: %s - %s",
+                response.status_code,
+                response.text,
+            )
+        else:
+            pass
+
+    def _send_gotify_message_with_image(self, title, message, image):
+        """Send a message with an image attachment to Gotify."""
+        if image is None:
+            LOGGER.error("Cannot send image notification: image is None")
+            return
+
+        url = f"{self._gotify_url}/message"
+        headers = {"X-Gotify-Key": self._gotify_token}
+
+        # Encode the image as base64
+        _, buffer = cv2.imencode(".jpg", image)
+        image_base64 = base64.b64encode(buffer.tobytes()).decode("utf-8")
+
+        # Include the image directly in the message using markdown
+        # Format: data:image/jpeg;base64,<base64-encoded-image>
+        image_markdown = f"![Image](data:image/jpeg;base64,{image_base64})"
+
+        # Combine the text message with the image markdown
+        message_with_image = f"{message}\n\n{image_markdown}"
+
+        # Create the message with the image embedded in markdown
+        data = {
+            "title": title,
+            "message": message_with_image,
+            "priority": self._priority,
+            "extras": {"client::display": {"contentType": "text/markdown"}},
+        }
+
+        response = requests.post(url, headers=headers, json=data, timeout=30)
+        if response.status_code != 200:
+            LOGGER.error(
+                "Failed to send Gotify message with image: %s - %s",
+                response.status_code,
+                response.text,
+            )
+        else:
+            pass
+
+    async def _run_until_stopped(self):
+        while not self._stop_event.is_set():
+            await asyncio.sleep(1)
+
+    def run_async(self):
+        """Run GotifyEventNotifier in a new event loop."""
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_until_complete(self._run_until_stopped())
+
+    def stop(self) -> None:
+        """Stop GotifyEventNotifier component."""
+        self._stop_event.set()

--- a/viseron/components/gotify/const.py
+++ b/viseron/components/gotify/const.py
@@ -1,0 +1,35 @@
+"""Gotify component constants."""
+
+COMPONENT = "gotify"
+DESC_COMPONENT = "Gotify server to send notifications for events."
+
+CONFIG_GOTIFY_URL = "gotify_url"
+CONFIG_GOTIFY_TOKEN = "gotify_token"
+CONFIG_GOTIFY_PRIORITY = "priority"
+CONFIG_GOTIFY_PRIORITY_DEFAULT = 5
+
+CONFIG_CAMERAS = "cameras"
+CONFIG_DETECTION_LABEL = "detection_label"
+CONFIG_DETECTION_LABEL_DEFAULT = "person"
+CONFIG_SEND_THUMBNAIL = "send_thumbnail"
+
+# Camera-specific configuration options
+CONFIG_CAMERA_DETECTION_LABEL = "detection_label"
+CONFIG_CAMERA_SEND_THUMBNAIL = "send_thumbnail"
+
+DESC_GOTIFY_URL = "Gotify server URL (e.g., https://gotify.example.com)."
+DESC_GOTIFY_TOKEN = "Gotify application token."
+DESC_GOTIFY_PRIORITY = "Priority of the notification (1-10)."
+DESC_DETECTION_LABEL = (
+    "Label(s) of the object(s) to send notifications for "
+    "(comma-separated for multiple labels, e.g., 'person,cat')."
+)
+DESC_SEND_THUMBNAIL = "Send a thumbnail of the detected object."
+
+DESC_CAMERAS = "Cameras to get notifications from."
+
+DESC_CAMERA_DETECTION_LABEL = (
+    "Label(s) of the object(s) to send notifications for this camera "
+    "(comma-separated for multiple labels)."
+)
+DESC_CAMERA_SEND_THUMBNAIL = "Send a thumbnail of the detected object for this camera."


### PR DESCRIPTION
# Add Gotify notification component

This PR adds a new Gotify notification component to Viseron that allows sending notifications to a Gotify server when recordings start.

## Features
- Send notifications to a Gotify server when recordings are triggered
- Configure notification priority (1-10)
- Filter notifications by object type (e.g., person, car, cat)
- Support for camera-specific configuration overrides
- Option to include thumbnail images of detected objects in notifications

## Configuration
The component can be configured in the Viseron configuration file:

```yaml
gotify:
  gotify_url: "https://gotify.example.com"  # URL to your Gotify server
  gotify_token: "YOUR_APPLICATION_TOKEN"     # Application token from Gotify
  priority: 5                               # Priority of the notifications (1-10)
  detection_label: "person,cat"             # Labels of objects to send notifications for
  send_thumbnail: false                     # Send a thumbnail of the detected object
  cameras:
    camera1:                              # Camera identifier with empty config
    camera2:                              # Another camera identifier
      detection_label: "car"              # Override detection label for this camera
      send_thumbnail: true                # Override thumbnail setting for this camera
```

## Implementation Details
- Listens for the `EVENT_RECORDER_START` event to send notifications only when recordings are triggered
- Supports filtering by object labels to reduce notification spam
- Handles image resizing and encoding for thumbnail delivery
- Runs in a separate thread to avoid blocking the main application
- Properly handles errors and provides fallback to text-only notifications if image processing fails

> [!WARNING]
> I had to edit scripts/gen_docs/__main__.py to remove ```"description": null``` from the config.json generation to be able to commit (cf. [fix convert to dictionary](https://github.com/roflcoopter/viseron/pull/941/commits/e57eb6786e574f5841a799843d44c76fc0d1d3d5))

> [!NOTE]
> This PR was in #938 but I started from a clean branch to understand the commit error so, here we go again  