### PR TITLE
file moves and deletes priority over tier check

### DIFF
--- a/docs/src/pages/components-explorer/components/storage/config.json
+++ b/docs/src/pages/components-explorer/components/storage/config.json
@@ -11,6 +11,7 @@
       },
       {
         "type": "integer",
+        "valueMin": 1,
         "name": "tier_check_workers",
         "description": "The number of worker threads to use for checking tiers. This can be used to speed up the tier check process by using multiple threads to check for files to move or delete.",
         "optional": true,

--- a/viseron/components/storage/config.py
+++ b/viseron/components/storage/config.py
@@ -399,7 +399,7 @@ STORAGE_SCHEMA = vol.Schema(
             CONFIG_TIER_CHECK_WORKERS,
             default=DEFAULT_TIER_CHECK_WORKERS,
             description=DESC_TIER_CHECK_WORKERS,
-        ): Maybe(vol.Coerce(int)),
+        ): Maybe(vol.All(vol.Coerce(int), vol.Range(min=1))),
         vol.Optional(
             CONFIG_TIER_CHECK_BATCH_SIZE,
             default=DEFAULT_TIER_CHECK_BATCH_SIZE,

--- a/viseron/components/storage/storage_subprocess.py
+++ b/viseron/components/storage/storage_subprocess.py
@@ -195,17 +195,74 @@ def initializer(cpulimit: int | None):
         )
 
 
-def worker_task(worker: Worker, process_queue: Queue, output_queue: Queue):
-    """Worker thread task."""
+def worker_task_files(
+    worker: Worker,
+    file_queue: Queue[DataItemDeleteFile | DataItemMoveFile],
+    output_queue: Queue[DataItemDeleteFile | DataItemMoveFile],
+):
+    """Worker thread that only processes file operation commands."""
     while True:
         try:
-            job = process_queue.get(block=True, timeout=1)
+            job = file_queue.get(timeout=1)
             worker.work_input(job)
             output_queue.put(job)
         except Empty:
             continue
         except Exception as exc:  # pylint: disable=broad-except
-            LOGGER.exception(f"Error in worker thread: {exc}")
+            LOGGER.exception(f"Error in file worker thread: {exc}")
+
+
+def worker_task_mixed(
+    worker: Worker,
+    check_queue: Queue[DataItem],
+    file_queue: Queue[DataItemDeleteFile | DataItemMoveFile],
+    output_queue: Queue[DataItem | DataItemDeleteFile | DataItemMoveFile],
+    name: str,
+):
+    """Worker thread that prioritizes file operations but also handles check_tier.
+
+    This ensures that file operations are not blocked by slow check_tier jobs.
+    """
+    job: DataItem | DataItemDeleteFile | DataItemMoveFile
+    while True:
+        try:
+            try:
+                job = file_queue.get_nowait()
+            except Empty:
+                job = check_queue.get(timeout=1)
+            worker.work_input(job)
+            output_queue.put(job)
+        except Empty:
+            continue
+        except Exception as exc:  # pylint: disable=broad-except
+            LOGGER.exception(f"Error in mixed worker thread {name}: {exc}")
+
+
+def dispatcher_task(
+    process_queue: Queue[DataItem | DataItemDeleteFile | DataItemMoveFile],
+    check_queue: Queue[DataItem],
+    file_queue: Queue[DataItemDeleteFile | DataItemMoveFile],
+):
+    """Dispatcher thread routing jobs to dedicated queues.
+
+    check_tier commands can be slow. File operations should not be blocked by them,
+    so they get their own queue and worker.
+    """
+    while True:
+        try:
+            job = process_queue.get(timeout=1)
+        except Empty:
+            continue
+
+        try:
+            if job.cmd == "check_tier":
+                check_queue.put(job)
+            elif job.cmd in ("move_file", "delete_file"):
+                file_queue.put(job)
+            else:
+                LOGGER.debug("Unknown command %s", job.cmd)
+        except Exception as exc:  # pylint: disable=broad-except
+            LOGGER.exception(f"Dispatcher error routing job: {exc}")
 
 
 def main():
@@ -213,6 +270,8 @@ def main():
     parser = get_parser()
     args = parser.parse_args()
     setup_logger(args.loglevel)
+    process_queue: Queue[DataItem | DataItemDeleteFile | DataItemMoveFile]
+    output_queue: Queue[DataItem | DataItemDeleteFile | DataItemMoveFile]
     process_queue, output_queue = connect(
         "127.0.0.1", int(args.manager_port), args.manager_authkey
     )
@@ -231,16 +290,40 @@ def main():
     ThreadWatchDog(background_scheduler)
 
     LOGGER.debug(f"Starting {args.workers} worker threads")
-    threads: list[RestartableThread] = []
+
+    check_queue: Queue[DataItem] = Queue()
+    file_queue: Queue[DataItemDeleteFile | DataItemMoveFile] = Queue()
+
+    dispatcher = RestartableThread(
+        name="storage_subprocess.dispatcher",
+        target=dispatcher_task,
+        args=(process_queue, check_queue, file_queue),
+        daemon=True,
+    )
+    dispatcher.start()
+
     for i in range(args.workers):
         thread = RestartableThread(
-            name=f"storage_subprocess.worker.{i}",
-            target=worker_task,
-            args=(worker, process_queue, output_queue),
+            name=f"storage_subprocess.mixed_worker.{i}",
+            target=worker_task_mixed,
+            args=(
+                worker,
+                check_queue,
+                file_queue,
+                output_queue,
+                f"mixed_worker.{i}",
+            ),
             daemon=True,
         )
         thread.start()
-        threads.append(thread)
+
+    thread = RestartableThread(
+        name="storage_subprocess.file_worker",
+        target=worker_task_files,
+        args=(worker, file_queue, output_queue),
+        daemon=True,
+    )
+    thread.start()
 
     while True:
         time.sleep(1)


### PR DESCRIPTION
Gives file move and delete operations priority over check tier commands.
Also dedicates one worker to file operations only.

This is done to avoid cases when all workers are tied up with checking tiers which can be slow, resulting in a delay in the file handling