### PR TITLE
allow for grouping events for different cameras

### DIFF
--- a/frontend/src/components/events/EventTable.tsx
+++ b/frontend/src/components/events/EventTable.tsx
@@ -31,13 +31,14 @@ const useGroupedEvents = (snapshotEvents: types.CameraEvent[]) => {
 
     snapshotEvents.forEach((event) => {
       // Filter out unwanted event types
-      if (!filters[event.type].checked) return;
+      if (!filters.eventTypes[event.type].checked) return;
 
       const currentTime = getEventTimestamp(event);
 
       if (
         groupStartTime - currentTime < 120 &&
-        event.camera_identifier === groupCameraIdentifier
+        (filters.groupCameras.checked ||
+          event.camera_identifier === groupCameraIdentifier)
       ) {
         currentGroup.push(event);
       } else {

--- a/frontend/src/components/events/FilterMenu.tsx
+++ b/frontend/src/components/events/FilterMenu.tsx
@@ -9,7 +9,11 @@ import MenuItem from "@mui/material/MenuItem";
 import { NestedMenuItem } from "mui-nested-menu";
 import React, { MouseEvent, useState } from "react";
 
-import { getIconFromType, useFilterStore } from "components/events/utils";
+import {
+  FilterKeysFromFilters,
+  getIconFromType,
+  useFilterStore,
+} from "components/events/utils";
 import * as types from "lib/types";
 
 interface MenuProps {
@@ -48,8 +52,7 @@ export const FilterMenu: React.FC = () => {
   };
 
   const handleCheckboxClick =
-    (filterKey: types.CameraEvent["type"]) =>
-    (event: MouseEvent<HTMLElement>) => {
+    (filterKey: FilterKeysFromFilters) => (event: MouseEvent<HTMLElement>) => {
       event.stopPropagation();
       event.preventDefault();
       toggleFilter(filterKey);
@@ -80,26 +83,36 @@ export const FilterMenu: React.FC = () => {
           parentMenuOpen={open}
           MenuProps={menuProps}
         >
-          {Object.keys(filters).map((filterKey) => {
+          {Object.keys(filters.eventTypes).map((filterKey) => {
             const key = filterKey as types.CameraEvent["type"];
             const Icon = getIconFromType(key);
             return (
               <MenuItem
-                key={filters[key].label}
+                key={filters.eventTypes[key].label}
                 onClick={handleCheckboxClick(key)}
               >
                 <Checkbox
-                  checked={filters[key].checked}
+                  checked={filters.eventTypes[key].checked}
                   onClick={handleCheckboxClick(key)}
                 />
                 <ListItemIcon>
                   <Icon />
                 </ListItemIcon>
-                <ListItemText primary={filters[key].label} />
+                <ListItemText primary={filters.eventTypes[key].label} />
               </MenuItem>
             );
           })}
         </NestedMenuItem>
+        <MenuItem
+          key={"groupCameras"}
+          onClick={handleCheckboxClick("groupCameras")}
+        >
+          <Checkbox
+            checked={filters.groupCameras.checked}
+            onClick={handleCheckboxClick("groupCameras")}
+          />
+          <ListItemText primary={filters.groupCameras.label} />
+        </MenuItem>
       </Menu>
     </>
   );

--- a/frontend/src/components/events/SnapshotEvent.tsx
+++ b/frontend/src/components/events/SnapshotEvent.tsx
@@ -18,6 +18,7 @@ import PopupState, { bindHover, bindPopover } from "material-ui-popup-state";
 import HoverPopover from "material-ui-popup-state/HoverPopover";
 import { memo, useCallback, useRef } from "react";
 
+import { CameraNameOverlay } from "components/camera/CameraNameOverlay";
 import {
   EVENT_ICON_HEIGHT,
   TICK_HEIGHT,
@@ -28,6 +29,7 @@ import {
   getEventTimestamp,
   getIcon,
   getSrc,
+  useFilterStore,
   useSelectEvent,
 } from "components/events/utils";
 import { useExportEvent } from "lib/commands";
@@ -135,6 +137,7 @@ const PopoverContent = ({ events }: { events: types.CameraEvent[] }) => {
   const width = matches ? (events.length > 1 ? "50vw" : "25vw") : "90vw";
   const handleEventClick = useSelectEvent();
   const exportEvent = useExportEvent();
+  const { filters } = useFilterStore();
 
   return (
     <Grid
@@ -172,6 +175,11 @@ const PopoverContent = ({ events }: { events: types.CameraEvent[] }) => {
                       objectFit: "contain",
                     }}
                   />
+                  {filters.groupCameras.checked && (
+                    <CameraNameOverlay
+                      camera_identifier={event.camera_identifier}
+                    />
+                  )}
                 </CardMedia>
               </CardActionArea>
               <CardContent>{getText(event)}</CardContent>


### PR DESCRIPTION
New button on the Events page to group events from different cameras.
Makes it easier to get an overview of the events if many cameras are viewed

![image](https://github.com/user-attachments/assets/6587bf28-3e3a-490b-ab02-9ebfbfbb3100)
