### PR TITLE
remove config bind mount and change its location in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,7 @@
   "overrideCommand": false,
   "containerEnv": {
     "DEVCONTAINER": "1",
+    "VISERON_CONFIG_DIR": "${containerWorkspaceFolder}/config",
     "PUID": "1000",
     "PGID": "1000"
   },
@@ -32,9 +33,6 @@
   },
   "userEnvProbe": "loginInteractiveShell",
   "runArgs": ["-e", "GIT_EDITOR=code --wait"],
-  "mounts": [
-    "source=${localWorkspaceFolder}/config,target=/config,type=bind,consistency=cached"
-  ],
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -30,8 +30,8 @@ sed -i 's/#force_color_prompt=yes/force_color_prompt=yes/g' $HOME/.bashrc
 
 # Create default config if it is missing
 cd $WORKSPACE_DIR
-mkdir -p $WORKSPACE_DIR/config
-FILE=$WORKSPACE_DIR/config/config.yaml
+mkdir -p $VISERON_CONFIG_DIR
+FILE=$VISERON_CONFIG_DIR/config.yaml
 if test -f "$FILE"; then
     echo "Config file already exists"
 else

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -91,6 +91,7 @@ ARG S6_OVERLAY_VERSION
 ARG EXTRA_APT_PACKAGES
 
 ENV \
+  VISERON_CONFIG_DIR=/config \
   DEBIAN_FRONTEND=noninteractive \
   S6_KEEP_ENV=1 \
   S6_SERVICES_GRACETIME=30000 \
@@ -100,7 +101,6 @@ ENV \
   LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib \
   PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.10/site-packages \
   OPENCV_OPENCL_CACHE_ENABLE=false \
-  PGDATA=/config/postgresql \
   PG_COLOR="always"
 
 ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_OVERLAY_ARCH}-installer /tmp/s6-overlay-installer

--- a/rootfs/etc/cont-finish.d/10-postgres
+++ b/rootfs/etc/cont-finish.d/10-postgres
@@ -11,7 +11,7 @@ done
 log_info "Viseron has stopped!"
 
 log_info "Stopping PostgreSQL..."
-s6-setuidgid postgres $PG_BIN/pg_ctl -D /config/postgresql -l /config/postgresql/logfile stop
+s6-setuidgid postgres $PG_BIN/pg_ctl -D $VISERON_CONFIG_DIR/postgresql -l $VISERON_CONFIG_DIR/postgresql/logfile stop
 
 # Wait until PostgreSQL has stopped
 log_info "Waiting for PostgreSQL Server to stop..."
@@ -21,4 +21,4 @@ done
 log_info "PostgreSQL Server has stopped!"
 
 # Restore permissions
-chown -R abc:abc /config/postgresql
+chown -R abc:abc $VISERON_CONFIG_DIR/postgresql

--- a/rootfs/etc/cont-init.d/40-set-env-vars
+++ b/rootfs/etc/cont-init.d/40-set-env-vars
@@ -3,6 +3,13 @@
 source /helpers/logger.sh
 
 mkdir -p /var/run/environment
+
+# Set Viseron config directory
+log_info "************* Setting Viseron config dir *****************"
+printf $VISERON_CONFIG_DIR > /var/run/environment/VISERON_CONFIG_DIR
+log_info "Viseron config dir: $VISERON_CONFIG_DIR"
+log_info "*********************** Done *****************************"
+
 log_info "****** Checking for hardware acceleration platforms ******"
 # Check for OpenCL
 OUTPUT=$(clinfo 2>&1)
@@ -57,8 +64,11 @@ printf "/home/abc" > /var/run/environment/HOME
 # Find latest version of postgresql
 export PG_VERSION=$(psql --version | awk '{print $3}' | awk -F'.' '{print $1}')
 export PG_BIN="/usr/lib/postgresql/$PG_VERSION/bin"
+export PGDATA=$VISERON_CONFIG_DIR/postgresql
 printf "$PG_VERSION" > /var/run/environment/PG_VERSION
 printf "$PG_BIN" > /var/run/environment/PG_BIN
+printf "$PGDATA" > /var/run/environment/PGDATA
 log_info "PostgreSQL major version: $PG_VERSION"
 log_info "PostgreSQL bin: $PG_BIN"
+log_info "PostgreSQL data dir: $PGDATA"
 log_info "*********************** Done *****************************"

--- a/rootfs/etc/services.d/go2rtc/run
+++ b/rootfs/etc/services.d/go2rtc/run
@@ -5,7 +5,7 @@ source /helpers/set_env.sh
 touch /tmp/go2rtc.yaml
 chown -R --silent abc:abc /tmp/go2rtc.yaml || :
 
