### PR TITLE
expose main stream resolution to get correct aspect ratio for streams

### DIFF
--- a/frontend/src/components/events/EventPlayerCard.tsx
+++ b/frontend/src/components/events/EventPlayerCard.tsx
@@ -64,7 +64,7 @@ const calculateCellDimensions = (
   const containerHeight = getContainerHeight(paperRef, smBreakpoint);
   const cellWidth = containerWidth / gridLayout.columns;
   const cellHeight = containerHeight / gridLayout.rows;
-  const cameraAspectRatio = camera.width / camera.height;
+  const cameraAspectRatio = camera.mainstream.width / camera.mainstream.height;
   const cellAspectRatio = cellWidth / cellHeight;
 
   if (cameraAspectRatio > cellAspectRatio) {
@@ -103,7 +103,7 @@ const calculateLayout = (
 
     // Adjust for aspect ratio
     Object.values(cameras).forEach((camera) => {
-      const aspectRatio = camera.width / camera.height;
+      const aspectRatio = camera.mainstream.width / camera.mainstream.height;
       const adjustedWidth = Math.min(cellWidth, cellHeight * aspectRatio);
       const adjustedHeight = Math.min(cellHeight, cellWidth / aspectRatio);
       minDimension = Math.min(minDimension, adjustedWidth, adjustedHeight);

--- a/frontend/src/components/recording/RecordingCard.tsx
+++ b/frontend/src/components/recording/RecordingCard.tsx
@@ -55,7 +55,7 @@ export default function RecordingCard({
           offset={500}
           placeholder={
             <VideoPlayerPlaceholder
-              aspectRatio={camera.width / camera.height}
+              aspectRatio={camera.mainstream.width / camera.mainstream.height}
             />
           }
         >

--- a/frontend/src/components/recording/RecordingCardDaily.tsx
+++ b/frontend/src/components/recording/RecordingCardDaily.tsx
@@ -67,7 +67,7 @@ export default function RecordingCardDaily({
           offset={500}
           placeholder={
             <VideoPlayerPlaceholder
-              aspectRatio={camera.width / camera.height}
+              aspectRatio={camera.mainstream.width / camera.mainstream.height}
             />
           }
         >

--- a/frontend/src/components/recording/RecordingCardLatest.tsx
+++ b/frontend/src/components/recording/RecordingCardLatest.tsx
@@ -108,7 +108,10 @@ export default function RecordingCardLatest({
           height={200}
           placeholder={
             <VideoPlayerPlaceholder
-              aspectRatio={cameraQuery.data.width / cameraQuery.data.height}
+              aspectRatio={
+                cameraQuery.data.mainstream.width /
+                cameraQuery.data.mainstream.height
+              }
             />
           }
         >

--- a/frontend/src/lib/helpers.tsx
+++ b/frontend/src/lib/helpers.tsx
@@ -69,7 +69,9 @@ export function getVideoElement(
 ) {
   if (!objHasValues(recording) || !recording) {
     return (
-      <VideoPlayerPlaceholder aspectRatio={camera.width / camera.height} />
+      <VideoPlayerPlaceholder
+        aspectRatio={camera.mainstream.width / camera.mainstream.height}
+      />
     );
   }
 
@@ -84,7 +86,9 @@ export function getVideoElement(
   return (
     <Suspense
       fallback={
-        <VideoPlayerPlaceholder aspectRatio={camera.width / camera.height} />
+        <VideoPlayerPlaceholder
+          aspectRatio={camera.mainstream.width / camera.mainstream.height}
+        />
       }
     >
       <VideoPlayer options={videoJsOptions} />

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -169,6 +169,10 @@ export interface Camera {
   width: number;
   height: number;
   access_token: string;
+  mainstream: {
+    width: number;
+    height: number;
+  };
   still_image: {
     refresh_interval: number;
     available: boolean;
@@ -189,6 +193,10 @@ export interface FailedCamera {
   name: string;
   width: number;
   height: number;
+  mainstream: {
+    width: number;
+    height: number;
+  };
   error: string;
   retrying: boolean;
   failed: true;

--- a/frontend/tests/lib/helpers.test.ts
+++ b/frontend/tests/lib/helpers.test.ts
@@ -17,6 +17,10 @@ const mockCamera: types.Camera = {
   identifier: "",
   name: "",
   access_token: "",
+  mainstream: {
+    width: 1920,
+    height: 1080,
+  },
   still_image: {
     refresh_interval: 0,
     available: true,

--- a/viseron/components/ffmpeg/camera.py
+++ b/viseron/components/ffmpeg/camera.py
@@ -540,6 +540,11 @@ class Camera(AbstractCamera):
         self._resolution = resolution
 
     @property
+    def mainstream_resolution(self) -> tuple[int, int]:
+        """Return mainstream resolution."""
+        return self.stream.mainstream.width, self.stream.mainstream.height
+
+    @property
     def recorder(self) -> Recorder:
         """Return recorder instance."""
         return self._recorder

--- a/viseron/components/ffmpeg/stream.py
+++ b/viseron/components/ffmpeg/stream.py
@@ -173,6 +173,11 @@ class Stream:
             pass
 
     @property
+    def mainstream(self) -> StreamInformation:
+        """Return main stream information."""
+        return self._mainstream
+
+    @property
     def width(self) -> int:
         """Return stream width."""
         if self._substream:

--- a/viseron/components/gstreamer/camera.py
+++ b/viseron/components/gstreamer/camera.py
@@ -463,6 +463,15 @@ class Camera(AbstractCamera):
         self._resolution = resolution
 
     @property
+    def mainstream_resolution(self) -> tuple[int, int]:
+        """Return mainstream resolution.
+
+        GStreamer does not support substream, so we return the same value as
+        self.resolution.
+        """
+        return self.resolution
+
+    @property
     def recorder(self) -> Recorder:
         """Return recorder instance."""
         return self._recorder

--- a/viseron/domains/camera/__init__.py
+++ b/viseron/domains/camera/__init__.py
@@ -191,6 +191,10 @@ class AbstractCamera(AbstractDomain):
             "width": self.resolution[0],
             "height": self.resolution[1],
             "access_token": self.access_token,
+            "mainstream": {
+                "width": self.mainstream_resolution[0],
+                "height": self.mainstream_resolution[1],
+            },
             "still_image": {
                 "refresh_interval": self.still_image[CONFIG_REFRESH_INTERVAL],
                 "available": self.still_image_available,
@@ -305,6 +309,14 @@ class AbstractCamera(AbstractDomain):
     @abstractmethod
     def resolution(self) -> tuple[int, int]:
         """Return stream resolution."""
+
+    @property
+    @abstractmethod
+    def mainstream_resolution(self) -> tuple[int, int]:
+        """Return mainstream resolution.
+
+        Only applicable for components that support substreams.
+        """
 
     @property
     def extension(self) -> str:
@@ -586,6 +598,10 @@ class FailedCamera:
             "identifier": self.identifier,
             "width": self.width,
             "height": self.height,
+            "mainstream": {
+                "width": self.width,
+                "height": self.height,
+            },
             "error": self.error,
             "retrying": self.retrying,
             "failed": True,


### PR DESCRIPTION
When using a substream that has different aspect ratio than the main stream, the aspect ratio of videoplayers was incorrectly set to the substreams resolution.

This PR fixes that