### PR TITLE
Add Notification Category to Components Explorer

### DIFF
--- a/docs/src/pages/components-explorer/components/telegram/_meta.tsx
+++ b/docs/src/pages/components-explorer/components/telegram/_meta.tsx
@@ -6,7 +6,7 @@ const ComponentMetadata: Component = {
   description: "Control PTZ cameras and receive notifications via Telegram",
   image:
     "https://upload.wikimedia.org/wikipedia/commons/thumb/8/83/Telegram_2019_Logo.svg/150px-Telegram_2019_Logo.svg.png",
-  tags: [],
+  tags: ["notification"],
 };
 
 export default ComponentMetadata;

--- a/docs/src/types.ts
+++ b/docs/src/types.ts
@@ -4,6 +4,7 @@ export type DomainType =
   | "image_classification"
   | "license_plate_recognition"
   | "motion_detector"
+  | "notification"
   | "nvr"
   | "object_detector"
   | "system";
@@ -45,6 +46,11 @@ export const Domains: { [type in DomainType]: Domain } = {
   motion_detector: {
     label: "Motion Detector",
     color: "#a44fb7",
+  },
+
+  notification: {
+    label: "Notification",
+    color: "#ff2a44",
   },
 
   nvr: {


### PR DESCRIPTION
# Add Notification Category to Components Explorer

This PR adds a new "Notification" category to the components explorer to properly categorize notification-related components.

## Changes:

1. Added a new "notification" domain type in `docs/src/types.ts` with:
   - Label: "Notification"
   - Color: "#ff2a44" (red for Alert)

2. Updated Telegram component metadata to include the "notification" tag

<details><summary>Screenshot</summary>
<p>

![image](https://github.com/user-attachments/assets/a9766d11-68e1-49d2-b289-a23530fda446)


</p>
</details> 