### PR TITLE
Timelapse improvements

### DIFF
--- a/docs/docs/documentation/installation.mdx
+++ b/docs/docs/documentation/installation.mdx
@@ -55,6 +55,7 @@ docker run --rm \
   -v {snapshots path}:/snapshots \
   -v {thumbnails path}:/thumbnails \
   -v {event clips path}:/event_clips \
+  -v {timelapse path}:/timelapse \
   -v {config path}:/config \
   -v /etc/localtime:/etc/localtime:ro \
   -p 8888:8888 \
@@ -67,8 +68,6 @@ docker run --rm \
 <TabItem value="docker-compose" label="Docker-Compose">
 
 ```yaml
-version: "2.4"
-
 services:
   viseron:
     image: roflcoopter/viseron:latest
@@ -79,6 +78,7 @@ services:
       - {snapshots path}:/snapshots
       - {thumbnails path}:/thumbnails
       - {event clips path}:/event_clips
+      - {timelapse path}:/timelapse
       - {config path}:/config
       - /etc/localtime:/etc/localtime:ro
     ports:
@@ -101,6 +101,7 @@ docker run --rm \
   -v {snapshots path}:/snapshots \
   -v {thumbnails path}:/thumbnails \
   -v {event clips path}:/event_clips \
+  -v {timelapse path}:/timelapse \
   -v {config path}:/config \
   -v /etc/localtime:/etc/localtime:ro \
   -p 8888:8888 \
@@ -114,8 +115,6 @@ docker run --rm \
 <TabItem value="docker-compose" label="Docker-Compose">
 
 ```yaml
-version: "2.4"
-
 services:
   viseron:
     image: roflcoopter/viseron:latest
@@ -126,6 +125,7 @@ services:
       - {snapshots path}:/snapshots
       - {thumbnails path}:/thumbnails
       - {event clips path}:/event_clips
+      - {timelapse path}:/timelapse
       - {config path}:/config
       - /etc/localtime:/etc/localtime:ro
     ports:
@@ -150,6 +150,7 @@ docker run --rm \
   -v {snapshots path}:/snapshots \
   -v {thumbnails path}:/thumbnails \
   -v {event clips path}:/event_clips \
+  -v {timelapse path}:/timelapse \
   -v {config path}:/config \
   -v /etc/localtime:/etc/localtime:ro \
   -p 8888:8888 \
@@ -163,8 +164,6 @@ docker run --rm \
 <TabItem value="docker-compose" label="Docker-Compose">
 
 ```yaml
-version: "2.4"
-
 services:
   viseron:
     image: roflcoopter/amd64-cuda-viseron:latest
@@ -175,6 +174,7 @@ services:
       - {snapshots path}:/snapshots
       - {thumbnails path}:/thumbnails
       - {event clips path}:/event_clips
+      - {timelapse path}:/timelapse
       - {config path}:/config
       - /etc/localtime:/etc/localtime:ro
     ports:
@@ -205,6 +205,7 @@ docker run --rm \
   -v {snapshots path}:/snapshots \
   -v {thumbnails path}:/thumbnails \
   -v {event clips path}:/event_clips \
+  -v {timelapse path}:/timelapse \
   -v {config path}:/config \
   -v /etc/localtime:/etc/localtime:ro \
   -p 8888:8888 \
@@ -226,8 +227,6 @@ You can probably get around this by manually mounting all the needed devices but
 <TabItem value="docker-compose" label="Docker-Compose">
 
 ```yaml
-version: "2.4"
-
 services:
   viseron:
     image: roflcoopter/jetson-nano-viseron:latest
@@ -238,6 +237,7 @@ services:
       - {snapshots path}:/snapshots
       - {thumbnails path}:/thumbnails
       - {event clips path}:/event_clips
+      - {timelapse path}:/timelapse
       - {config path}:/config
       - /etc/localtime:/etc/localtime:ro
     ports:
@@ -270,6 +270,7 @@ docker run --rm \
   -v {snapshots path}:/snapshots \
   -v {thumbnails path}:/thumbnails \
   -v {event clips path}:/event_clips \
+  -v {timelapse path}:/timelapse \
   -v {config path}:/config \
   -v /etc/localtime:/etc/localtime:ro \
   -v /dev/bus/usb:/dev/bus/usb \
