### PR TITLE
remove motion contours from motion detected event

### DIFF
--- a/viseron/domains/motion_detector/__init__.py
+++ b/viseron/domains/motion_detector/__init__.py
@@ -133,7 +133,9 @@ class EventMotionDetected(EventData):
         return {
             "camera_identifier": self.camera_identifier,
             "motion_detected": self.motion_detected,
-            "motion_contours": self.motion_contours,
+            "max_area": (
+                self.motion_contours.max_area if self.motion_contours else None
+            ),
         }
 
 


### PR DESCRIPTION
Remove motion contours from the motion detected events `as_dict` function. The array can be very large and affects performance of event listeners