-rm -f /config/go2rtc.log
+rm -f $VISERON_CONFIG_DIR/go2rtc.log
 
 echo "Starting go2rtc..."
-exec justc-envdir /var/run/environment s6-setuidgid abc exec go2rtc --config /tmp/go2rtc.yaml 2>&1 | tee -a /config/go2rtc.log
+exec justc-envdir /var/run/environment s6-setuidgid abc exec go2rtc --config /tmp/go2rtc.yaml 2>&1 | tee -a $VISERON_CONFIG_DIR/go2rtc.log

--- a/rootfs/etc/services.d/nginx/run
+++ b/rootfs/etc/services.d/nginx/run
@@ -3,4 +3,4 @@
 source /helpers/set_env.sh
 
 echo "Starting nginx..."
-exec justc-envdir /var/run/environment exec nginx -c /usr/local/nginx/conf/nginx.conf 2>&1 | tee -a /config/nginx.log
+exec justc-envdir /var/run/environment exec nginx -c /usr/local/nginx/conf/nginx.conf 2>&1 | tee -a $VISERON_CONFIG_DIR/nginx.log

--- a/rootfs/etc/services.d/postgres/run
+++ b/rootfs/etc/services.d/postgres/run
@@ -3,4 +3,4 @@
 source /helpers/set_env.sh
 
 echo "Starting PostgreSQL Server..."
-s6-setuidgid postgres $PG_BIN/postgres -D /config/postgresql
+s6-setuidgid postgres $PG_BIN/postgres -D $VISERON_CONFIG_DIR/postgresql

--- a/scripts/gen_docs/__main__.py
+++ b/scripts/gen_docs/__main__.py
@@ -1,4 +1,6 @@
 """Generate docs skeleton."""
+# pylint: disable=wrong-import-position
+# flake8: noqa: E402
 import argparse
 import importlib
 import json
@@ -8,6 +10,9 @@ from collections.abc import Mapping
 
 import typing_extensions
 import voluptuous as vol
+
+# Hardcode the config dir to /config, as it is overridden in the Devcontainer
+os.environ["VISERON_CONFIG_DIR"] = "/config"
 
 from viseron.config import UNSUPPORTED
 from viseron.helpers.validators import (

--- a/viseron/const.py
+++ b/viseron/const.py
@@ -1,13 +1,15 @@
 """Constants."""
+import os
 from typing import Final
 
 import cv2
 
 DEFAULT_PORT = 9999
-CONFIG_PATH = "/config/config.yaml"
-SECRETS_PATH = "/config/secrets.yaml"
-STORAGE_PATH = "/config/.viseron"
-VISERON_LOG_PATH = "/config/viseron.log"
+CONFIG_DIR = os.getenv("VISERON_CONFIG_DIR", "/config")
+CONFIG_PATH = f"{CONFIG_DIR}/config.yaml"
+SECRETS_PATH = f"{CONFIG_DIR}/secrets.yaml"
+STORAGE_PATH = f"{CONFIG_DIR}/.viseron"
+VISERON_LOG_PATH = f"{CONFIG_DIR}/viseron.log"
 TEMP_DIR = "/tmp/viseron"
 DEFAULT_CONFIG = """# Thanks for trying out Viseron!
 # This is a small walkthrough of the configuration to get you started.

--- a/viseron/domains/face_recognition/const.py
+++ b/viseron/domains/face_recognition/const.py
@@ -1,6 +1,8 @@
 """Face recognition constants."""
 from typing import Final
 
+from viseron.const import CONFIG_DIR
+
 DOMAIN: Final = "face_recognition"
 
 UNKNOWN_FACE = "unknown"
@@ -19,7 +21,7 @@ CONFIG_SAVE_UNKNOWN_FACES = "save_unknown_faces"
 CONFIG_UNKNOWN_FACES_PATH = "unknown_faces_path"
 CONFIG_EXPIRE_AFTER = "expire_after"
 
-DEFAULT_FACE_RECOGNITION_PATH = "/config/face_recognition/faces"
+DEFAULT_FACE_RECOGNITION_PATH = f"{CONFIG_DIR}/face_recognition/faces"
 DEFAULT_SAVE_FACES = True
 DEFAULT_SAVE_UNKNOWN_FACES = True
 DEFAULT_EXPIRE_AFTER = 5


### PR DESCRIPTION
Removes the devcontainer bind mount which doesnt work when running `cloneInVolume` which is used from the Developer docs.
Instead, the Viseron config dir is now dynamically set using the env var VISERON_CONFIG_DIR.
Normally its set to `/config` but is overridden in the devcontainer to be `${containerWorkspaceFolder}/config`