### PR TITLE
Discord component for notifications

### DIFF
--- a/docs/src/pages/components-explorer/components/discord/_meta.tsx
+++ b/docs/src/pages/components-explorer/components/discord/_meta.tsx
@@ -1,0 +1,12 @@
+import { Component } from "@site/src/types";
+
+const ComponentMetadata: Component = {
+  title: "Discord Notifications",
+  name: "discord",
+  description: "Receive notifications via Discord webhooks",
+  image:
+    "https://assets-global.website-files.com/6257adef93867e50d84d30e2/636e0a6a49cf127bf92de1e2_icon_clyde_blurple_RGB.png",
+  tags: [],
+};
+
+export default ComponentMetadata;

--- a/docs/src/pages/components-explorer/components/discord/_meta.tsx
+++ b/docs/src/pages/components-explorer/components/discord/_meta.tsx
@@ -6,7 +6,7 @@ const ComponentMetadata: Component = {
   description: "Receive notifications via Discord webhooks",
   image:
     "https://assets-global.website-files.com/6257adef93867e50d84d30e2/636e0a6a49cf127bf92de1e2_icon_clyde_blurple_RGB.png",
-  tags: [],
+  tags: ["notification"],
 };
 
 export default ComponentMetadata;

--- a/docs/src/pages/components-explorer/components/discord/config.json
+++ b/docs/src/pages/components-explorer/components/discord/config.json
@@ -14,48 +14,48 @@
         "value": [
           {
             "type": "map",
-            "name": {
-              "type": "CAMERA_IDENTIFIER"
-            },
-            "description": "Camera identifier. Valid characters are lowercase a-z, numbers and underscores.",
-            "cameraidentifier": true,
             "value": [
               {
                 "type": "string",
                 "name": "webhook_url",
-                "description": "Discord webhook URL (camera-specific override).",
+                "description": "Discord webhook URL. Can be overridden per camera.",
                 "optional": true,
                 "default": null
               },
               {
                 "type": "string",
                 "name": "detection_label",
-                "description": "Label of the object to send notifications for (camera-specific override).",
+                "description": "Label of the object to send notifications for.",
                 "optional": true,
                 "default": null
               },
               {
                 "type": "boolean",
                 "name": "send_detection_thumbnail",
-                "description": "Send a thumbnail of the detected object (camera-specific override).",
+                "description": "Send a thumbnail of the detected object.",
                 "optional": true,
                 "default": null
               },
               {
                 "type": "boolean",
                 "name": "send_detection_video",
-                "description": "Send a video of the detected object (camera-specific override).",
+                "description": "Send a video of the detected object.",
                 "optional": true,
                 "default": null
               },
               {
                 "type": "integer",
                 "name": "max_video_size_mb",
-                "description": "Maximum size of video to send in MB (camera-specific override).",
+                "description": "Maximum size of video to send in MB (Discord limit is 8MB for free tier, 50MB for level 2 boosted servers and 100MB for level 3 boosted servers).",
                 "optional": true,
                 "default": null
               }
             ],
+            "name": {
+              "type": "CAMERA_IDENTIFIER"
+            },
+            "description": "Camera identifier. Valid characters are lowercase a-z, numbers and underscores.",
+            "cameraidentifier": true,
             "default": null
           }
         ],
@@ -81,7 +81,7 @@
       {
         "type": "boolean",
         "name": "send_detection_video",
-        "description": "Send a video of the detected object (up to 8MB due to Discord webhook limit).",
+        "description": "Send a video of the detected object.",
         "optional": true,
         "default": true
       },

