### PR TITLE
refator(backend): remove all direct usage of DataStream

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,12 +29,15 @@ class MockViseron(Viseron):
 
     def __init__(self) -> None:
         super().__init__(start_background_scheduler=False)
-        self.register_domain = Mock(  # type: ignore[method-assign]
+        self.register_domain: Mock = Mock(
             side_effect=self.register_domain,
         )
         self.mocked_register_domain = self.register_domain
-        self.add_entity = MagicMock(  # type: ignore[method-assign]
+        self.add_entity: MagicMock = MagicMock(
             auto_spec=self.add_entity,
+        )
+        self.listen_event: MagicMock = MagicMock(
+            auto_spec=self.listen_event,
         )
 
 

--- a/viseron/components/ffmpeg/camera.py
+++ b/viseron/components/ffmpeg/camera.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 
 from viseron import Viseron
 from viseron.const import ENV_CUDA_SUPPORTED, ENV_VAAPI_SUPPORTED
-from viseron.domains.camera import AbstractCamera
+from viseron.domains.camera import AbstractCamera, EventFrameBytesData
 from viseron.domains.camera.config import (
     BASE_CONFIG_SCHEMA as BASE_CAMERA_CONFIG_SCHEMA,
     DEFAULT_RECORDER,
@@ -500,7 +500,14 @@ class Camera(AbstractCamera):
             self._poll_timer = utcnow().timestamp()
             self.shared_frames.create(shared_frame, frame_bytes)
             self.current_frame = shared_frame
-            self._data_stream.publish_data(self.frame_bytes_topic, self.current_frame)
+            self._vis.dispatch_event(
+                self.frame_bytes_topic,
+                EventFrameBytesData(
+                    camera_identifier=self.identifier,
+                    shared_frame=self.current_frame,
+                ),
+                store=False,
+            )
 
         self.connected = False
         self.still_image_available = self.still_image_configured

--- a/viseron/components/gstreamer/camera.py
+++ b/viseron/components/gstreamer/camera.py
@@ -34,7 +34,7 @@ from viseron.components.ffmpeg.const import (
     DESC_RECORDER_OUTPUT_ARGS,
     DESC_RECORDER_VIDEO_FILTERS,
 )
-from viseron.domains.camera import AbstractCamera
+from viseron.domains.camera import AbstractCamera, EventFrameBytesData
 from viseron.domains.camera.config import (
     BASE_CONFIG_SCHEMA as BASE_CAMERA_CONFIG_SCHEMA,
     DEFAULT_RECORDER,
@@ -356,8 +356,13 @@ class Camera(AbstractCamera):
                 self.still_image_available = True
                 empty_frames = 0
                 self._poll_timer = utcnow().timestamp()
-                self._data_stream.publish_data(
-                    self.frame_bytes_topic, self.current_frame
+                self._vis.dispatch_event(
+                    self.frame_bytes_topic,
+                    EventFrameBytesData(
+                        camera_identifier=self.identifier,
+                        shared_frame=self.current_frame,
+                    ),
+                    store=False,
                 )
                 continue
 

--- a/viseron/components/nvr/const.py
+++ b/viseron/components/nvr/const.py
@@ -14,7 +14,7 @@ NO_DETECTOR_FPS: Final = 1
 SCANNER_RESULT_RETRIES: Final = 5
 
 # Data stream topic constants
-DATA_PROCESSED_FRAME_TOPIC = "{camera_identifier}/nvr/processed_frame"
+EVENT_PROCESSED_FRAME_TOPIC = "{camera_identifier}/nvr/processed_frame"
 
 
 # Event topic constants

--- a/viseron/domains/camera/__init__.py
+++ b/viseron/domains/camera/__init__.py
@@ -18,10 +18,6 @@ from sqlalchemy import or_, select
 from typing_extensions import assert_never
 
 from viseron.components import DomainToSetup
-from viseron.components.data_stream import (
-    COMPONENT as DATA_STREAM_COMPONENT,
-    DataStream,
-)
 from viseron.components.go2rtc.const import COMPONENT as GO2RTC_COMPONENT
 from viseron.components.storage.config import validate_tiers
 from viseron.components.storage.const import (
@@ -95,6 +91,15 @@ LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
+class EventFrameBytesData(EventData):
+    """Hold information on camera frame bytes event."""
+
+    json_serializable = False
+    camera_identifier: str
+    shared_frame: SharedFrame
+
+
+@dataclass
 class EventCameraStatusData(EventData):
     """Hold information on camera status event."""
 
@@ -108,7 +113,7 @@ class EventCameraStillImageAvailable(EventData):
     available: bool
 
 
-DATA_FRAME_BYTES_TOPIC = "{camera_identifier}/camera/frame_bytes"
+EVENT_FRAME_BYTES_TOPIC = "{camera_identifier}/camera/frame_bytes"
 
 
 class AbstractCamera(AbstractDomain):
@@ -128,10 +133,9 @@ class AbstractCamera(AbstractDomain):
         self._still_image_available: bool = False
         self.stopped = Event()
         self.stopped.set()
-        self._data_stream: DataStream = vis.data[DATA_STREAM_COMPONENT]
         self.current_frame: SharedFrame | None = None
         self.shared_frames = SharedFrames(vis)
-        self.frame_bytes_topic = DATA_FRAME_BYTES_TOPIC.format(
+        self.frame_bytes_topic = EVENT_FRAME_BYTES_TOPIC.format(
             camera_identifier=self.identifier
         )
         self.access_tokens: deque = deque([], 2)

--- a/viseron/domains/motion_detector/const.py
+++ b/viseron/domains/motion_detector/const.py
@@ -5,8 +5,8 @@ DOMAIN: Final = "motion_detector"
 
 
 # Data stream topic constants
-DATA_MOTION_DETECTOR_SCAN = "motion_detector/{camera_identifier}/scan"
-DATA_MOTION_DETECTOR_RESULT = "motion_detector/{camera_identifier}/result"
+EVENT_MOTION_DETECTOR_SCAN = "motion_detector/{camera_identifier}/scan"
+EVENT_MOTION_DETECTOR_RESULT = "motion_detector/{camera_identifier}/result"
 
 
 # Event topic constants

--- a/viseron/domains/object_detector/const.py
+++ b/viseron/domains/object_detector/const.py
@@ -9,8 +9,8 @@ DOMAIN: Final = "object_detector"
 MODEL_CACHE: Final = os.path.join(CONFIG_DIR, "models")
 
 # Data stream topic constants
-DATA_OBJECT_DETECTOR_SCAN = "object_detector/{camera_identifier}/scan"
-DATA_OBJECT_DETECTOR_RESULT = "object_detector/{camera_identifier}/result"
+EVENT_OBJECT_DETECTOR_SCAN = "object_detector/{camera_identifier}/scan"
+EVENT_OBJECT_DETECTOR_RESULT = "object_detector/{camera_identifier}/result"
 
 
 # Event topic constants


### PR DESCRIPTION
In order to prepare for hot reloading of the config, all direct usage of DataStream has to be removed in favor of `listen_event` so it can be tracked properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched core frame delivery and processing to an event-driven system across cameras, NVR, motion and object detectors.
  * Standardized detector scan/result messaging to event topics and introduced event payload types for inter-component events.
  * Updated web streaming pipeline to consume event-based processed frames and static stream events.

* **Tests**
  * Updated tests and mocks to use event-listener patterns and new event payloads.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->