### PR TITLE
set hailo multi_process_service to false by default and fix config re…

### DIFF
--- a/docs/src/pages/components-explorer/components/hailo/config.json
+++ b/docs/src/pages/components-explorer/components/hailo/config.json
@@ -385,7 +385,7 @@
         "name": "multi_process_service",
         "description": "Allow multiple processes to share the Hailo device.",
         "optional": true,
-        "default": true
+        "default": false
       }
     ],
     "name": "hailo",

--- a/viseron/components/hailo/__init__.py
+++ b/viseron/components/hailo/__init__.py
@@ -97,7 +97,7 @@ def setup(vis: Viseron, config: dict[str, Any]) -> bool:
     config = config[COMPONENT]
 
     try:
-        vis.data[COMPONENT] = Hailo8Detector(vis, config[CONFIG_OBJECT_DETECTOR])
+        vis.data[COMPONENT] = Hailo8Detector(vis, config)
     except Exception as error:
         LOGGER.error("Failed to start Hailo 8 detector: %s", error, exc_info=True)
         raise ComponentNotReady from error
@@ -137,8 +137,10 @@ class Hailo8Detector(ChildProcessWorker):
             LOGGER.error("Failed to detect Hailo architecture.")
             raise ComponentNotReady
 
-        self.model_path = get_model(config[CONFIG_MODEL_PATH], hailo_arch)
-        self.labels = load_labels(config[CONFIG_LABEL_PATH])
+        self.model_path = get_model(
+            config[CONFIG_OBJECT_DETECTOR][CONFIG_MODEL_PATH], hailo_arch
+        )
+        self.labels = load_labels(config[CONFIG_OBJECT_DETECTOR][CONFIG_LABEL_PATH])
 
         self._result_queues: dict[str, Queue] = {}
         self._process_initialization_done = mp.Event()

--- a/viseron/components/hailo/const.py
+++ b/viseron/components/hailo/const.py
@@ -16,7 +16,7 @@ HAILO8L_DEFAULT_URL = (
 CONFIG_OBJECT_DETECTOR = "object_detector"
 CONFIG_MULTI_PROCESS_SERVICE = "multi_process_service"
 
-DEFAULT_MULTI_PROCESS_SERVICE: Final = True
+DEFAULT_MULTI_PROCESS_SERVICE: Final = False
 
 DESC_COMPONENT = "Hailo configuration."
 DESC_OBJECT_DETECTOR = "Object detector domain config."


### PR DESCRIPTION
Two fixes to the Hailo component:
- Fix config referencing, closes #1179 
- Default `multi_process_service` to false since it requires special CMake parameters to enable