### PR TITLE
nginx: proxy.conf: remove ssl_early_data

### DIFF
--- a/rootfs/usr/local/nginx/conf/proxy.conf
+++ b/rootfs/usr/local/nginx/conf/proxy.conf
@@ -19,7 +19,6 @@ proxy_no_cache $cookie_session;
 
 # Proxy Header Settings
 proxy_set_header Connection "Upgrade";
-proxy_set_header Early-Data $ssl_early_data;
 proxy_set_header Host $http_host;
 proxy_set_header Proxy "";
 proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
When running the container on Nintendo Switch (Jetson TX1) with host Fedora 42; the following issue occurs: `nginx: [emerg] unknown directive "ssl_early_data"` Looks similar to https://forum.mattermost.com/t/nginx-proxy-unknown-directive-ssl-early-data/12112