### PR TITLE
set requested timestamp from query parameter

### DIFF
--- a/docs/docs/documentation/configuration/recordings.mdx
+++ b/docs/docs/documentation/configuration/recordings.mdx
@@ -356,3 +356,20 @@ This will create `.mp4` files for all event recordings, which will be stored in 
 THe `.mp4` files will be created in the `/event_clips` directory, unless you have set a different path in the [storage component](/components-explorer/components/storage).
 
 :::
+
+## Events page query parameters
+
+The `Events` page supports a number of query parameters to control the behavior of the page.
+
+The following query parameters are supported:
+
+- `tab`: The tab to show. This can be `events` or `timeline`.
+- `camera`: The camera identifier of the camera to show.
+- `date`: The date to show, in the format `YYYY-MM-DD`.
+- `timestamp`: The timestamp to seek to. This is a Unix timestamp in seconds.
+
+Example URL to show the timeline for camera `camera_one` and seek to the timestamp `1745001300`:
+
+```bash
+http://localhost:8888/#/events?tab=timeline&camera=camera_one&timestamp=1745001300
+```

--- a/frontend/src/pages/Events.tsx
+++ b/frontend/src/pages/Events.tsx
@@ -2,10 +2,14 @@ import dayjs, { Dayjs } from "dayjs";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import ServerDown from "svg/undraw/server_down.svg?react";
+import { useShallow } from "zustand/react/shallow";
 
 import { ErrorMessage } from "components/error/ErrorMessage";
 import { Layout } from "components/events/Layouts";
-import { useCameraStore } from "components/events/utils";
+import {
+  useCameraStore,
+  useReferencePlayerStore,
+} from "components/events/utils";
 import { Loading } from "components/loading/Loading";
 import { useHideScrollbar } from "hooks/UseHideScrollbar";
 import { useTitle } from "hooks/UseTitle";
@@ -33,7 +37,11 @@ const Events = () => {
   useHideScrollbar();
   const [searchParams] = useSearchParams();
   const { selectSingleCamera } = useCameraStore();
-
+  const { setRequestedTimestamp } = useReferencePlayerStore(
+    useShallow((state) => ({
+      setRequestedTimestamp: state.setRequestedTimestamp,
+    })),
+  );
   const camerasAll = useCamerasAll();
 
   const [date, setDate] = useState<Dayjs | null>(
@@ -51,6 +59,7 @@ const Events = () => {
         camerasAll.combinedData[searchParams.get("camera") as string]
           .identifier,
       );
+      searchParams.delete("camera");
       const newUrl = removeURLParameter(window.location.href, "camera");
       window.history.pushState({ path: newUrl }, "", newUrl);
     }
@@ -61,6 +70,18 @@ const Events = () => {
       insertURLParameter("date", date.format("YYYY-MM-DD"));
     }
   }, [date]);
+
+  useEffect(() => {
+    if (searchParams.has("timestamp")) {
+      const timestamp = searchParams.get("timestamp");
+      if (timestamp && !isNaN(Number(timestamp))) {
+        setRequestedTimestamp(Number(timestamp));
+      }
+      searchParams.delete("timestamp");
+      const newUrl = removeURLParameter(window.location.href, "timestamp");
+      window.history.pushState({ path: newUrl }, "", newUrl);
+    }
+  }, [searchParams, setRequestedTimestamp]);
 
   if (camerasAll.cameras.isError) {
     return (


### PR DESCRIPTION
Allows setting the timestamp which the Events page starts to play on load by using the query parameter `timestamp`.
The timestamp should be a UTC timestamp.

Example URL: `http://host.lan:8888/#/events?tab=timeline&date=2025-04-18&timestamp=1745001300`

Closes #942 