### PR TITLE
YOLO component documentation now indicates model_path is required

### DIFF
--- a/docs/src/pages/components-explorer/components/yolo/config.json
+++ b/docs/src/pages/components-explorer/components/yolo/config.json
@@ -343,9 +343,9 @@
           {
             "type": "string",
             "name": "model_path",
-            "description": "Path to a YOLO model.More information <a href=https://docs.ultralytics.com/models>here</a>.",
-            "optional": true,
-            "default": "/detectors/models/yolo/default.pt"
+            "description": "Path to a YOLO model. See <i>Pre-trained models</i> below.",
+            "required": true,
+            "default": null
           },
           {
             "type": "float",

--- a/viseron/components/yolo/__init__.py
+++ b/viseron/components/yolo/__init__.py
@@ -39,7 +39,7 @@ from .const import (
 
 OBJECT_DETECTOR_SCHEMA = OBJECT_DETECTOR_BASE_CONFIG_SCHEMA.extend(
     {
-        vol.Optional(
+        vol.Required(
             CONFIG_MODEL_PATH,
             default=DEFAULT_MODEL_PATH,
             description=DESC_MODEL_PATH,

--- a/viseron/components/yolo/const.py
+++ b/viseron/components/yolo/const.py
@@ -13,7 +13,7 @@ CONFIG_IOU = "iou"
 CONFIG_HALF_PRECISION = "half_precision"
 CONFIG_DEVICE = "device"
 
-DEFAULT_MODEL_PATH = "/detectors/models/yolo/default.pt"
+DEFAULT_MODEL_PATH: Final = None
 DEFAULT_MIN_CONFIDENCE = 0.25
 DEFAULT_IOU = 0.7
 DEFAULT_HALF_PRECISION = False
@@ -22,11 +22,7 @@ DEFAULT_DEVICE: Final = None
 DESC_COMPONENT = "YOLO configuration."
 DESC_OBJECT_DETECTOR = "Object detector domain config."
 
-DESC_MODEL_PATH = (
-    "Path to a YOLO model."
-    "More information "
-    "<a href=https://docs.ultralytics.com/models>here</a>."
-)
+DESC_MODEL_PATH = "Path to a YOLO model. See <i>Pre-trained models</i> below."
 DESC_MIN_CONFIDENCE = (
     "Minimum confidence to consider a detection.<br>"
     "This minimum is enforced during inference before being filtered by values "


### PR DESCRIPTION
This change is for YOLO entry in the component browser.  Currently, the `model_path` entry indicates it is an optional entry.  In fact, the YOLO component requires a valid `model_path`.  This PR updates the entry in the component browser making it clear it is required.

Note:  My dev container is working enough to run the commit hooks (which generated `config.json`.  However, the container is not working enough to view the docs locally (`npm run start` in the docs directory fails).  If that can be a problem feel free to reject this PR and I will revisit the functionality of my dev container.


