### PR TITLE
assign cameras to users

### DIFF
--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -230,11 +230,14 @@ async function authUpdateUser({
   name,
   username,
   role,
+  assigned_cameras,
 }: types.AuthUserResponse) {
   const response = await viseronAPI.put(`/auth/user/${id}`, {
     name,
     username,
     role,
+    assigned_cameras:
+      assigned_cameras && assigned_cameras.length > 0 ? assigned_cameras : null,
   });
   return response.data;
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -126,6 +126,7 @@ export type AuthUserResponse = {
   name: string;
   username: string;
   role: "admin" | "read" | "write";
+  assigned_cameras: string[] | null;
 };
 
 export type AuthUsersResponse = {

--- a/frontend/tests/utils/renderWithContext.tsx
+++ b/frontend/tests/utils/renderWithContext.tsx
@@ -27,6 +27,7 @@ function customRender(
     name: "",
     username: "",
     role: "admin",
+    assigned_cameras: null,
   },
   options?: Omit<RenderOptions, "wrapper">,
 ) {

--- a/tests/components/webserver/api/v1/test_auth.py
+++ b/tests/components/webserver/api/v1/test_auth.py
@@ -512,6 +512,7 @@ class TestAuthAPIHandler(TestAppBaseAuth):
                         "name": "Updated Name",
                         "username": "updated_username",
                         "role": "write",
+                        "assigned_cameras": None,
                     }
                 ),
             )
@@ -534,6 +535,7 @@ class TestAuthAPIHandler(TestAppBaseAuth):
                         "name": "Updated Name",
                         "username": "updated_username",
                         "role": "write",
+                        "assigned_cameras": None,
                     }
                 ),
             )
@@ -557,6 +559,7 @@ class TestAuthAPIHandler(TestAppBaseAuth):
                         "name": "Updated Name",
                         "username": "test1",
                         "role": "write",
+                        "assigned_cameras": None,
                     }
                 ),
             )
@@ -572,6 +575,7 @@ class TestAuthAPIHandler(TestAppBaseAuth):
             "name": "Updated Name",
             "username": "updated_username",
             "role": "invalid",
+            "assigned_cameras": None,
         }
         response = self.fetch_with_auth(
             "/api/v1/auth/user/123456789",

--- a/tests/components/webserver/test_auth.py
+++ b/tests/components/webserver/test_auth.py
@@ -160,7 +160,9 @@ class TestAuth:
     def test_update_user(self):
         """Test updating a user's details."""
         user = self.auth.add_user("Test", "test", "test", Role.ADMIN)
-        self.auth.update_user(user.id, "Updated Name", "updated_username", Role.ADMIN)
+        self.auth.update_user(
+            user.id, "Updated Name", "updated_username", Role.ADMIN, None
+        )
         updated_user = self.auth.get_user(user.id)
         assert updated_user is not None
         assert updated_user.id == user.id
@@ -175,14 +177,14 @@ class TestAuth:
             LastAdminUserError, match="Cannot change the role of the last admin user"
         ):
             self.auth.update_user(
-                user.id, "Updated Name", "updated_username", Role.WRITE
+                user.id, "Updated Name", "updated_username", Role.WRITE, None
             )
 
     def test_update_user_nonexistent(self):
         """Test updating a nonexistent user."""
         with pytest.raises(UserDoesNotExistError):
             self.auth.update_user(
-                "nonexistent_id", "Updated Name", "updated_username", Role.WRITE
+                "nonexistent_id", "Updated Name", "updated_username", Role.WRITE, None
             )
 
     def test_update_user_duplicate_username(self):
@@ -190,7 +192,7 @@ class TestAuth:
         self.auth.add_user("Test1", "test1", "test", Role.ADMIN)
         user2 = self.auth.add_user("Test2", "test2", "test", Role.WRITE)
         with pytest.raises(UserExistsError, match="Username test1 is already taken"):
-            self.auth.update_user(user2.id, "Updated Name", "test1", Role.WRITE)
+            self.auth.update_user(user2.id, "Updated Name", "test1", Role.WRITE, None)
 
     def test_update_user_invalid_role(self):
         """Test updating a user with an invalid role."""
@@ -202,6 +204,7 @@ class TestAuth:
                 "Updated Name",
                 "updated_username",
                 "invalid",  # type: ignore[arg-type]
+                None,
             )
 
     def test_generate_refresh_token(self):

--- a/viseron/components/webserver/api/v1/auth.py
+++ b/viseron/components/webserver/api/v1/auth.py
@@ -118,6 +118,7 @@ class AuthAPIHandler(BaseAPIHandler):
                     vol.Required("name"): str,
                     vol.Required("username"): str,
                     vol.Required("role"): vol.In([e.value for e in Role]),
+                    vol.Required("assigned_cameras"): vol.Maybe(list),
                 }
             ),
         },
@@ -330,6 +331,7 @@ class AuthAPIHandler(BaseAPIHandler):
                 self.json_body["name"],
                 self.json_body["username"],
                 Role(self.json_body["role"]),
