### PR TITLE
fix cleanup jobs to run on all tier paths

### DIFF
--- a/viseron/components/storage/__init__.py
+++ b/viseron/components/storage/__init__.py
@@ -7,7 +7,7 @@ import logging
 import os
 import pathlib
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, TypedDict, overload
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, overload
 
 import voluptuous as vol
 from alembic import command, script
@@ -301,27 +301,97 @@ class Storage:
             return self._get_session_expire()
         return self._get_session()
 
+    @overload
     def get_event_clips_path(self, camera: AbstractCamera) -> str:
+        ...
+
+    @overload
+    def get_event_clips_path(
+        self, camera: AbstractCamera, all_tiers: Literal[False]
+    ) -> str:
+        ...
+
+    @overload
+    def get_event_clips_path(
+        self, camera: AbstractCamera, all_tiers: Literal[True]
+    ) -> list[str]:
+        ...
+
+    def get_event_clips_path(
+        self, camera: AbstractCamera, all_tiers: bool = False
+    ) -> str | list[str]:
         """Get event clips path for camera."""
         self.create_tier_handlers(camera)
-        return get_event_clips_path(
-            self._camera_tier_handlers[camera.identifier][TIER_CATEGORY_RECORDER][0][
-                TIER_SUBCATEGORY_EVENT_CLIPS
-            ].tier,
-            camera,
-        )
+        if not all_tiers:
+            return get_event_clips_path(
+                self._camera_tier_handlers[camera.identifier][TIER_CATEGORY_RECORDER][
+                    0
+                ][TIER_SUBCATEGORY_EVENT_CLIPS].tier,
+                camera,
+            )
+        return [
+            get_event_clips_path(
+                tier_handler[TIER_SUBCATEGORY_EVENT_CLIPS].tier, camera
+            )
+            for tier_handler in self._camera_tier_handlers[camera.identifier][
+                TIER_CATEGORY_RECORDER
+            ]
+        ]
 
+    @overload
     def get_segments_path(self, camera: AbstractCamera) -> str:
+        ...
+
+    @overload
+    def get_segments_path(
+        self, camera: AbstractCamera, all_tiers: Literal[False]
+    ) -> str:
+        ...
+
+    @overload
+    def get_segments_path(
+        self, camera: AbstractCamera, all_tiers: Literal[True]
+    ) -> list[str]:
+        ...
+
+    def get_segments_path(
+        self, camera: AbstractCamera, all_tiers: bool = False
+    ) -> str | list[str]:
         """Get segments path for camera."""
         self.create_tier_handlers(camera)
-        return get_segments_path(
-            self._camera_tier_handlers[camera.identifier][TIER_CATEGORY_RECORDER][0][
-                TIER_SUBCATEGORY_SEGMENTS
-            ].tier,
-            camera,
-        )
+        if not all_tiers:
+            return get_segments_path(
+                self._camera_tier_handlers[camera.identifier][TIER_CATEGORY_RECORDER][
+                    0
+                ][TIER_SUBCATEGORY_SEGMENTS].tier,
+                camera,
+            )
+        return [
+            get_segments_path(tier_handler[TIER_SUBCATEGORY_SEGMENTS].tier, camera)
+            for tier_handler in self._camera_tier_handlers[camera.identifier][
+                TIER_CATEGORY_RECORDER
+            ]
+        ]
 
+    @overload
     def get_thumbnails_path(self, camera: AbstractCamera) -> str:
+        ...
+
+    @overload
+    def get_thumbnails_path(
+        self, camera: AbstractCamera, all_tiers: Literal[False]
+    ) -> str:
+        ...
+
+    @overload
+    def get_thumbnails_path(
+        self, camera: AbstractCamera, all_tiers: Literal[True]
+    ) -> list[str]:
+        ...
+
+    def get_thumbnails_path(
+        self, camera: AbstractCamera, all_tiers: bool = False
+    ) -> str | list[str]:
         """Get thumbnails path for camera.
 
         This is an UNMONITORED path, meaning that the files in this path will not be
@@ -329,27 +399,55 @@ class Storage:
         recording.
         """
         self.create_tier_handlers(camera)
-        return get_thumbnails_path(
-            self._camera_tier_handlers[camera.identifier][TIER_CATEGORY_RECORDER][0][
-                TIER_SUBCATEGORY_EVENT_CLIPS
-            ].tier,
-            camera,
-        )
+        if not all_tiers:
+            return get_thumbnails_path(
+                self._camera_tier_handlers[camera.identifier][TIER_CATEGORY_RECORDER][
+                    0
+                ][TIER_SUBCATEGORY_THUMBNAILS].tier,
+                camera,
+            )
+        return [
+            get_thumbnails_path(tier_handler[TIER_SUBCATEGORY_THUMBNAILS].tier, camera)
+            for tier_handler in self._camera_tier_handlers[camera.identifier][
+                TIER_CATEGORY_RECORDER
+            ]
+        ]
+
+    @overload
+    def get_snapshots_path(self, camera: AbstractCamera, domain: SnapshotDomain) -> str:
+        ...
+
+    @overload
+    def get_snapshots_path(
+        self, camera: AbstractCamera, domain: SnapshotDomain, all_tiers: Literal[False]
+    ) -> str:
+        ...
+
+    @overload
+    def get_snapshots_path(
+        self, camera: AbstractCamera, domain: SnapshotDomain, all_tiers: Literal[True]
+    ) -> list[str]:
+        ...
 
     def get_snapshots_path(
-        self,
-        camera: AbstractCamera,
-        domain: SnapshotDomain,
-    ) -> str:
+        self, camera: AbstractCamera, domain: SnapshotDomain, all_tiers: bool = False
+    ) -> str | list[str]:
         """Get snapshots path for camera."""
         self.create_tier_handlers(camera)
