### PR TITLE
fix object detector zone examples in the docs

### DIFF
--- a/docs/src/pages/components-explorer/_domains/object_detector/index.mdx
+++ b/docs/src/pages/components-explorer/_domains/object_detector/index.mdx
@@ -22,7 +22,7 @@ Object detectors can be taxing on the system, so it is wise to combine it with a
 
 ### Zones \{#object-detector-zones}
 
-<ObjectDetectorZones />
+<ObjectDetectorZones meta={props.meta} />
 
 ### Mask \{#object-detector-mask}
 

--- a/docs/src/pages/components-explorer/_domains/object_detector/zones.mdx
+++ b/docs/src/pages/components-explorer/_domains/object_detector/zones.mdx
@@ -15,27 +15,27 @@ actually interested in, excluding the sidewalk.
       ? props.meta.name
       : "<object detector component>"
   }:
-  object_detector:
-    cameras:
-      camera_one:
-        ...
-        // highlight-start
-        zones:
-          - name: sidewalk
-            coordinates:
-              - x: 522
-                y: 11
-              - x: 729
-                y: 275
-              - x: 333
-                y: 603
-              - x: 171
-                y: 97
-            labels:
-              - label: person
-                confidence: 0.8
-                trigger_event_recording: true
-        // highlight-end`}
+    object_detector:
+      cameras:
+        camera_one:
+          ...
+          // highlight-start
+          zones:
+            - name: sidewalk
+              coordinates:
+                - x: 522
+                  y: 11
+                - x: 729
+                  y: 275
+                - x: 333
+                  y: 603
+                - x: 171
+                  y: 97
+              labels:
+                - label: person
+                  confidence: 0.8
+                  trigger_event_recording: true
+          // highlight-end`}
 
 </CodeBlock>
 


### PR DESCRIPTION
Fix an error in the zone example yaml in the docs. Indentation was wrong and the component being viewed was not inserted