### PR TITLE
Update launch.json to use debugpy instead of python for debugging configurations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,7 +3,7 @@
   "configurations": [
     {
       "name": "Viseron",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
       "module": "viseron",
       "justMyCode": true,
@@ -14,7 +14,7 @@
     },
     {
       "name": "Generate Docs",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
       "module": "scripts.gen_docs",
       "args": ["-c", "${input:component}"],


### PR DESCRIPTION
When I open this file in VS Code, I get the following warning:
```
This configuration will be deprecated soon. 
Please replace `python` with `debugpy` to use the new Python Debugger extension.
```

It turns out that the value 'python' has been deprecated by VS Code based on the URL: https://code.visualstudio.com/docs/python/debugging#_troubleshooting.

There it says:
```
You have "type" set to the deprecated value "python" in your launch.json file: 
replace "python" with "debugpy" instead to work with the Python Debugger extension.
```