-        return get_snapshots_path(
-            self._camera_tier_handlers[camera.identifier]["snapshots"][0][
-                domain.value
-            ].tier,
-            camera,
-            domain,
-        )
+        if not all_tiers:
+            return get_snapshots_path(
+                self._camera_tier_handlers[camera.identifier][TIER_CATEGORY_SNAPSHOTS][
+                    0
+                ][domain.value].tier,
+                camera,
+                domain,
+            )
+        return [
+            get_snapshots_path(tier_handler[domain.value].tier, camera, domain)
+            for tier_handler in self._camera_tier_handlers[camera.identifier][
+                TIER_CATEGORY_SNAPSHOTS
+            ]
+        ]
 
     def search_file(
         self, camera_identifier: str, category: str, subcategory: str, path: str

--- a/viseron/components/storage/jobs.py
+++ b/viseron/components/storage/jobs.py
@@ -743,9 +743,9 @@ class CleanupManager:
     def __init__(self, vis: Viseron, storage: Storage):
         self._vis = vis
         self.jobs: list[BaseCleanupJob] = [
-            OrphanedFilesCleanup(vis, storage, CronTrigger(minute=0, jitter=600)),
+            OrphanedFilesCleanup(vis, storage, CronTrigger(hour=0, jitter=3600)),
             OrphanedDatabaseFilesCleanup(
-                vis, storage, CronTrigger(minute=0, jitter=600)
+                vis, storage, CronTrigger(hour=0, jitter=3600)
             ),
             EmptyFoldersCleanup(vis, storage, CronTrigger(hour=0, jitter=3600)),
             OrphanedThumbnailsCleanup(vis, storage, CronTrigger(hour=0, jitter=3600)),

--- a/viseron/components/storage/jobs.py
+++ b/viseron/components/storage/jobs.py
@@ -198,15 +198,14 @@ class OrphanedFilesCleanup(BaseCleanupJob):
 
         paths = []
         for camera in cameras.values():
-            paths += [
-                self._storage.get_event_clips_path(camera),
-                self._storage.get_segments_path(camera),
-                self._storage.get_thumbnails_path(camera),
-            ] + [
-                self._storage.get_snapshots_path(camera, domain)
-                for camera in cameras.values()
-                for domain in SnapshotDomain
-            ]
+            paths += self._storage.get_event_clips_path(camera, all_tiers=True)
+            paths += self._storage.get_segments_path(camera, all_tiers=True)
+            paths += self._storage.get_thumbnails_path(camera, all_tiers=True)
+
+            for domain in SnapshotDomain:
+                paths += self._storage.get_snapshots_path(
+                    camera, domain, all_tiers=True
+                )
 
         total_files_processed = 0
         with self._storage.get_session() as session:
@@ -349,27 +348,28 @@ class EmptyFoldersCleanup(BaseCleanupJob):
         if not cameras:
             return
 
+        paths = []
         for camera in cameras.values():
-            for path in [
-                self._storage.get_event_clips_path(camera),
-                self._storage.get_segments_path(camera),
-                self._storage.get_thumbnails_path(camera),
-            ] + [
-                self._storage.get_snapshots_path(camera, domain)
-                for domain in SnapshotDomain
-            ]:
-                time.sleep(1)
-                for root, dirs, files in os.walk(path, topdown=False):
-                    processed_count += 1
-                    self.log_progress(
-                        f"{self.name} processed {processed_count} folders"
-                    )
-                    if root == path:
-                        continue
-                    if not dirs and not files:
-                        LOGGER.debug("Deleting folder %s", root)
-                        os.rmdir(root)
-                        deleted_count += 1
+            paths += self._storage.get_event_clips_path(camera, all_tiers=True)
+            paths += self._storage.get_segments_path(camera, all_tiers=True)
+            paths += self._storage.get_thumbnails_path(camera, all_tiers=True)
+
+            for domain in SnapshotDomain:
+                paths += self._storage.get_snapshots_path(
+                    camera, domain, all_tiers=True
+                )
+
+        for path in paths:
+            time.sleep(1)
+            for root, dirs, files in os.walk(path, topdown=False):
+                processed_count += 1
+                self.log_progress(f"{self.name} processed {processed_count} folders")
+                if root == path:
+                    continue
+                if not dirs and not files:
+                    LOGGER.debug("Deleting folder %s", root)
+                    os.rmdir(root)
+                    deleted_count += 1
 
         LOGGER.debug(
             "%s deleted %d empty folders, took %s",
@@ -398,10 +398,13 @@ class OrphanedThumbnailsCleanup(BaseCleanupJob):
         if not cameras:
             return
 
+        paths = []
+        for camera in cameras.values():
+            paths += self._storage.get_thumbnails_path(camera, all_tiers=True)
+
         with self._storage.get_session() as session:
-            for camera in cameras.values():
+            for thumbnails_path in paths:
                 files_processed = 0
-                thumbnails_path = self._storage.get_thumbnails_path(camera)
                 if not os.path.exists(thumbnails_path):
                     continue
 
@@ -478,10 +481,13 @@ class OrphanedEventClipsCleanup(BaseCleanupJob):
         if not cameras:
             return
 
+        paths = []
+        for camera in cameras.values():
+            paths += self._storage.get_event_clips_path(camera, all_tiers=True)
+
         with self._storage.get_session() as session:
-            for camera in cameras.values():
+            for event_clips_path in paths:
                 files_processed = 0
-                event_clips_path = self._storage.get_event_clips_path(camera)
                 if not os.path.exists(event_clips_path):
                     continue
 


### PR DESCRIPTION
Cleanup jobs were only running on the first tier. This fixes so that all tiers are checked.