### PR TITLE
RPi3 ignore ultralytics

### DIFF
--- a/docker/jetson-nano/Dockerfile.wheels
+++ b/docker/jetson-nano/Dockerfile.wheels
@@ -32,6 +32,7 @@ RUN [ "cross-build-start" ]
 RUN apt-get -yqq update && apt-get install -yq --no-install-recommends \
   wget \
   curl \
+  build-essential \
   gcc \
   python3 \
   python3-dev \

--- a/docs/src/pages/components-explorer/components/yolo/index.mdx
+++ b/docs/src/pages/components-explorer/components/yolo/index.mdx
@@ -11,19 +11,25 @@ Ultralytics YOLO supports a wide range of models, from early versions like YOLOv
 
 :::warning
 
-This component has undergone limited testing.  In addition to partial functional testing, only the following models have been confirmed to work: yolov5mu.pt, yolov8n, and yolo11s.pt
+This component has undergone limited testing. In addition to partial functional testing, only the following models have been confirmed to work: yolov5mu.pt, yolov8n, and yolo11s.pt
 
 :::
 
 :::note
 
-`yolo` component uses the official [`ultralytics`](https://docs.ultralytics.com/usage/python) python package.  A GPU is used when available.
+`yolo` component uses the official [`ultralytics`](https://docs.ultralytics.com/usage/python) python package. A GPU is used when available.
 
 :::
 
 :::info
 
-Models are not installed by default.  See below for steps to define the model as well as make them available to Viseron.
+Models are not installed by default. See below for steps to define the model as well as make them available to Viseron.
+
+:::
+
+:::warning
+
+The `yolo` component is not compatible with the Raspberry Pi 3. Use another object detection component such as `darknet` or `edgetpu` instead.
 
 :::
 
@@ -67,20 +73,21 @@ Examples of where to find pre-trained models:
 - [Roboflow](https://universe.roboflow.com/)
 - [Hugging Face](https://huggingface.co/models?pipeline_tag=object-detection&sort=trending)
 
-There are models for many different tasks, including object detection.  If you are not sure if there is a problem with Viseron please confirm your
-Viseron environment with a stock YOLO model from Ultralytics.  For example: [yolov8n.pt](https://github.com/ultralytics/assets/releases/download/v8.3.0/yolov8n.pt)
+There are models for many different tasks, including object detection. If you are not sure if there is a problem with Viseron please confirm your
+Viseron environment with a stock YOLO model from Ultralytics. For example: [yolov8n.pt](https://github.com/ultralytics/assets/releases/download/v8.3.0/yolov8n.pt)
 
-This component does not provide any training capabilities.  See the [Ultralytics training](https://docs.ultralytics.com/modes/train/) documentation for more information.
+This component does not provide any training capabilities. See the [Ultralytics training](https://docs.ultralytics.com/modes/train/) documentation for more information.
 
 #### Where to place models
 
 Place your YOLO models in a directory of your choice.
 
-There will be a later step to map the directory to the container.  Therefore, choose a location supported by docker compose.  If in doubt, do not use a SMB or NFS share.
+There will be a later step to map the directory to the container. Therefore, choose a location supported by docker compose. If in doubt, do not use a SMB or NFS share.
 
 #### Configuring Docker to make models available to Viseron
 
 The following `docker-compose.yaml` snippet will show how to map the directory above to the container:
+
 ```yaml title="/docker-compose.yaml"
     volumes:
       - {models path}:/detectors/models/yolo
@@ -90,7 +97,7 @@ This is the only change to `docker-compose.yaml` required for this component.
 
 #### Configuring Viseron to use a model
 
-Modify the `model_path` setting in your Viseron `config.yaml` to point to one of the model(s) you installed.  See the example above.
+Modify the `model_path` setting in your Viseron `config.yaml` to point to one of the model(s) you installed. See the example above.
 
 Only one model can be used at a time.
 
@@ -103,6 +110,7 @@ There is no functionality to resize the image in the `yolo` component configurat
 ### Labels
 
 When Viseron loads the model, it will print that model's labels to the log.
+
 ```
 cd {location of Viseron docker-compose.yaml}
 docker compose logs | grep "Labels"
@@ -110,4 +118,3 @@ viseron  | 2025-05-29 08:19:04.943 [INFO    ] [viseron.components.yolo.object_de
 ```
 
 <ComponentTroubleshooting meta={ComponentMetadata} />
-

--- a/requirements-3.9.txt
+++ b/requirements-3.9.txt
@@ -1,2 +1,3 @@
 numpy==1.26.4
+pillow==11.1.0
 pycoral~=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ numpy==1.26.4
 paho-mqtt==2.1.0
 path.py==12.5.0
 pillow==11.1.0
-psutil==5.9.8
+psutil==7.0.0
 psycopg2-binary==2.9.9
 pyjwt==2.8.0
 python-debouncer==0.1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,4 @@ sqlalchemy==2.0.30
 watchdog==4.0.0
 python-telegram-bot==21.4
 onvif-zeep==0.2.12
-ultralytics==8.3.146
+ultralytics==8.3.146; platform_machine == "x86_64" or platform_machine == "aarch64"

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ imutils==0.5.4
 numpy==1.26.4
 paho-mqtt==2.1.0
 path.py==12.5.0
+pillow==11.1.0
 psutil==5.9.8
 psycopg2-binary==2.9.9
 pyjwt==2.8.0


### PR DESCRIPTION
Stop Ultralytics from being installed on the RPi3 as it is not supported.

Also pins Pillow to 11.1.0 to resolve a build error when building the Python 3.9 wheels