@@ -288,7 +289,6 @@ docker run --rm \
 <TabItem value="docker-compose" label="Docker-Compose">
 
 ```yaml
-version: "2.4"
 services:
   viseron:
     image: roflcoopter/viseron:latest
@@ -299,6 +299,7 @@ services:
       - {snapshots path}:/snapshots
       - {thumbnails path}:/thumbnails
       - {event clips path}:/event_clips
+      - {timelapse path}:/timelapse
       - {config path}:/config
       - /etc/localtime:/etc/localtime:ro
     devices:
@@ -342,6 +343,7 @@ docker run --rm \
   -v {snapshots path}:/snapshots \
   -v {thumbnails path}:/thumbnails \
   -v {event clips path}:/event_clips \
+  -v {timelapse path}:/timelapse \
   -v {config path}:/config \
   -v /etc/localtime:/etc/localtime:ro \
   -v /opt/vc/lib:/opt/vc/lib \
@@ -358,7 +360,6 @@ docker run --rm \
 <TabItem value="docker-compose" label="Docker-Compose">
 
 ```yaml
-version: "2.4"
 services:
   viseron:
     image: roflcoopter/viseron:latest
@@ -369,6 +370,7 @@ services:
       - {snapshots path}:/snapshots
       - {thumbnails path}:/thumbnails
       - {event clips path}:/event_clips
+      - {timelapse path}:/timelapse
       - {config path}:/config
       - /etc/localtime:/etc/localtime:ro
       - /opt/vc/lib:/opt/vc/lib
@@ -447,6 +449,7 @@ docker run --rm \
   -v {snapshots path}:/snapshots \
   -v {thumbnails path}:/thumbnails \
   -v {event clips path}:/event_clips \
+  -v {timelapse path}:/timelapse \
   -v {config path}:/config \
   -v /etc/localtime:/etc/localtime:ro \
   -p 8888:8888 \
@@ -465,8 +468,6 @@ docker run --rm \
 Example docker-compose
 
 ```yaml
-version: "2.4"
-
 services:
   viseron:
     image: roflcoopter/viseron:latest
@@ -477,6 +478,7 @@ services:
       - {snapshots path}:/snapshots
       - {thumbnails path}:/thumbnails
       - {event clips path}:/event_clips
+      - {timelapse path}:/timelapse
       - {config path}:/config
       - /etc/localtime:/etc/localtime:ro
     ports:

--- a/docs/src/pages/components-explorer/components/ffmpeg/index.mdx
+++ b/docs/src/pages/components-explorer/components/ffmpeg/index.mdx
@@ -211,6 +211,7 @@ docker run --rm \
   -v {snapshots path}:/snapshots \
   -v {thumbnails path}:/thumbnails \
   -v {event clips path}:/event_clips \
+  -v {timelapse path}:/timelapse \
   -v {config path}:/config \
   -v /etc/localtime:/etc/localtime:ro \
   -p 8888:8888 \
@@ -235,6 +236,7 @@ services:
       - {snapshots path}:/snapshots
       - {thumbnails path}:/thumbnails
       - {event clips path}:/event_clips
+      - {timelapse path}:/timelapse
       - {config path}:/config
       - /etc/localtime:/etc/localtime:ro
     ports:

--- a/docs/src/pages/components-explorer/components/hailo/index.mdx
+++ b/docs/src/pages/components-explorer/components/hailo/index.mdx
@@ -70,6 +70,7 @@ Viseron is currently using the version 4.22.0 of the Hailo runtime, and you may 
 :::
 
 ## Mounting the device
+
 To allow the Viseron container to access the Hailo device, you need to mount it when starting the container.
 
 <Tabs groupId="docker-type">
@@ -81,6 +82,7 @@ docker run --rm \
   -v {snapshots path}:/snapshots \
   -v {thumbnails path}:/thumbnails \
   -v {event clips path}:/event_clips \
+  -v {timelapse path}:/timelapse \
   -v {config path}:/config \
   -v /etc/localtime:/etc/localtime:ro \
   -p 8888:8888 \
@@ -106,6 +108,7 @@ services:
       - {snapshots path}:/snapshots
       - {thumbnails path}:/thumbnails
       - {event clips path}:/event_clips
+      - {timelapse path}:/timelapse
       - {config path}:/config
       - /etc/localtime:/etc/localtime:ro
     ports:

--- a/docs/src/pages/components-explorer/components/logger/index.mdx
+++ b/docs/src/pages/components-explorer/components/logger/index.mdx
@@ -68,6 +68,7 @@ docker run --rm \
   -v {snapshots path}:/snapshots \
   -v {thumbnails path}:/thumbnails \
   -v {event clips path}:/event_clips \
+  -v {timelapse path}:/timelapse \
   -v {config path}:/config \
   -v /etc/localtime:/etc/localtime:ro \
   -p 8888:8888 \
@@ -84,8 +85,6 @@ docker run --rm \
 <TabItem value="docker-compose" label="Docker-Compose">
 
 ```yaml
