### PR TITLE
pin hls files to first tier

### DIFF
--- a/viseron/components/storage/queries.py
+++ b/viseron/components/storage/queries.py
@@ -116,13 +116,13 @@ def get_time_period_fragments(
         .where(Files.duration.isnot(None))
         .where(
             or_(
-                # Fetch all files that start within the recording
+                # Fetch all files that start between the start and end timestamp
                 Files.orig_ctime.between(
                     start,
                     end,
                 ),
-                # Fetch the first file that starts before the recording but
-                # ends during the recording
+                # Fetch the first file that starts before the start timestamp but
+                # ends during the requested time period
                 and_(
                     start >= Files.orig_ctime,
                     start

--- a/viseron/components/storage/tier_handler.py
+++ b/viseron/components/storage/tier_handler.py
@@ -190,6 +190,11 @@ class TierHandler(FileSystemEventHandler):
         """Return tier id."""
         return self._tier_id
 
+    @property
+    def tier_base_path(self) -> str:
+        """Return tier base path."""
+        return self._tier[CONFIG_PATH]
+
     def add_file_handler(self, path: str, pattern: str):
         """Add file handler to webserver."""
         self._logger.debug(f"Adding handler for /files{pattern}")


### PR DESCRIPTION
According to HLS specifications, a file URL is not allowed to change on updates. Since Viseron moves files between tiers this can occur.

In order to comply with the specs, all files in the playlist are delivered with the first tier as the base path, and query parameters (which are allowed to change between updates) are added to instruct the backend where to find the files when playback is requested