--- a/docs/src/pages/components-explorer/components/discord/config.json
+++ b/docs/src/pages/components-explorer/components/discord/config.json
@@ -1,0 +1,101 @@
+[
+  {
+    "type": "map",
+    "value": [
+      {
+        "type": "string",
+        "name": "webhook_url",
+        "description": "Discord webhook URL. Can be overridden per camera.",
+        "required": true,
+        "default": null
+      },
+      {
+        "type": "map",
+        "value": [
+          {
+            "type": "map",
+            "name": {
+              "type": "CAMERA_IDENTIFIER"
+            },
+            "description": "Camera identifier. Valid characters are lowercase a-z, numbers and underscores.",
+            "cameraidentifier": true,
+            "value": [
+              {
+                "type": "string",
+                "name": "webhook_url",
+                "description": "Discord webhook URL (camera-specific override).",
+                "optional": true,
+                "default": null
+              },
+              {
+                "type": "string",
+                "name": "detection_label",
+                "description": "Label of the object to send notifications for (camera-specific override).",
+                "optional": true,
+                "default": null
+              },
+              {
+                "type": "boolean",
+                "name": "send_detection_thumbnail",
+                "description": "Send a thumbnail of the detected object (camera-specific override).",
+                "optional": true,
+                "default": null
+              },
+              {
+                "type": "boolean",
+                "name": "send_detection_video",
+                "description": "Send a video of the detected object (camera-specific override).",
+                "optional": true,
+                "default": null
+              },
+              {
+                "type": "integer",
+                "name": "max_video_size_mb",
+                "description": "Maximum size of video to send in MB (camera-specific override).",
+                "optional": true,
+                "default": null
+              }
+            ],
+            "default": null
+          }
+        ],
+        "name": "cameras",
+        "description": "Cameras to get notifications from.",
+        "required": true,
+        "default": null
+      },
+      {
+        "type": "string",
+        "name": "detection_label",
+        "description": "Label of the object to send notifications for.",
+        "optional": true,
+        "default": "person"
+      },
+      {
+        "type": "boolean",
+        "name": "send_detection_thumbnail",
+        "description": "Send a thumbnail of the detected object.",
+        "optional": true,
+        "default": true
+      },
+      {
+        "type": "boolean",
+        "name": "send_detection_video",
+        "description": "Send a video of the detected object (up to 8MB due to Discord webhook limit).",
+        "optional": true,
+        "default": true
+      },
+      {
+        "type": "integer",
+        "name": "max_video_size_mb",
+        "description": "Maximum size of video to send in MB (Discord limit is 8MB for free tier, 50MB for level 2 boosted servers and 100MB for level 3 boosted servers).",
+        "optional": true,
+        "default": 8
+      }
+    ],
+    "name": "discord",
+    "description": "Discord webhook to send notifications.",
+    "required": true,
+    "default": null
+  }
+]

--- a/docs/src/pages/components-explorer/components/discord/index.mdx
+++ b/docs/src/pages/components-explorer/components/discord/index.mdx
@@ -1,0 +1,58 @@
+import ComponentConfiguration from "@site/src/pages/components-explorer/_components/ComponentConfiguration";
+import ComponentHeader from "@site/src/pages/components-explorer/_components/ComponentHeader";
+import ComponentTroubleshooting from "@site/src/pages/components-explorer/_components/ComponentTroubleshooting";
+
+import ComponentMetadata from "./_meta";
+import config from "./config.json";
+
+<ComponentHeader meta={ComponentMetadata} />
+
+The Discord component sends notifications to a Discord webhook when events are detected. It can send text messages, thumbnail images, and video clips (up to 8MB by default).
+
+The component sends notifications at two key moments:
+1. **At the start of recording**: A notification message is always sent as soon as recording starts, with a thumbnail if configured and available
+2. **At the end of recording**: If video sending is enabled, a notification with the video is sent when the recording is complete
+   - If the video is smaller than the configured size limit, the complete video is sent
+   - If the video exceeds the size limit, the first portion of the video (up to the configured size limit) is sent
+
+This approach ensures you get immediate notification of events while also receiving video evidence once the recording is complete.
+
+## Configuration
+
+<details>
+  <summary>Configuration example</summary>
+
+```yaml
+discord:
+  webhook_url: "https://discord.com/api/webhooks/your-webhook-url"  # Global default webhook URL
+  send_detection_thumbnail: true  # Global default
+  send_detection_video: true  # Global default
+  max_video_size_mb: 8  # Global default (8MB for free tier, 50MB for level 2 boosted servers, 100MB for level 3)
+  detection_label: "person"  # Global default, defaults to "person"
+  cameras:
+    camera_1:  # Replace with your camera identifier
+      # Camera-specific overrides (optional)
+      webhook_url: "https://discord.com/api/webhooks/camera1-specific-webhook"  # Camera-specific webhook URL
+      send_detection_thumbnail: false  # Override global setting for this camera
+      send_detection_video: false  # Override global setting for this camera
+      max_video_size_mb: 50  # Override global setting for this camera (if you have a boosted server)
+      detection_label: "car"  # Override global setting for this camera
+    camera_2:  # Replace with your camera identifier
+      # You can have different webhooks for different cameras
+      webhook_url: "https://discord.com/api/webhooks/camera2-specific-webhook"
+```
+
+</details>
+
+<ComponentConfiguration meta={ComponentMetadata} config={config} />
+
+## Discord Webhook Setup
+
+1. In your Discord server, go to Server Settings > Integrations > Webhooks
+2. Click "New Webhook"
+3. Give your webhook a name and select the channel it should post to
+4. Click "Copy Webhook URL" and use this URL in your Viseron configuration
+
+## Troubleshooting
+
+<ComponentTroubleshooting meta={ComponentMetadata} />

