### PR TITLE
force pytorch CPU install in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
         uses: ./.github/templates/run_in_venv
         with:
           command: |
-            pip3 install -r requirements.txt -r requirements_test.txt -r requirements_ci.txt && \
+            pip3 install --extra-index-url https://download.pytorch.org/whl/cpu -r requirements.txt -r requirements_test.txt -r requirements_ci.txt && \
             pre-commit install
 
   prepare-pre-commit:
@@ -430,7 +430,7 @@ jobs:
           docker compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env pull amd64-wheels
       - name: Re-build wheels
         run: |
-          docker compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env build --build-arg BUILDKIT_INLINE_CACHE=1 amd64-wheels
+          docker compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env build --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg EXTRA_PIP_ARGS="--extra-index-url https://download.pytorch.org/whl/cpu" amd64-wheels
           docker compose --file azure-pipelines/docker-compose-build.yaml --env-file azure-pipelines/.env build --build-arg BUILDKIT_INLINE_CACHE=1 amd64-viseron
       - name: Build pytest Docker image
         run: |


### PR DESCRIPTION
Ultralytics depends on Pytorch which is causing out of space error in CI due to installing CUDA libraries.

This is an attempt to force CPU only install of Pytorch