### PR TITLE
allow multiple processes to share hailo device

### DIFF
--- a/docs/src/pages/components-explorer/components/hailo/config.json
+++ b/docs/src/pages/components-explorer/components/hailo/config.json
@@ -379,6 +379,13 @@
         "description": "Object detector domain config.",
         "required": true,
         "default": null
+      },
+      {
+        "type": "boolean",
+        "name": "multi_process_service",
+        "description": "Allow multiple processes to share the Hailo device.",
+        "optional": true,
+        "default": true
       }
     ],
     "name": "hailo",

--- a/viseron/components/hailo/const.py
+++ b/viseron/components/hailo/const.py
@@ -15,20 +15,23 @@ HAILO8L_DEFAULT_URL = (
 
 # CONFIG_SCHEMA constants
 CONFIG_OBJECT_DETECTOR = "object_detector"
+CONFIG_MULTI_PROCESS_SERVICE = "multi_process_service"
+
+DEFAULT_MULTI_PROCESS_SERVICE: Final = True
+
+DESC_COMPONENT = "Hailo configuration."
+DESC_OBJECT_DETECTOR = "Object detector domain config."
+DESC_MULTI_PROCESS_SERVICE = "Allow multiple processes to share the Hailo device."
 
 # OBJECT_DETECTOR_SCHEMA constants
 CONFIG_MODEL_PATH = "model_path"
 CONFIG_LABEL_PATH = "label_path"
 CONFIG_MAX_DETECTIONS = "max_detections"
 
-
 DEFAULT_MODEL_PATH: Final = None
 DEFAULT_LABEL_PATH = "/detectors/models/darknet/coco.names"
 DEFAULT_MAX_DETECTIONS = 50
 
-
-DESC_COMPONENT = "Hailo configuration."
-DESC_OBJECT_DETECTOR = "Object detector domain config."
 DESC_MODEL_PATH = (
     "Path or URL to a Hailo-8 model in HEF format."
     " If a URL is provided, the model will be downloaded on startup."


### PR DESCRIPTION
Allow users to run the Hailo inference in shared mode, meaning other applications can access the Hailo device at the same time.
On recommendation of the Hailo team