### PR TITLE
fix timing issue with _concatenate_fragements

### DIFF
--- a/tests/domains/camera/test_recorder.py
+++ b/tests/domains/camera/test_recorder.py
@@ -11,12 +11,16 @@ import pytest
 from sqlalchemy import insert
 from sqlalchemy.orm import Session
 
-from viseron.components.storage.models import Recordings
+from viseron.components.storage.models import Files, Recordings
+from viseron.domains.camera import AbstractCamera
 from viseron.domains.camera.recorder import (
+    AbstractRecorder,
     RecorderBase,
+    Recording,
     delete_recordings,
     get_recordings,
 )
+from viseron.watchdog.thread_watchdog import RestartableThread
 
 from tests.common import MockCamera
 
@@ -233,3 +237,268 @@ class TestRecorderBase:
             datetime.timedelta(seconds=time.localtime().tm_gmtoff)
         )
         assert result is True
+
+
+#
+# Test cases that work with segments
+#
+# Note: Segments are written to the database only after the file is fully written.
+#       As a result, concatenation of segments cannot fully happen until the segments
+#       within the recording time period have been completed.
+#
+#       Some of these test cases are designed to test this behavior.  They do this
+#       by delaying the addition of segments so they are written after the recording
+#       is ccomplete.
+#
+
+
+@pytest.mark.parametrize(
+    "segments, expected",
+    [
+        ((-4), 1),
+        ((-6, -3), 2),
+        ((-20), 0),
+    ],
+)
+class ConcreteTestRecorder(AbstractRecorder):
+    """Test recorder class that implements abstract methods."""
+
+    def __init__(self, vis: Viseron, config, camera: AbstractCamera) -> None:
+        super().__init__(vis, "test", config, camera)
+
+    def _start(self, recording, shared_frame, objects_in_fov) -> None:
+        pass
+
+    def _stop(self, recording) -> None:
+        pass
+
+    @property
+    def lookback(self) -> Literal[5]:
+        """Return lookback."""
+        return 5
+
+
+@pytest.fixture(name="add_recording_to_session")
+def fixture_add_recording_to_session(
+    get_db_session: Callable[[], Session]
+) -> Callable[
+    [int, datetime.datetime, datetime.datetime, datetime.datetime, str, str], None
+]:
+    """Fixture to add a recording to the session."""
+
+    def _add_recording(
+        recording_id: int,
+        start_time: datetime.datetime,
+        adjusted_start_time: datetime.datetime,
+        end_time: datetime.datetime,
+        camera_identifier: str,
+        thumbnail_path: str,
+    ) -> None:
+        """Add a recording to the session."""
+        with get_db_session() as session:
+            session.execute(
+                insert(Recordings).values(
+                    id=recording_id,
+                    camera_identifier=camera_identifier,
+                    start_time=start_time,
+                    adjusted_start_time=adjusted_start_time,
+                    end_time=end_time,
+                    thumbnail_path=thumbnail_path,
+                )
+            )
+            session.commit()
+
+    return _add_recording
+
+
+@pytest.fixture(name="add_segment_to_session")
+def fixture_add_segment_to_session(
+    get_db_session: Callable[[], Session]
+) -> Callable[[datetime.datetime, float, float], None]:
+    """Fixture to add a segment to the session with an incrementing variable."""
+
+    counter = {"value": 0}
+
+    def _add_segment(
+        segment_start: datetime.datetime, duration: float, delay: float
+    ) -> None:
+        """Add a segment to the session after a delay, incrementing counter."""
+        counter["value"] += 1
+        segment_number = counter["value"]
+
+        time.sleep(delay)
+
+        with get_db_session() as session:
+            session.execute(
+                insert(Files).values(
+                    path=f"/tmp/fragment{segment_number}.mp4",
+                    tier_id=1,
+                    tier_path="/tmp/tier1",
+                    camera_identifier="test1",
+                    category="recorder",
+                    subcategory="segments",
+                    duration=duration,
+                    directory="/tmp",
+                    filename=f"fragment{segment_number}.mp4",
+                    size=1024,
+                    orig_ctime=segment_start,
+                )
+            )
+            session.commit()
+
+    return _add_segment
+
+
+@pytest.fixture(name="recorder")
+def fixture_patched_recorder(vis: Viseron):
+    """Fixture to create a test recorder with mocked vis.add_entity."""
+    with patch.object(vis, "add_entity") as mock_add_entity:
+        config = MagicMock()
+        nested_dict = {"filename_pattern": "%H-%M-%S"}
+        config.__getitem__.return_value.__getitem__.side_effect = nested_dict.get
+        recorder = ConcreteTestRecorder(vis, config, MockCamera())
+        # pylint: disable=protected-access
+        recorder._logger = MagicMock()
+        assert mock_add_entity.call_count == 2
+
+        yield recorder
+
+
+@pytest.fixture(name="recording_params")
+def fixture_recording_params():
+    """Fixture to provide common recording parameters."""
+    return {
+        "record_id": 1,
+        "start_time": datetime.datetime(
+            2023, 3, 2, 12, 0, tzinfo=datetime.timezone.utc
+        ),
+        "adjusted_start_time": datetime.datetime(
+            2023, 3, 2, 12, 0, tzinfo=datetime.timezone.utc
+        ),
+        "end_time": datetime.datetime(2023, 3, 2, 12, 0, tzinfo=datetime.timezone.utc)
+        + datetime.timedelta(seconds=6.0),
+        "camera_identifier": "test1",
+        "thumbnail_path": "/tmp/thumbnail.jpg",
+        "date": "2023-03-02",
+    }
+
+
+@pytest.fixture(name="create_recording")
+def fixture_create_recording(recording_params):
+    """Fixture to create a Recording object from params."""
+
+    def _create_recording(**overrides) -> Recording:
+        params = {**recording_params, **overrides}
+        return Recording(
+            id=params["record_id"],
+            start_time=params["start_time"],
+            start_timestamp=params["start_time"].timestamp(),
+            end_time=params["end_time"],
+            end_timestamp=params["end_time"].timestamp(),
+            date=params.get("date", params["start_time"].strftime("%Y-%m-%d")),
+            thumbnail=None,
+            thumbnail_path=params["thumbnail_path"],
+            clip_path=None,
+            objects=[],
+        )
+
+    return _create_recording
+
+
+@pytest.fixture(name="add_db_recording")
+def fixture_add_db_recording(add_recording_to_session, recording_params):
+    """Fixture to add a recording to the DB."""
+
+    def _add_db_recording(**overrides):
+        params = {**recording_params, **overrides}
+        add_recording_to_session(
+            params["record_id"],
+            params["start_time"],
+            params["adjusted_start_time"],
+            params["end_time"],
+            params["camera_identifier"],
+            params["thumbnail_path"],
+        )
+
+    return _add_db_recording
+
+
+class TestAbstractRecorder:
+    """Test the AbstractRecorder class."""
+
+    def test_no_active_recording(self, recorder: ConcreteTestRecorder):
+        """Test no active recording."""
+        recording = None
+
+        recorder.stop(recording)
+
+        # pylint: disable=protected-access
+        recorder._logger.error.assert_called_with(  # type: ignore [attr-defined]
+            "No active recording to stop"
+        )
+        assert recorder.active_recording is None
+
+    @pytest.mark.parametrize(  # start of segments relative to start of recording
+        "segment_offsets, expected",
+        [
+            ([-2], 1),
+            ([-7, 3], 2),
+            ([-16, 7], None),
+        ],
+        ids=[
+            "recording bounded by single segment",
+            "one segment ends and another starts while recording",
+            "segments outside of recording",
+        ],
+    )
+    def test_segment_cases(
+        self,
+        get_db_session: Callable[[], Session],
+        recorder: ConcreteTestRecorder,
+        add_db_recording,
+        create_recording,
+        add_segment_to_session: Callable[[datetime.datetime, float, float], None],
+        segment_offsets,
+        expected,
+    ):
+        """Handle different cases where segments are being concatenated."""
+        add_db_recording()
+        recording = create_recording()
+
+        # pylint: disable=protected-access
+        with patch.object(recorder._storage, "get_session") as mock_get_session, patch(
+            "shutil.move"
+        ) as _:
+            mock_get_session.return_value = get_db_session()
+
+            # Use a container to store the return value from the thread target
+            result_container = {}
+
+            def target_with_result(*args, **kwargs):
+                result_container["num_fragments"] = recorder._concatenate_fragments(
+                    *args, **kwargs
+                )
+
+            concat_thread = RestartableThread(
+                name="viseron.camera.test.concatenate_fragments",
+                target=target_with_result,
+                args=(recording,),
+                register=False,
+            )
+            concat_thread.start()
+
+            recording_time = (recording.end_time - recording.start_time).total_seconds()
+            segment_duration = 10.0
+
+            for offset in segment_offsets:
+                # delay from end of recording to when segment should be inserted
+                delay = segment_duration - recording_time + offset
+                delay = max(delay, 0.0)
+                segment_start = recording.start_time + datetime.timedelta(
+                    seconds=offset
+                )
+                add_segment_to_session(segment_start, segment_duration, delay)
+
+            concat_thread.join()
+
+            assert result_container["num_fragments"] == expected


