### PR TITLE
info message when recording has no fragments

### DIFF
--- a/viseron/domains/camera/recorder.py
+++ b/viseron/domains/camera/recorder.py
@@ -375,6 +375,12 @@ class AbstractRecorder(ABC, RecorderBase):
             Fragment(file.filename, file.path, file.duration, file.orig_ctime)
             for file in files
         ]
+        if len(fragments) == 0:
+            self._logger.info(
+                "No fragments immediately available to generate event clip"
+            )
+            return
+
         event_clip = self._camera.fragmenter.concatenate_fragments(fragments)
         if not event_clip:
             return


### PR DESCRIPTION
*Update:*:  Although I see no impact in the UI I must be missing something.  For those recordings that have the error there is no `clip_path` in the db even after waiting:
```sql
viseron=# select clip_path from recordings where id=12639;

  id   | camera_identifier |         start_time         |          end_time          |         created_at         |         updated_at         | trigger_type | trigger_id |         thumbnail_path         | clip_path |    adjusted_start_time     
-------+-------------------+----------------------------+----------------------------+----------------------------+----------------------------+--------------+------------+--------------------------------+-----------+----------------------------
 12639 | camera_1          | 2025-06-19 16:45:33.580065 | 2025-06-19 16:45:35.466289 | 2025-06-19 16:45:33.580646 | 2025-06-19 16:45:35.466929 | MOTION       |            | thumbnails/camera_1/12639.jpg  |           | 2025-06-19 16:45:23.580065

```

*Note:* I am still not fully grasping the root cause with this problem.  This pull request contains my best attempt at a fix but I could be off with this.

Per discussion #1010 this pull request intends to address an issue I am experiencing.  I could have sworn others have reported this but I cannot find any references for this specific problem.  It appears to be a timing issue on my system.

Basically, sometimes after a short recording is stopped there are no fragments immediately available to concatenate.  At this point I get an error in the logs:
```
viseron  | 2025-06-19 09:06:03.707 [INFO    ] [viseron.components.ffmpeg.recorder.camera_1] - Starting recorder                                                                                         
viseron  | 2025-06-19 09:06:04.706 [INFO    ] [viseron.components.nvr.nvr.camera_1] - Stopping recording in: 1s                                                                                         
viseron  | 2025-06-19 09:06:05.711 [INFO    ] [viseron.components.nvr.nvr.camera_1] - Stopping recording in: 0s
viseron  | 2025-06-19 09:06:05.712 [INFO    ] [viseron.components.ffmpeg.recorder.camera_1] - Stopping recorder                                                                                         viseron  | 2025-06-19 09:06:05.744 [ERROR   ] [viseron.domains.camera.fragmenter.camera_1.ffmpeg] - pipe:: Invalid data found when processing input
viseron  | 2025-06-19 09:06:05.745 [ERROR   ] [viseron.domains.camera.fragmenter.camera_1] - Command
 '['ffmpeg', '-hide_banner', '-loglevel', 'error', '-protocol_whitelist', 'file,pipe', '-i', '-', '-
c:v', 'copy', '-c:a', 'copy', '-movflags', '+faststart', '/tmp/viseron/2af1708a-5f8c-48db-8bf5-646a2
5348967.mp4']' returned non-zero exit status 1.
```

If I quickly go into UI to download the recording I get a pop-up error.  If I try again the download works.  I recently have not been able to reproduce this UI behavior: Even recordings that generate the error download fine from the UI.

### The change
Since there appears to be no functional impact of the error the change generates an info message and exits gracefully.

### Open question 
The only concern I see with the change is that there could be a case where there is a recording (recording is not None) and the fragments are never written out.  I don't see how this can happen but that could be my limited knowledge of Viseron.