### PR TITLE
feat(storage): add 'drain' option to tier configuration

### DIFF
--- a/docs/src/pages/components-explorer/components/ffmpeg/config.json
+++ b/docs/src/pages/components-explorer/components/ffmpeg/config.json
@@ -237,6 +237,13 @@
                               "default": false
                             },
                             {
+                              "type": "boolean",
+                              "name": "drain",
+                              "description": "When a tier limit is reached, move all files to the next tier. If disabled, only move the files that exceed the limit. By using drain together with a smaller RAM disk as the first tier, you reduce the stress on storage devices by moving files in larger batches. Note that when using drain together with event recordings, partial moves of files will still occur.",
+                              "optional": true,
+                              "default": false
+                            },
+                            {
                               "type": "map",
                               "value": [
                                 {
@@ -667,6 +674,13 @@
                               "default": false
                             },
                             {
+                              "type": "boolean",
+                              "name": "drain",
+                              "description": "When a tier limit is reached, move all files to the next tier. If disabled, only move the files that exceed the limit. By using drain together with a smaller RAM disk as the first tier, you reduce the stress on storage devices by moving files in larger batches. Note that when using drain together with event recordings, partial moves of files will still occur.",
+                              "optional": true,
+                              "default": false
+                            },
+                            {
                               "type": "map",
                               "value": [
                                 {
@@ -848,6 +862,13 @@
                                   "type": "boolean",
                                   "name": "move_on_shutdown",
                                   "description": "Move/delete files to the next tier when Viseron shuts down. Useful to not lose files when shutting down Viseron if using a RAM disk.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
+                                  "type": "boolean",
+                                  "name": "drain",
+                                  "description": "When a tier limit is reached, move all files to the next tier. If disabled, only move the files that exceed the limit. By using drain together with a smaller RAM disk as the first tier, you reduce the stress on storage devices by moving files in larger batches. Note that when using drain together with event recordings, partial moves of files will still occur.",
                                   "optional": true,
                                   "default": false
                                 },
@@ -1043,6 +1064,13 @@
                                   "default": false
                                 },
                                 {
+                                  "type": "boolean",
+                                  "name": "drain",
+                                  "description": "When a tier limit is reached, move all files to the next tier. If disabled, only move the files that exceed the limit. By using drain together with a smaller RAM disk as the first tier, you reduce the stress on storage devices by moving files in larger batches. Note that when using drain together with event recordings, partial moves of files will still occur.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
                                   "type": "map",
                                   "value": [
                                     {
@@ -1234,6 +1262,13 @@
                                   "default": false
                                 },
                                 {
+                                  "type": "boolean",
+                                  "name": "drain",
+                                  "description": "When a tier limit is reached, move all files to the next tier. If disabled, only move the files that exceed the limit. By using drain together with a smaller RAM disk as the first tier, you reduce the stress on storage devices by moving files in larger batches. Note that when using drain together with event recordings, partial moves of files will still occur.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
                                   "type": "map",
                                   "value": [
                                     {
@@ -1421,6 +1456,13 @@
                                   "type": "boolean",
                                   "name": "move_on_shutdown",
                                   "description": "Move/delete files to the next tier when Viseron shuts down. Useful to not lose files when shutting down Viseron if using a RAM disk.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
+                                  "type": "boolean",
+                                  "name": "drain",
+                                  "description": "When a tier limit is reached, move all files to the next tier. If disabled, only move the files that exceed the limit. By using drain together with a smaller RAM disk as the first tier, you reduce the stress on storage devices by moving files in larger batches. Note that when using drain together with event recordings, partial moves of files will still occur.",
                                   "optional": true,
                                   "default": false
                                 },

--- a/docs/src/pages/components-explorer/components/gstreamer/config.json
+++ b/docs/src/pages/components-explorer/components/gstreamer/config.json
@@ -237,6 +237,13 @@
                               "default": false
                             },
                             {
+                              "type": "boolean",
+                              "name": "drain",
+                              "description": "When a tier limit is reached, move all files to the next tier. If disabled, only move the files that exceed the limit. By using drain together with a smaller RAM disk as the first tier, you reduce the stress on storage devices by moving files in larger batches. Note that when using drain together with event recordings, partial moves of files will still occur.",
+                              "optional": true,
+                              "default": false
+                            },
+                            {
                               "type": "map",
                               "value": [
                                 {
@@ -667,6 +674,13 @@
                               "default": false
                             },
                             {
+                              "type": "boolean",
+                              "name": "drain",
+                              "description": "When a tier limit is reached, move all files to the next tier. If disabled, only move the files that exceed the limit. By using drain together with a smaller RAM disk as the first tier, you reduce the stress on storage devices by moving files in larger batches. Note that when using drain together with event recordings, partial moves of files will still occur.",
+                              "optional": true,
+                              "default": false
+                            },
+                            {
                               "type": "map",
                               "value": [
                                 {
@@ -848,6 +862,13 @@
                                   "type": "boolean",
                                   "name": "move_on_shutdown",
                                   "description": "Move/delete files to the next tier when Viseron shuts down. Useful to not lose files when shutting down Viseron if using a RAM disk.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
+                                  "type": "boolean",
+                                  "name": "drain",
+                                  "description": "When a tier limit is reached, move all files to the next tier. If disabled, only move the files that exceed the limit. By using drain together with a smaller RAM disk as the first tier, you reduce the stress on storage devices by moving files in larger batches. Note that when using drain together with event recordings, partial moves of files will still occur.",
                                   "optional": true,
                                   "default": false
                                 },
@@ -1043,6 +1064,13 @@
                                   "default": false
                                 },
                                 {
+                                  "type": "boolean",
+                                  "name": "drain",
+                                  "description": "When a tier limit is reached, move all files to the next tier. If disabled, only move the files that exceed the limit. By using drain together with a smaller RAM disk as the first tier, you reduce the stress on storage devices by moving files in larger batches. Note that when using drain together with event recordings, partial moves of files will still occur.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
                                   "type": "map",
                                   "value": [
                                     {
@@ -1234,6 +1262,13 @@
                                   "default": false
                                 },
                                 {
+                                  "type": "boolean",
+                                  "name": "drain",
+                                  "description": "When a tier limit is reached, move all files to the next tier. If disabled, only move the files that exceed the limit. By using drain together with a smaller RAM disk as the first tier, you reduce the stress on storage devices by moving files in larger batches. Note that when using drain together with event recordings, partial moves of files will still occur.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
                                   "type": "map",
                                   "value": [
                                     {
@@ -1421,6 +1456,13 @@
                                   "type": "boolean",
                                   "name": "move_on_shutdown",
                                   "description": "Move/delete files to the next tier when Viseron shuts down. Useful to not lose files when shutting down Viseron if using a RAM disk.",
+                                  "optional": true,
+                                  "default": false
+                                },
+                                {
+                                  "type": "boolean",
+                                  "name": "drain",
+                                  "description": "When a tier limit is reached, move all files to the next tier. If disabled, only move the files that exceed the limit. By using drain together with a smaller RAM disk as the first tier, you reduce the stress on storage devices by moving files in larger batches. Note that when using drain together with event recordings, partial moves of files will still occur.",
                                   "optional": true,
                                   "default": false
                                 },

--- a/docs/src/pages/components-explorer/components/storage/config.json
+++ b/docs/src/pages/components-explorer/components/storage/config.json
@@ -60,6 +60,13 @@
                   "default": false
                 },
                 {
+                  "type": "boolean",
+                  "name": "drain",
+                  "description": "When a tier limit is reached, move all files to the next tier. If disabled, only move the files that exceed the limit. By using drain together with a smaller RAM disk as the first tier, you reduce the stress on storage devices by moving files in larger batches. Note that when using drain together with event recordings, partial moves of files will still occur.",
+                  "optional": true,
+                  "default": false
+                },
+                {
                   "type": "map",
                   "value": [
                     {
@@ -490,6 +497,13 @@
                   "default": false
                 },
                 {
+                  "type": "boolean",
+                  "name": "drain",
+                  "description": "When a tier limit is reached, move all files to the next tier. If disabled, only move the files that exceed the limit. By using drain together with a smaller RAM disk as the first tier, you reduce the stress on storage devices by moving files in larger batches. Note that when using drain together with event recordings, partial moves of files will still occur.",
+                  "optional": true,
+                  "default": false
+                },
+                {
                   "type": "map",
                   "value": [
                     {
@@ -678,6 +692,13 @@
                       "type": "boolean",
                       "name": "move_on_shutdown",
                       "description": "Move/delete files to the next tier when Viseron shuts down. Useful to not lose files when shutting down Viseron if using a RAM disk.",
+                      "optional": true,
+                      "default": false
+                    },
+                    {
+                      "type": "boolean",
+                      "name": "drain",
+                      "description": "When a tier limit is reached, move all files to the next tier. If disabled, only move the files that exceed the limit. By using drain together with a smaller RAM disk as the first tier, you reduce the stress on storage devices by moving files in larger batches. Note that when using drain together with event recordings, partial moves of files will still occur.",
                       "optional": true,
                       "default": false
                     },
@@ -873,6 +894,13 @@
                       "default": false
                     },
                     {
+                      "type": "boolean",
+                      "name": "drain",
+                      "description": "When a tier limit is reached, move all files to the next tier. If disabled, only move the files that exceed the limit. By using drain together with a smaller RAM disk as the first tier, you reduce the stress on storage devices by moving files in larger batches. Note that when using drain together with event recordings, partial moves of files will still occur.",
+                      "optional": true,
+                      "default": false
+                    },
+                    {
                       "type": "map",
                       "value": [
                         {
@@ -1064,6 +1092,13 @@
                       "default": false
                     },
                     {
+                      "type": "boolean",
+                      "name": "drain",
+                      "description": "When a tier limit is reached, move all files to the next tier. If disabled, only move the files that exceed the limit. By using drain together with a smaller RAM disk as the first tier, you reduce the stress on storage devices by moving files in larger batches. Note that when using drain together with event recordings, partial moves of files will still occur.",
+                      "optional": true,
+                      "default": false
+                    },
+                    {
                       "type": "map",
                       "value": [
                         {
@@ -1251,6 +1286,13 @@
                       "type": "boolean",
                       "name": "move_on_shutdown",
                       "description": "Move/delete files to the next tier when Viseron shuts down. Useful to not lose files when shutting down Viseron if using a RAM disk.",
+                      "optional": true,
+                      "default": false
+                    },
+                    {
+                      "type": "boolean",
+                      "name": "drain",
+                      "description": "When a tier limit is reached, move all files to the next tier. If disabled, only move the files that exceed the limit. By using drain together with a smaller RAM disk as the first tier, you reduce the stress on storage devices by moving files in larger batches. Note that when using drain together with event recordings, partial moves of files will still occur.",
                       "optional": true,
                       "default": false
                     },
@@ -1448,6 +1490,13 @@
                   "type": "boolean",
                   "name": "move_on_shutdown",
                   "description": "Move/delete files to the next tier when Viseron shuts down. Useful to not lose files when shutting down Viseron if using a RAM disk.",
+                  "optional": true,
+                  "default": false
+                },
+                {
+                  "type": "boolean",
+                  "name": "drain",
+                  "description": "When a tier limit is reached, move all files to the next tier. If disabled, only move the files that exceed the limit. By using drain together with a smaller RAM disk as the first tier, you reduce the stress on storage devices by moving files in larger batches. Note that when using drain together with event recordings, partial moves of files will still occur.",
                   "optional": true,
                   "default": false
                 },

--- a/tests/components/storage/test__init__.py
+++ b/tests/components/storage/test__init__.py
@@ -18,6 +18,7 @@ from viseron.components.storage.const import (
     CONFIG_CHECK_INTERVAL,
     CONFIG_CONTINUOUS,
     CONFIG_DAYS,
+    CONFIG_DRAIN,
     CONFIG_EVENTS,
     CONFIG_FACE_RECOGNITION,
     CONFIG_GB,
@@ -113,7 +114,7 @@ TIER_CONFIG = {
                                     CONFIG_HOURS: None,
                                     CONFIG_MINUTES: None,
                                 },
-                                CONFIG_MAX_SIZE: {CONFIG_GB: None, CONFIG_MB: 1024},
+                                CONFIG_MAX_SIZE: {CONFIG_GB: None, CONFIG_MB: 1024.0},
                                 CONFIG_MIN_AGE: {
                                     CONFIG_DAYS: None,
                                     CONFIG_HOURS: None,
@@ -122,6 +123,7 @@ TIER_CONFIG = {
                                 CONFIG_MIN_SIZE: {CONFIG_GB: None, CONFIG_MB: None},
                             },
                             CONFIG_MOVE_ON_SHUTDOWN: False,
+                            CONFIG_DRAIN: False,
                             CONFIG_PATH: "/",
                             CONFIG_POLL: False,
                         }
@@ -192,6 +194,7 @@ TIER_CONFIG = {
                                 CONFIG_MIN_SIZE: {CONFIG_GB: None, CONFIG_MB: None},
                             },
                             CONFIG_MOVE_ON_SHUTDOWN: False,
+                            CONFIG_DRAIN: False,
                             CONFIG_PATH: "/test/",
                             CONFIG_POLL: False,
                         }
@@ -245,6 +248,7 @@ TIER_CONFIG = {
                             },
                             CONFIG_MIN_SIZE: {CONFIG_GB: None, CONFIG_MB: None},
                             CONFIG_MOVE_ON_SHUTDOWN: False,
+                            CONFIG_DRAIN: False,
                             CONFIG_PATH: "/test/",
                             CONFIG_POLL: False,
                         }
@@ -307,6 +311,7 @@ TIER_CONFIG = {
                             },
                             CONFIG_MIN_SIZE: {CONFIG_GB: None, CONFIG_MB: None},
                             CONFIG_MOVE_ON_SHUTDOWN: False,
+                            CONFIG_DRAIN: False,
                             CONFIG_PATH: "/test/",
                             CONFIG_POLL: False,
                         }
@@ -334,6 +339,7 @@ TIER_CONFIG = {
                                 },
                                 CONFIG_MIN_SIZE: {CONFIG_GB: None, CONFIG_MB: None},
                                 CONFIG_MOVE_ON_SHUTDOWN: False,
+                                CONFIG_DRAIN: False,
                                 CONFIG_POLL: False,
                             }
                         ]

--- a/tests/components/storage/test_config.py
+++ b/tests/components/storage/test_config.py
@@ -62,6 +62,7 @@ def create_tier(
     events=None,
     continuous=None,
     move_on_shutdown=False,
+    drain=False,
     poll=False,
     check_interval=None,
 ):
@@ -71,6 +72,7 @@ def create_tier(
         "events": create_retain_config(**(events or {})),
         "continuous": create_retain_config(**(continuous or {})),
         "move_on_shutdown": move_on_shutdown,
+        "drain": drain,
         "poll": poll,
         "check_interval": create_check_interval(**(check_interval or {})),
     }
@@ -79,6 +81,7 @@ def create_tier(
 def create_tier_snapshots(
     path="/",
     move_on_shutdown=False,
+    drain=False,
     poll=False,
     check_interval=None,
     max_age=None,
@@ -90,6 +93,7 @@ def create_tier_snapshots(
     return {
         "path": path,
         "move_on_shutdown": move_on_shutdown,
+        "drain": drain,
         "poll": poll,
         "check_interval": create_check_interval(**(check_interval or {})),
         **create_retain_config(
@@ -111,6 +115,7 @@ DEFAULT_CONFIG = {
                     "path": "/",
                     **create_retain_config(max_age={"days": 7}),
                     "move_on_shutdown": False,
+                    "drain": False,
                     "poll": False,
                     "check_interval": create_check_interval(),
                 }

--- a/viseron/components/storage/config.py
+++ b/viseron/components/storage/config.py
@@ -11,6 +11,7 @@ from viseron.components.storage.const import (
     CONFIG_CHECK_INTERVAL,
     CONFIG_CONTINUOUS,
     CONFIG_DAYS,
+    CONFIG_DRAIN,
     CONFIG_EVENTS,
     CONFIG_FACE_RECOGNITION,
     CONFIG_GB,
@@ -44,6 +45,7 @@ from viseron.components.storage.const import (
     DEFAULT_CHECK_INTERVAL_SECONDS,
     DEFAULT_CONTINUOUS,
     DEFAULT_DAYS,
+    DEFAULT_DRAIN,
     DEFAULT_EVENTS,
     DEFAULT_FACE_RECOGNITION,
     DEFAULT_GB,
@@ -77,6 +79,7 @@ from viseron.components.storage.const import (
     DESC_CHECK_INTERVAL_SECONDS,
     DESC_CONTINUOUS,
     DESC_DOMAIN_TIERS,
+    DESC_DRAIN,
     DESC_EVENTS,
     DESC_FACE_RECOGNITION,
     DESC_INTERVAL,
@@ -230,6 +233,11 @@ TIER_SCHEMA_SNAPSHOTS = TIER_SCHEMA_BASE.extend(
             description=DESC_MOVE_ON_SHUTDOWN,
         ): bool,
         vol.Optional(
+            CONFIG_DRAIN,
+            default=DEFAULT_DRAIN,
+            description=DESC_DRAIN,
+        ): bool,
+        vol.Optional(
             CONFIG_CHECK_INTERVAL,
             default=DEFAULT_CHECK_INTERVAL,
             description=DESC_CHECK_INTERVAL,
@@ -276,6 +284,11 @@ TIER_SCHEMA_RECORDER = vol.Schema(
             CONFIG_MOVE_ON_SHUTDOWN,
             default=DEFAULT_MOVE_ON_SHUTDOWN,
             description=DESC_MOVE_ON_SHUTDOWN,
+        ): bool,
+        vol.Optional(
+            CONFIG_DRAIN,
+            default=DEFAULT_DRAIN,
+            description=DESC_DRAIN,
         ): bool,
         vol.Optional(
             CONFIG_CHECK_INTERVAL,

--- a/viseron/components/storage/const.py
+++ b/viseron/components/storage/const.py
@@ -58,6 +58,7 @@ CONFIG_TIER_CHECK_SLEEP_BETWEEN_BATCHES: Final = "tier_check_sleep_between_batch
 CONFIG_PATH: Final = "path"
 CONFIG_POLL: Final = "poll"
 CONFIG_MOVE_ON_SHUTDOWN: Final = "move_on_shutdown"
+CONFIG_DRAIN: Final = "drain"
 CONFIG_CHECK_INTERVAL: Final = "check_interval"
 CONFIG_MIN_SIZE: Final = "min_size"
 CONFIG_MAX_SIZE: Final = "max_size"
@@ -114,6 +115,7 @@ DEFAULT_MOTION_DETECTOR: Final = None
 
 DEFAULT_POLL = False
 DEFAULT_MOVE_ON_SHUTDOWN = False
+DEFAULT_DRAIN = False
 DEFAULT_CHECK_INTERVAL: Final = {
     CONFIG_MINUTES: 1,
 }
@@ -223,6 +225,14 @@ DESC_POLL = (
 DESC_MOVE_ON_SHUTDOWN = (
     "Move/delete files to the next tier when Viseron shuts down. "
     "Useful to not lose files when shutting down Viseron if using a RAM disk."
+)
+DESC_DRAIN = (
+    "When a tier limit is reached, move all files to the next tier. "
+    "If disabled, only move the files that exceed the limit. "
+    "By using drain together with a smaller RAM disk as the first tier, you reduce the "
+    "stress on storage devices by moving files in larger batches. "
+    "Note that when using drain together with event recordings, partial moves of files "
+    "will still occur."
 )
 DESC_CHECK_INTERVAL = "How often to check for files to move to the next tier."
 DESC_CHECK_INTERVAL_DAYS = "Days between checks for files to move/delete."

--- a/viseron/components/storage/storage_subprocess.py
+++ b/viseron/components/storage/storage_subprocess.py
@@ -42,6 +42,7 @@ class DataItem:
     min_age: datetime.timedelta
     max_age: datetime.timedelta
     min_bytes: int
+    drain: bool
     files_enabled: bool = True
     events_enabled: bool = False
     events_max_bytes: int | None = None

--- a/viseron/components/storage/tier_handler.py
+++ b/viseron/components/storage/tier_handler.py
@@ -31,6 +31,7 @@ from viseron.components.storage.const import (
     CONFIG_CHECK_INTERVAL,
     CONFIG_CONTINUOUS,
     CONFIG_DAYS,
+    CONFIG_DRAIN,
     CONFIG_EVENTS,
     CONFIG_HOURS,
     CONFIG_INTERVAL,
@@ -232,6 +233,7 @@ class TierHandler(FileSystemEventHandler):
             min_age=self._min_age,
             max_age=self._max_age,
             min_bytes=self._min_bytes,
+            drain=self._tier[CONFIG_DRAIN],
         )
 
     def _check_tier_event_handler(self, _event: Event) -> None:
@@ -554,6 +556,7 @@ class SegmentsTierHandler(TierHandler):
             ),
             max_age=self._continuous_max_age,
             min_bytes=self._continuous_min_bytes,
+            drain=self._tier[CONFIG_DRAIN],
             events_enabled=self._events_enabled,
             events_max_bytes=self._events_max_bytes,
             events_min_age=self._events_min_age,


### PR DESCRIPTION
Introduces a new config option called `drain` to all tier configs which empties the entire tier when a limit is hit.
Can be used to move files in larger batches, reducing stress on disks