### PR DESCRIPTION
This pull request intends to address a timing issue when [concatenating fragments](https://github.com/roflcoopter/viseron/blob/0568e0ea7b768fc95cd4469e7402e87e7587bf9b/viseron/domains/camera/recorder.py#L369).  It results in an error [discussed here](https://github.com/roflcoopter/viseron/discussions/1010).

I have incorrectly diagnosed the problem a couple times but I think I have it figured out now.

### To reproduce

1.  User has `create_event_clip` enabled
2. A recording completes before segments applicable to that recording have been written
3. ffmpeg is called for that recording however there are no segments available so it errors out

In theory this would also result in not taking into account all segments if a segment ends during the recording and another is started while recording is in progress.

This case will not result in an error.  However, there will be one segment missing from the concatenation.

### The fix

The in the PR involved adding a delay in the thread that concatenates the segments.  This allows time for in progress segments to be written to disk.

### Reason for this solution and alternate approach

It seems like a delay similar to this is used at [another locaation](https://github.com/john-/viseron/blob/0568e0ea7b768fc95cd4469e7402e87e7587bf9b/viseron/components/storage/check_tier.py#L203) in the code.

An alternate way may be able to have logic that blocks the concatenation until the in progress segment is written to disk.

As this is for the clip recording feature it is OK to have this delay before the recording is fully complete.

### Test cases

There should be test cases that address the cases I am aware of.  One can comment out the delay in concatenation to see the impact on the test cases.

The return value to `_concatenate_fragments` was added to aid in unit testing.
