### PR TITLE
edgetpu restart on failure

### DIFF
--- a/viseron/components/edgetpu/__init__.py
+++ b/viseron/components/edgetpu/__init__.py
@@ -5,6 +5,7 @@ import ast
 import logging
 import multiprocessing as mp
 import subprocess as sp
+import threading
 from abc import abstractmethod
 from queue import Queue
 
@@ -257,7 +258,13 @@ class EdgeTPU(SubProcessWorker):
         self._result_queues: dict[str, Queue] = {}
         self._process_initialization_done = mp.Event()
         self._process_initialization_error = mp.Event()
+        self._reload_lock = threading.Lock()
+        self._consecutive_failures = 0
         super().__init__(vis, f"{COMPONENT}.{domain}")
+        self.initialize()
+
+    def initialize(self) -> None:
+        """Initialize EdgeTPU."""
         self._process_initialization_done.wait(30)
         if (
             not self._process_initialization_done.is_set()
@@ -280,6 +287,23 @@ class EdgeTPU(SubProcessWorker):
     @abstractmethod
     def post_process(self, item):
         """Post process after invoke."""
+
+    def reload_if_needed(self):
+        """Reload the interpreter if it fails 10 times in a row."""
+        with self._reload_lock:
+            self._consecutive_failures += 1
+            if self._consecutive_failures >= 10:
+                try:
+                    LOGGER.warning(
+                        "Reloading EdgeTPU interpreter after "
+                        f"{self._consecutive_failures} consecutive failures."
+                    )
+                    self.stop()
+                    self.start()
+                except Exception as e:  # pylint: disable=broad-except
+                    LOGGER.error(f"Failed to reload EdgeTPU interpreter: {e}")
+                finally:
+                    self._consecutive_failures = 0
 
     def spawn_subprocess(self) -> RestartablePopen:
         """Spawn subprocess."""

--- a/viseron/components/edgetpu/object_detector.py
+++ b/viseron/components/edgetpu/object_detector.py
@@ -67,6 +67,10 @@ class ObjectDetector(AbstractObjectDetector):
             self._camera.resolution,
         )
 
+    def result_failed_callback(self):
+        """Call EdgeTPU reload_if_needed on failure."""
+        self._edgetpu.reload_if_needed()
+
     @property
     def model_width(self) -> int:
         """Return trained model width."""

--- a/viseron/domains/motion_detector/__init__.py
+++ b/viseron/domains/motion_detector/__init__.py
@@ -454,6 +454,13 @@ class AbstractMotionDetectorScanner(AbstractMotionDetector):
         if event_data.data.scan is False:
             self._motion_detected_setter(False, None, None)
 
+    def result_failed_callback(self):
+        """Detector result failed callback.
+
+        Called when the NVR component does not receive a result from the motion
+        detector.
+        """
+
     def stop(self) -> None:
         """Stop motion detector."""
         self._kill_received = True

--- a/viseron/domains/object_detector/__init__.py
+++ b/viseron/domains/object_detector/__init__.py
@@ -577,6 +577,13 @@ class AbstractObjectDetector(AbstractDomain):
             for zone in self.zones:
                 zone.objects_in_zone_setter(None, [])
 
+    def result_failed_callback(self):
+        """Detector result failed callback.
+
+        Called when the NVR component does not receive a result from the object
+        detector.
+        """
+
     def stop(self) -> None:
         """Stop object detector."""
         self._kill_received = True

--- a/viseron/helpers/subprocess_worker.py
+++ b/viseron/helpers/subprocess_worker.py
@@ -39,8 +39,14 @@ class SubProcessWorker(ABC):
         self._name = name
 
         self._authkey_store = BaseManagerAuthkeyStore(vis)
-        self._server_port = get_free_port(port=50000)
 
+        self.start()
+
+        vis.register_signal_handler(VISERON_SIGNAL_SHUTDOWN, self.stop)
+
+    def start(self) -> None:
+        """Start the subprocess worker."""
+        self._server_port = get_free_port(port=50000)
         self._process_frames_proc_exit = mp.Event()
 
         self.input_queue: Any = Queue(maxsize=100)
@@ -77,8 +83,6 @@ class SubProcessWorker(ABC):
         LOGGER.debug("Spawned subprocess")
         self._process_frames_proc = self.spawn_subprocess()
         LOGGER.debug(f"Started subprocess {self.subprocess_name}")
-
-        vis.register_signal_handler(VISERON_SIGNAL_SHUTDOWN, self.stop)
 
     @property
     def subprocess_name(self) -> str:
@@ -165,7 +169,7 @@ class Server:
 
     def start_server(self):
         """Start the server."""
-        LOGGER.debug("Starting queue manager server")
+        LOGGER.debug(f"Starting queue manager server on {self.address}:{self.port}")
         self._manager = start(
             address=self.address,
             port=self.port,


### PR DESCRIPTION
Adds a new callback in motion/object detector, `result_failed_callback`, that is called from the `NVR` component when it waits for too long before retrieving a result.

EdgeTPU processes will be restarted after 10 failures has occured