### PR TITLE
add lookback adjustment when clicking on an event

### DIFF
--- a/frontend/src/components/events/FilterMenu.tsx
+++ b/frontend/src/components/events/FilterMenu.tsx
@@ -113,6 +113,16 @@ export const FilterMenu: React.FC = () => {
           />
           <ListItemText primary={filters.groupCameras.label} />
         </MenuItem>
+        <MenuItem
+          key={"lookbackAdjust"}
+          onClick={handleCheckboxClick("lookbackAdjust")}
+        >
+          <Checkbox
+            checked={filters.lookbackAdjust.checked}
+            onClick={handleCheckboxClick("lookbackAdjust")}
+          />
+          <ListItemText primary={filters.lookbackAdjust.label} />
+        </MenuItem>
       </Menu>
     </>
   );

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -257,6 +257,7 @@ type CameraBaseEvent = {
   id: number;
   created_at: string;
   created_at_timestamp: number;
+  lookback: number;
 };
 
 type CameraBaseTimedEvent = CameraBaseEvent & {

--- a/viseron/components/webserver/api/v1/events.py
+++ b/viseron/components/webserver/api/v1/events.py
@@ -115,6 +115,7 @@ class EventsAPIHandler(BaseAPIHandler):
                         else None,
                         "created_at": event.created_at,
                         "created_at_timestamp": event.created_at.timestamp(),
+                        "lookback": camera.recorder.lookback,
                     }
                 )
         return motion_events
@@ -155,6 +156,7 @@ class EventsAPIHandler(BaseAPIHandler):
                         "created_at": event.created_at,
                         "created_at_timestamp": event.created_at.timestamp(),
                         "snapshot_path": f"/files{event.snapshot_path}",
+                        "lookback": camera.recorder.lookback,
                     }
                 )
         return object_events
@@ -206,6 +208,7 @@ class EventsAPIHandler(BaseAPIHandler):
                         "thumbnail_path": f"/files{event.thumbnail_path}",
                         "created_at": event.created_at,
                         "created_at_timestamp": event.created_at.timestamp(),
+                        "lookback": camera.recorder.lookback,
                     }
                 )
         return recording_events
@@ -254,6 +257,7 @@ class EventsAPIHandler(BaseAPIHandler):
                         "data": event.data,
                         "created_at": event.created_at,
                         "created_at_timestamp": event.created_at.timestamp(),
+                        "lookback": camera.recorder.lookback,
                     }
                 )
         return post_processor_events


### PR DESCRIPTION
Add a new checkbox to the filter menu which controls wether the played back timestamp is adjusted by the configured lookback value or not

![image](https://github.com/user-attachments/assets/c135bf59-232f-4c72-8bd2-cf55d6f5dfc7)

Closes #966 