-version: "2.4"
-
 services:
   viseron:
     image: roflcoopter/viseron:latest
@@ -96,6 +95,7 @@ services:
       - {snapshots path}:/snapshots
       - {thumbnails path}:/thumbnails
       - {event clips path}:/event_clips
+      - {timelapse path}:/timelapse
       - {config path}:/config
       - /etc/localtime:/etc/localtime:ro
     ports:

--- a/viseron/components/storage/jobs.py
+++ b/viseron/components/storage/jobs.py
@@ -201,6 +201,10 @@ class OrphanedFilesCleanup(BaseCleanupJob):
             paths += self._storage.get_event_clips_path(camera, all_tiers=True)
             paths += self._storage.get_segments_path(camera, all_tiers=True)
             paths += self._storage.get_thumbnails_path(camera, all_tiers=True)
+            if timelapse_path := self._storage.get_timelapse_path(
+                camera, all_tiers=True
+            ):
+                paths += timelapse_path
 
             for domain in SnapshotDomain:
                 paths += self._storage.get_snapshots_path(
@@ -438,6 +442,10 @@ class EmptyFoldersCleanup(BaseCleanupJob):
             paths += self._storage.get_event_clips_path(camera, all_tiers=True)
             paths += self._storage.get_segments_path(camera, all_tiers=True)
             paths += self._storage.get_thumbnails_path(camera, all_tiers=True)
+            if timelapse_path := self._storage.get_timelapse_path(
+                camera, all_tiers=True
+            ):
+                paths += timelapse_path
 
             for domain in SnapshotDomain:
                 paths += self._storage.get_snapshots_path(

--- a/viseron/components/storage/tier_handler.py
+++ b/viseron/components/storage/tier_handler.py
@@ -1200,21 +1200,8 @@ class TimelapseTierHandler(TierHandler):
         self._interval = calculate_age(self._tier.get(CONFIG_INTERVAL, {}))
         self.add_file_handler(self._path, rf"{self._path}/(.*.jpg$)")
 
-    def _on_deleted(self, event: FileDeletedEvent) -> None:
-        if event.src_path.endswith(".tmp"):
-            return
-        super()._on_deleted(event)
-
-    def _on_modified(self, event: FileModifiedEvent) -> None:
-        if event.src_path.endswith(".tmp"):
-            return
-        super()._on_modified(event)
-
     def _on_created(self, event: FileCreatedEvent) -> None:
         """Handle file creation with interval-based cleanup."""
-        if event.src_path.endswith(".tmp"):
-            return
-
         super()._on_created(event)
 
         # If no interval is set, keep all files

--- a/viseron/components/storage/util.py
+++ b/viseron/components/storage/util.py
@@ -15,6 +15,7 @@ from viseron.components.storage.const import (
     CONFIG_MB,
     CONFIG_MINUTES,
     CONFIG_PATH,
+    CONFIG_SECONDS,
     TIER_CATEGORY_SNAPSHOTS,
     TIER_SUBCATEGORY_EVENT_CLIPS,
     TIER_SUBCATEGORY_SEGMENTS,
@@ -37,6 +38,7 @@ def calculate_age(age: dict[str, Any]) -> timedelta:
         days=age[CONFIG_DAYS] if age[CONFIG_DAYS] else 0,
         hours=age[CONFIG_HOURS] if age[CONFIG_HOURS] else 0,
         minutes=age[CONFIG_MINUTES] if age[CONFIG_MINUTES] else 0,
+        seconds=age.get(CONFIG_SECONDS, None) if age.get(CONFIG_SECONDS, None) else 0,
     )
 
 

--- a/viseron/domains/camera/__init__.py
+++ b/viseron/domains/camera/__init__.py
@@ -168,6 +168,9 @@ class AbstractCamera(AbstractDomain):
             self, SnapshotDomain.MOTION_DETECTOR
         )
         self.timelapse_folder: str | None = self._storage.get_timelapse_path(self)
+        self.temp_timelapse_folder: str | None = (
+            TEMP_DIR + self.timelapse_folder if self.timelapse_folder else None
+        )
 
         self.fragmenter: Fragmenter = Fragmenter(vis, self)
         if self.config[CONFIG_PASSWORD]:


### PR DESCRIPTION
A few fixes to the timelapse functionality introduced in #1104 

- Extract frames to a temporary folder instead of placing it in the tier folder, reducing some traffic
- Specifying seconds in the timelapse interval did not work since `calculate_age`  did not take seconds into account
- Add the new timelapse path to cleanup jobs
- Update docker docs to include timelapse volume