--- a/viseron/components/discord/__init__.py
+++ b/viseron/components/discord/__init__.py
@@ -1,0 +1,352 @@
+"""Discord webhook notifications."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from threading import Lock, Thread
+from typing import TYPE_CHECKING, Dict, Set
+
+import requests
+import voluptuous as vol
+
+from viseron.const import VISERON_SIGNAL_SHUTDOWN
+from viseron.domains.camera import AbstractCamera
+from viseron.domains.camera.const import EVENT_RECORDER_COMPLETE, EVENT_RECORDER_START
+from viseron.domains.camera.recorder import EventRecorderData, Recording
+from viseron.helpers.validators import CameraIdentifier, CoerceNoneToDict
+
+from .const import (
+    COMPONENT,
+    CONFIG_CAMERAS,
+    CONFIG_DETECTION_LABEL,
+    CONFIG_DETECTION_LABEL_DEFAULT,
+    CONFIG_DISCORD_WEBHOOK_URL,
+    CONFIG_MAX_VIDEO_SIZE_MB,
+    CONFIG_MAX_VIDEO_SIZE_MB_DEFAULT,
+    CONFIG_SEND_THUMBNAIL,
+    CONFIG_SEND_VIDEO,
+    DESC_CAMERAS,
+    DESC_COMPONENT,
+    DESC_DETECTION_LABEL,
+    DESC_DISCORD_WEBHOOK_URL,
+    DESC_MAX_VIDEO_SIZE_MB,
+    DESC_SEND_THUMBNAIL,
+    DESC_SEND_VIDEO,
+)
+
+if TYPE_CHECKING:
+    from viseron import Event, Viseron
+
+LOGGER = logging.getLogger(__name__)
+
+CAMERA_SCHEMA = vol.Schema(
+    {
+        vol.Optional(
+            CONFIG_DISCORD_WEBHOOK_URL,
+            description=DESC_DISCORD_WEBHOOK_URL,
+        ): str,
+        vol.Optional(
+            CONFIG_DETECTION_LABEL,
+            description=DESC_DETECTION_LABEL,
+        ): str,
+        vol.Optional(
+            CONFIG_SEND_THUMBNAIL,
+            description=DESC_SEND_THUMBNAIL,
+        ): bool,
+        vol.Optional(
+            CONFIG_SEND_VIDEO,
+            description=DESC_SEND_VIDEO,
+        ): bool,
+        vol.Optional(
+            CONFIG_MAX_VIDEO_SIZE_MB,
+            description=DESC_MAX_VIDEO_SIZE_MB,
+        ): int,
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+CONFIG_SCHEMA: vol.Schema = vol.Schema(
+    {
+        vol.Required(COMPONENT, description=DESC_COMPONENT): {
+            vol.Required(
+                CONFIG_DISCORD_WEBHOOK_URL, description=DESC_DISCORD_WEBHOOK_URL
+            ): str,
+            vol.Optional(
+                CONFIG_DETECTION_LABEL,
+                description=DESC_DETECTION_LABEL,
+                default=CONFIG_DETECTION_LABEL_DEFAULT,
+            ): str,
+            vol.Optional(
+                CONFIG_SEND_THUMBNAIL, description=DESC_SEND_THUMBNAIL, default=True
+            ): bool,
+            vol.Optional(
+                CONFIG_SEND_VIDEO, description=DESC_SEND_VIDEO, default=True
+            ): bool,
+            vol.Optional(
+                CONFIG_MAX_VIDEO_SIZE_MB,
+                description=DESC_MAX_VIDEO_SIZE_MB,
+                default=CONFIG_MAX_VIDEO_SIZE_MB_DEFAULT,
+            ): int,
+            vol.Required(CONFIG_CAMERAS, description=DESC_CAMERAS): {
+                CameraIdentifier(): vol.All(CoerceNoneToDict(), CAMERA_SCHEMA),
+            },
+        }
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+def setup(vis: Viseron, config) -> bool:
+    """Set up the Discord component."""
+    component_config = config[COMPONENT]
+
+    discord_notifier = DiscordNotifier(vis, component_config)
+    Thread(target=discord_notifier.run_async).start()
+
+    vis.register_signal_handler(VISERON_SIGNAL_SHUTDOWN, discord_notifier.stop)
+    return True
+
+
+class DiscordNotifier:
+    """
+    Discord webhook notifier class.
+
+    This class sends notifications to a Discord webhook when an event occurs.
+    """
+
+    def __init__(self, vis, config) -> None:
+        self._vis = vis
+        self._config = config
+        self._webhook_url = self._config[CONFIG_DISCORD_WEBHOOK_URL]
+        self._loop = asyncio.new_event_loop()
+        self._stop_event = asyncio.Event()
+        self._active_recordings: Dict[int, Recording] = {}
+        self._sent_recordings: Set[int] = set()
+        self._lock = Lock()
+        
+        # Register for recorder events for all configured cameras
+        for camera_identifier in self._config[CONFIG_CAMERAS]:
+            self._vis.listen_event(
+                EVENT_RECORDER_START.format(camera_identifier=camera_identifier),
+                self._recorder_start_event,
+            )
+            self._vis.listen_event(
+                EVENT_RECORDER_COMPLETE.format(camera_identifier=camera_identifier),
+                self._recorder_complete_event,
+            )
+        
+        self._vis.data[COMPONENT] = self
+        
+    def _get_camera_config(self, camera_identifier: str, key: str, default=None):
+        """Get camera-specific config or global default."""
+        camera_config = self._config[CONFIG_CAMERAS].get(camera_identifier, {})
+        return camera_config.get(key, self._config.get(key, default))
+        
+    def _get_webhook_url(self, camera_identifier: str | None):
+        """Get webhook URL for a specific camera or global default."""
+        camera_config = self._config[CONFIG_CAMERAS].get(camera_identifier, {})
+        return camera_config.get(CONFIG_DISCORD_WEBHOOK_URL, self._webhook_url)
+        
+    def _recorder_start_event(self, event_data: Event[EventRecorderData]) -> None:
+        """Handle recorder start event."""
+        camera = event_data.data.camera
+        recording = event_data.data.recording
+        
+        # Always send a start notification with message
+        message = f"Recording started on {camera.identifier}"
+        if recording.objects:
+            message += f" - Detected {recording.objects[0].label}"
+        
+        # Check if thumbnail should be included
+        send_thumbnail = self._get_camera_config(
+            camera.identifier, CONFIG_SEND_THUMBNAIL, True
+        )
+        thumbnail_path = recording.thumbnail_path
+        
+        if (
+            send_thumbnail
+            and thumbnail_path is not None
+            and os.path.exists(thumbnail_path)
+        ):
+            # Send message with thumbnail
+            self._send_discord_file(
+                thumbnail_path,
+                message,
+                "thumbnail.jpg",
+                camera.identifier
+            )
+        else:
+            # Send message only
+            self._send_discord_message(message, camera.identifier)
+
+    def _recorder_complete_event(self, event_data: Event[EventRecorderData]) -> None:
+        """Handle recorder complete event."""
+        asyncio.run_coroutine_threadsafe(
+            self._send_notifications(event_data), self._loop
+        )
+
+    async def _send_notifications(self, event_data: Event[EventRecorderData]) -> None:
+        """Send notifications to Discord webhook."""
+        camera: AbstractCamera = event_data.data.camera
+        recording = event_data.data.recording
+        
+        # Check if this recording has already been sent
+        with self._lock:
+            already_sent = recording.id in self._sent_recordings
+        
+        # Check if video sending is enabled for this camera
+        send_video = self._get_camera_config(
+            camera.identifier, CONFIG_SEND_VIDEO, True
+        )
+        
+        # Get max video size for this camera
+        max_size_mb = self._get_camera_config(
+            camera.identifier, CONFIG_MAX_VIDEO_SIZE_MB, CONFIG_MAX_VIDEO_SIZE_MB_DEFAULT
+        )
+        max_size_bytes = max_size_mb * 1024 * 1024
+        
+        # Prepare message
+        message = f"Recording completed for {camera.identifier}"
+        if recording.objects:
+            message += f" - Detected {recording.objects[0].label}"
+        
+        # Check if we can send video
+        clip_path = recording.clip_path
+        can_send_video = (
+            not already_sent
+            and send_video
+            and clip_path is not None
+            and os.path.exists(clip_path)
+        )
+        
+        # If we can't send video, send a message with thumbnail
+        if not can_send_video:
+            # Send message
+            self._send_discord_message(message, camera.identifier)
+            
+            # Send thumbnail if configured and available
+            send_thumbnail = self._get_camera_config(
+                camera.identifier, CONFIG_SEND_THUMBNAIL, True
+            )
+            thumbnail_path = recording.thumbnail_path
+            if (
+                send_thumbnail
+                and thumbnail_path is not None
+                and os.path.exists(thumbnail_path)
+            ):
+                self._send_discord_file(
+                    thumbnail_path,
+                    f"Thumbnail for {camera.identifier}",
+                    "thumbnail.jpg",
+                    camera.identifier
+                )
+        else:
+            # We can send video, check file size
+            assert clip_path is not None  # For type checking
+            file_size = os.path.getsize(clip_path)
+            
+            # Prepare caption for video
+            caption = f"Complete video from {camera.identifier}"
+            if recording.objects:
+                caption += f" - Detected {recording.objects[0].label}"
+            
+            # We already checked that clip_path is not None above, but let's assert it again for type checking
+            assert clip_path is not None
+            
+            # If file is smaller than the limit, send the complete video
+            if file_size <= max_size_bytes:
+                LOGGER.info(
+                    f"Sending complete video file ({file_size/1024/1024:.1f}MB)."
+                )
+                self._send_discord_file(
+                    clip_path,
+                    caption,
+                    f"{camera.identifier}_event_complete.mp4",
+                    camera.identifier
+                )
+            else:
+                # Video is too large, send the first max_size_bytes
+                LOGGER.info(
+                    f"Video too large ({file_size/1024/1024:.1f}MB), sending first {max_size_mb}MB."
+                )
+                # Calculate approximate percentage of the video that is being sent
+                percentage = min(100, int((max_size_bytes / file_size) * 100))
+                self._send_discord_file_partial(
+                    clip_path,
+                    f"{caption} \r\nTruncated to {max_size_mb}MB / {percentage}% of the original video due to Discord file size limit.\r\n"
+                    f"Note: The video player may show the full duration, but playback will stop early due to truncation.",
+                    f"{camera.identifier}_event_partial.mp4",
+                    max_size_bytes,
+                    camera.identifier
+                )
+
+    def _send_discord_message(self, content: str, camera_identifier: str) -> bool:
+        """Send a text message to Discord webhook."""
+        webhook_url = self._get_webhook_url(camera_identifier) if camera_identifier else self._webhook_url
+        try:
+            response = requests.post(
+                webhook_url,
+                json={"content": content},
+                timeout=30
+            )
+            response.raise_for_status()
+            return True
+        except requests.RequestException as e:
+            LOGGER.error(f"Failed to send Discord message: {e}")
+            return False
+
+    def _send_discord_file(self, file_path: str, content: str, filename: str, camera_identifier: str) -> bool:
+        """Send a file to Discord webhook."""
+        webhook_url = self._get_webhook_url(camera_identifier) if camera_identifier else self._webhook_url
+        try:
+            with open(file_path, "rb") as file:
+                response = requests.post(
+                    webhook_url,
+                    files={"file": (filename, file)},
+                    data={"content": content},
+                    timeout=60
+                )
+            response.raise_for_status()
+            return True
+        except requests.RequestException as e:
+            LOGGER.error(f"Failed to send Discord file {file_path}: {e}")
+            return False
+
+    def _send_discord_file_partial(
+        self, file_path: str, content: str, filename: str, max_bytes: int, camera_identifier: str
+    ) -> bool:
+        """Send a partial file to Discord webhook (first max_bytes only)."""
+        webhook_url = self._get_webhook_url(camera_identifier) if camera_identifier else self._webhook_url
+        try:
+            with open(file_path, "rb") as file:
+                file_data = file.read(max_bytes)
+                
+            response = requests.post(
+                webhook_url,
+                files={"file": (filename, file_data)},
+                data={"content": content},
+                timeout=60
+            )
+            response.raise_for_status()
+            return True
+        except requests.RequestException as e:
+            LOGGER.error(f"Failed to send partial Discord file {file_path}: {e}")
+            return False
+
+    async def _run_until_stopped(self):
+        """Run until stopped."""
+        while not self._stop_event.is_set():
+            await asyncio.sleep(1)
+
+    def run_async(self):
+        """Run DiscordNotifier in a new event loop."""
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_until_complete(self._run_until_stopped())
+        LOGGER.info("DiscordNotifier done")
+
+    def stop(self) -> None:
+        """Stop DiscordNotifier component."""
+        self._stop_event.set()
+        LOGGER.info("Stopping DiscordNotifier")

--- a/viseron/components/discord/const.py
+++ b/viseron/components/discord/const.py
@@ -1,0 +1,20 @@
+"""Discord component constants."""
+
+COMPONENT = "discord"
+DESC_COMPONENT = "Discord webhook to send notifications."
+
+CONFIG_DISCORD_WEBHOOK_URL = "webhook_url"
+CONFIG_CAMERAS = "cameras"
+CONFIG_DETECTION_LABEL = "detection_label"
+CONFIG_DETECTION_LABEL_DEFAULT = "person"
+CONFIG_SEND_THUMBNAIL = "send_detection_thumbnail"
+CONFIG_SEND_VIDEO = "send_detection_video"
+CONFIG_MAX_VIDEO_SIZE_MB = "max_video_size_mb"
+CONFIG_MAX_VIDEO_SIZE_MB_DEFAULT = 8
+
+DESC_DISCORD_WEBHOOK_URL = "Discord webhook URL. Can be overridden per camera."
+DESC_DETECTION_LABEL = "Label of the object to send notifications for."
+DESC_SEND_THUMBNAIL = "Send a thumbnail of the detected object."
+DESC_SEND_VIDEO = "Send a video of the detected object."
+DESC_MAX_VIDEO_SIZE_MB = "Maximum size of video to send in MB (Discord limit is 8MB for free tier, 50MB for level 2 boosted servers and 100MB for level 3 boosted servers)."
+DESC_CAMERAS = "Cameras to get notifications from."

--- a/viseron/components/discord/const.py
+++ b/viseron/components/discord/const.py
@@ -16,5 +16,9 @@ DESC_DISCORD_WEBHOOK_URL = "Discord webhook URL. Can be overridden per camera."
 DESC_DETECTION_LABEL = "Label of the object to send notifications for."
 DESC_SEND_THUMBNAIL = "Send a thumbnail of the detected object."
 DESC_SEND_VIDEO = "Send a video of the detected object."
-DESC_MAX_VIDEO_SIZE_MB = "Maximum size of video to send in MB (Discord limit is 8MB for free tier, 50MB for level 2 boosted servers and 100MB for level 3 boosted servers)."
+DESC_MAX_VIDEO_SIZE_MB = (
+    "Maximum size of video to send in MB "
+    "(Discord limit is 8MB for free tier, 50MB for level 2 boosted servers "
+    "and 100MB for level 3 boosted servers)."
+)
 DESC_CAMERAS = "Cameras to get notifications from."


### PR DESCRIPTION
# Adding a Discord component for notifications

## Description

This PR adds a new Discord component to Viseron that allows sending notifications to a Discord webhook when events are detected.

### Features

- **Notifications at key moments**:
  1. **At the start of recording**: A notification message is always sent as soon as recording starts, with or without a thumbnail depending on configuration
  2. **At the end of recording**: If video sending is enabled, a notification with the video is sent either:
     - Complete, if the size limit isn't reached
     - Truncated at the size limit, if reached

- **Configurable parameters**:
  - Discord Webhook URL
  - Thumbnail sending
  - Video sending
  - Detection label (default: "person")
  - Per-camera configuration (ability to override global settings for each camera)

- **Respects Discord limits**:
  - Configurable parameter for maximum video size (default: 8MB)
  - Recommended values based on server boost level:
    - Non-boosted server: 8MB (default)
    - Level 2 boosted server: 50MB
    - Level 3 boosted server: 100MB
  - Sends the first few MB of video (according to configuration) if the total size exceeds this limit

### Configuration Example

```yaml
discord:
  webhook_url: "https://discord.com/api/webhooks/your-webhook-url"
  send_detection_thumbnail: true
  send_detection_video: true
  max_video_size_mb: 8  # 8MB for free tier, 50MB for level 2 boosted servers, 100MB for level 3
  detection_label: "person"
  cameras:
    camera_1:
      send_detection_thumbnail: false
      send_detection_video: false
      max_video_size_mb: 50  # Override for boosted server
      detection_label: "car"
    camera_2:
```

### Documentation

Complete documentation has been added in the `docs/src/pages/components-explorer/components/discord/` folder.