+                self.json_body["assigned_cameras"],
             )
         except UserDoesNotExistError as error:
             self.response_error(HTTPStatus.NOT_FOUND, reason=str(error))

--- a/viseron/components/webserver/api/v1/cameras.py
+++ b/viseron/components/webserver/api/v1/cameras.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 import logging
 
 from viseron.components.webserver.api.handlers import BaseAPIHandler
-from viseron.const import DOMAIN_FAILED, REGISTERED_DOMAINS
-from viseron.domains.camera.const import DOMAIN as CAMERA_DOMAIN
 
 LOGGER = logging.getLogger(__name__)
 
@@ -17,26 +15,19 @@ class CamerasAPIHandler(BaseAPIHandler):
         {
             "path_pattern": r"/cameras",
             "supported_methods": ["GET"],
-            "method": "get_cameras",
+            "method": "get_cameras_endpoint",
         },
         {
             "path_pattern": r"/cameras/failed",
             "supported_methods": ["GET"],
-            "method": "get_failed_cameras",
+            "method": "get_failed_cameras_endpoint",
         },
     ]
 
-    async def get_cameras(self) -> None:
+    async def get_cameras_endpoint(self) -> None:
         """Return cameras."""
-        await self.response_success(
-            response=self._vis.data[REGISTERED_DOMAINS].get(CAMERA_DOMAIN, {})
-        )
+        await self.response_success(response=self._get_cameras())
 
-    async def get_failed_cameras(self) -> None:
+    async def get_failed_cameras_endpoint(self) -> None:
         """Return failed cameras."""
-        failed_cameras = {}
-        for failed_camera in (
-            self._vis.data[DOMAIN_FAILED].get(CAMERA_DOMAIN, {}).values()
-        ):
-            failed_cameras[failed_camera.identifier] = failed_camera.error_instance
-        await self.response_success(response=failed_cameras)
+        await self.response_success(response=self._get_failed_cameras())

--- a/viseron/components/webserver/auth.py
+++ b/viseron/components/webserver/auth.py
@@ -97,6 +97,7 @@ class User:
     role: Role
     id: str = field(default_factory=lambda: uuid.uuid4().hex)
     enabled: bool = True
+    assigned_cameras: list[str] | None = None
 
     def asdict(self) -> dict[str, Any]:
         """Convert user to dict."""
@@ -105,6 +106,7 @@ class User:
             "name": self.name,
             "username": self.username,
             "role": self.role.value,
+            "assigned_cameras": self.assigned_cameras,
         }
 
 
@@ -319,7 +321,14 @@ class Auth:
             LOGGER.debug(f"Password changed for user {user.username}")
             self.save()
 
-    def update_user(self, user_id: str, name: str, username: str, role: Role) -> None:
+    def update_user(
+        self,
+        user_id: str,
+        name: str,
+        username: str,
+        role: Role,
+        assigned_cameras: list[str] | None,
+    ) -> None:
         """Update user details."""
         with self._user_lock:
             if user_id not in self.users:
@@ -348,6 +357,7 @@ class Auth:
             user.name = name.strip()
             user.username = username.strip().casefold()
             user.role = role
+            user.assigned_cameras = assigned_cameras
             LOGGER.debug(f"Updated user {user.username}")
             self.save()
 
@@ -368,6 +378,7 @@ class Auth:
                 role=Role(user["group"] if user.get("group", False) else user["role"]),
                 id=user["id"],
                 enabled=user["enabled"],
+                assigned_cameras=user.get("assigned_cameras", None),
             )
 
         for refresh_token in data.get("refresh_tokens", {}).values():

--- a/viseron/components/webserver/websocket_api/commands.py
+++ b/viseron/components/webserver/websocket_api/commands.py
@@ -44,13 +44,7 @@ from viseron.components.webserver.const import (
     WS_ERROR_SAVE_CONFIG_FAILED,
 )
 from viseron.components.webserver.download_token import DownloadToken
-from viseron.const import (
-    CONFIG_PATH,
-    EVENT_STATE_CHANGED,
-    REGISTERED_DOMAINS,
-    RESTART_EXIT_CODE,
-)
-from viseron.domains.camera.const import DOMAIN as CAMERA_DOMAIN
+from viseron.const import CONFIG_PATH, EVENT_STATE_CHANGED, RESTART_EXIT_CODE
 from viseron.domains.camera.fragmenter import (
     Fragment,
     Timespan,
@@ -263,7 +257,7 @@ async def get_cameras(connection: WebSocketHandler, message) -> None:
     await connection.async_send_message(
         result_message(
             message["command_id"],
-            connection.vis.data[REGISTERED_DOMAINS].get(CAMERA_DOMAIN, {}),
+            connection.get_cameras(),
         ),
     )
 


### PR DESCRIPTION
This PR makes it possible to assign cameras per user.

Admins can choose what cameras each user can access using the User Management page.
The user will then not see the cameras at all in the UI and the API will not return them, even if somehow requested.

Some camera events may still slip through tho but that should not matter.
