### PR TITLE
don't try to generate event clip when no fragments available

### DIFF
--- a/viseron/domains/camera/recorder.py
+++ b/viseron/domains/camera/recorder.py
@@ -375,6 +375,10 @@ class AbstractRecorder(ABC, RecorderBase):
             Fragment(file.filename, file.path, file.duration, file.orig_ctime)
             for file in files
         ]
+        if len(fragments) == 0:
+            self._logger.info("No fragments immediately available to generate event clip.")
+            return
+
         event_clip = self._camera.fragmenter.concatenate_fragments(fragments)
         if not event_clip:
             return


### PR DESCRIPTION
The error message this addresses is benign and does not cause any functional impact:
```
viseron  | 2025-06-06 16:10:19.613 [ERROR   ] [viseron.domains.camera.fragmenter.camera_1.ffmpeg] - pipe:: Invalid data found when processing input
viseron  | 2025-06-06 16:10:19.614 [ERROR   ] [viseron.domains.camera.fragmenter.camera_1] - Command '['ffmpeg', '-hide_banner', '-loglevel', 'error', '-protocol_whitelist', 'file,pipe', '-i', '-', '-c:v', 'copy', '-c:a', 'copy', '-movflags', '+faststart', '/tmp/viseron/55ad4526-ba0a-4bfa-9745-71670c2e8c34.mp4']' returned non-zero exit status 1.
```

This error only occurs when `create_event_clip` is true and there are no fragments available at the time `Fragmenter::concatenate_fragments` is called.

On my system, when this error occurs the event clip is available after a very short period of time.

Based on this, the pull request does not try to call `concatenate_fragments` when there are no available fragments.  It prints an info message instead.

Discussion on this [topic](https://github.com/roflcoopter/viseron/discussions/1010)