### PR TITLE
remove unused tenacity dep in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ requests==2.31.0
 scikit-learn==1.2.2
 scipy==1.13.0
 supervision==0.21.0
-tenacity==8.3.0
 tornado==6.4.2
 typing-extensions==4.13.2
 urllib3==1.26.15


### PR DESCRIPTION
The python library tenacity is no longer used by Viseron