### PR TITLE
refactor(backend): prepare for full typing of vis.data

### DIFF
--- a/viseron/__init__.py
+++ b/viseron/__init__.py
@@ -346,7 +346,7 @@ class Viseron:
             )
             raise DataStreamNotLoaded
 
-        data_stream: DataStream = self.data[DATA_STREAM_COMPONENT]
+        data_stream = self.data[DATA_STREAM_COMPONENT]
         topic = f"event/{event}"
         uuid = data_stream.subscribe_data(topic, callback, ioloop=ioloop)
 
@@ -573,7 +573,7 @@ class Viseron:
         self.shutdown_event.set()
 
         if self.data.get(DATA_STREAM_COMPONENT, None):
-            data_stream: DataStream = self.data[DATA_STREAM_COMPONENT]
+            data_stream = self.data[DATA_STREAM_COMPONENT]
 
         if (
             self._thread_watchdog

--- a/viseron/components/compreface/const.py
+++ b/viseron/components/compreface/const.py
@@ -2,11 +2,11 @@
 
 from typing import Final
 
-COMPONENT = "compreface"
+COMPONENT: Final = "compreface"
 SUBJECTS = "subjects"
 
 # CONFIG_SCHEMA constants
-CONFIG_FACE_RECOGNITION = "face_recognition"
+CONFIG_FACE_RECOGNITION: Final = "face_recognition"
 CONFIG_HOST = "host"
 CONFIG_PORT = "port"
 CONFIG_API_KEY = "recognition_api_key"

--- a/viseron/components/compreface/face_recognition.py
+++ b/viseron/components/compreface/face_recognition.py
@@ -64,9 +64,7 @@ class FaceRecognition(AbstractFaceRecognition):
                 "Make sure the component is set up correctly."
             )
 
-        self._compreface_service: CompreFaceService = self._vis.data[COMPONENT][
-            CONFIG_FACE_RECOGNITION
-        ]
+        self._compreface_service = self._vis.data[COMPONENT][CONFIG_FACE_RECOGNITION]
 
         if config[CONFIG_FACE_RECOGNITION][CONFIG_USE_SUBJECTS]:
             self.update_subject_entities()
@@ -212,9 +210,7 @@ class CompreFaceTrain:
                 "Make sure the component is set up correctly."
             )
 
-        self._compreface_service: CompreFaceService = self._vis.data[COMPONENT][
-            CONFIG_FACE_RECOGNITION
-        ]
+        self._compreface_service = self._vis.data[COMPONENT][CONFIG_FACE_RECOGNITION]
         self._face_collection = (
             self._compreface_service.recognition_service.get_face_collection()
         )

--- a/viseron/components/darknet/const.py
+++ b/viseron/components/darknet/const.py
@@ -5,7 +5,7 @@ from typing import Final
 
 import cv2
 
-COMPONENT = "darknet"
+COMPONENT: Final = "darknet"
 
 
 # CONFIG_SCHEMA constants

--- a/viseron/components/darknet/object_detector.py
+++ b/viseron/components/darknet/object_detector.py
@@ -12,7 +12,6 @@ from .const import COMPONENT
 
 if TYPE_CHECKING:
     from viseron import Viseron
-    from viseron.components.darknet import BaseDarknet
     from viseron.domains.camera.shared_frames import SharedFrame
     from viseron.domains.object_detector.detected_object import DetectedObject
 
@@ -32,7 +31,7 @@ class ObjectDetector(AbstractObjectDetector):
 
     def __init__(self, vis: Viseron, config, camera_identifier) -> None:
         super().__init__(vis, COMPONENT, config, camera_identifier)
-        self._darknet: BaseDarknet = vis.data[COMPONENT]
+        self._darknet = vis.data[COMPONENT]
         self._object_result_queue: Queue[list[DetectedObject]] = Queue(maxsize=1)
 
     def preprocess(self, frame: SharedFrame):

--- a/viseron/components/data_stream/__init__.py
+++ b/viseron/components/data_stream/__init__.py
@@ -11,7 +11,7 @@ import time
 import uuid
 from collections.abc import Callable
 from queue import Empty, Queue
-from typing import Any, TypedDict
+from typing import Any, Final, TypedDict
 
 from tornado.ioloop import IOLoop
 from tornado.queues import Queue as tornado_queue
@@ -19,7 +19,7 @@ from tornado.queues import Queue as tornado_queue
 from viseron import helpers
 from viseron.watchdog.thread_watchdog import RestartableThread
 
-COMPONENT = "data_stream"
+COMPONENT: Final = "data_stream"
 
 LOGGER = logging.getLogger(__name__)
 

--- a/viseron/components/dlib/const.py
+++ b/viseron/components/dlib/const.py
@@ -1,22 +1,27 @@
 """dlib constants."""
 
-COMPONENT = "dlib"
+from typing import Final
+
+COMPONENT: Final = "dlib"
 
 # CONFIG_SCHEMA constants
-CONFIG_FACE_RECOGNITION = "face_recognition"
+CONFIG_FACE_RECOGNITION: Final = "face_recognition"
 
 
 # FACE_RECOGNITION_SCHEMA constants
-CONFIG_MODEL = "model"
+CONFIG_MODEL: Final = "model"
 
-DESC_COMPONENT = "dlib configuration."
-DESC_FACE_RECOGNITION = "Face recognition domain config."
-DESC_MODEL = (
+DESC_COMPONENT: Final = "dlib configuration."
+DESC_FACE_RECOGNITION: Final = "Face recognition domain config."
+DESC_MODEL: Final = (
     "Which face recognition model to run. "
     "See <a href=#models>models</a> for more information on this."
 )
 
-SUPPORTED_MODELS = [
+SUPPORTED_MODELS: Final = [
     "hog",
     "cnn",
 ]
+
+# Viseron data keys
+CLASSIFIER: Final = "classifier"

--- a/viseron/components/dlib/face_recognition.py
+++ b/viseron/components/dlib/face_recognition.py
@@ -11,7 +11,7 @@ from viseron.domains.face_recognition import AbstractFaceRecognition
 from viseron.domains.face_recognition.const import CONFIG_FACE_RECOGNITION_PATH
 from viseron.helpers import calculate_absolute_coords
 
-from .const import COMPONENT, CONFIG_FACE_RECOGNITION, CONFIG_MODEL
+from .const import CLASSIFIER, COMPONENT, CONFIG_FACE_RECOGNITION, CONFIG_MODEL
 from .predict import predict
 from .train import train
 
@@ -23,8 +23,6 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 TRAIN_LOCK = threading.Lock()
-
-CLASSIFIER = "CLASSIFIER"
 
 
 def setup(vis: Viseron, config, identifier) -> bool:

--- a/viseron/components/edgetpu/const.py
+++ b/viseron/components/edgetpu/const.py
@@ -1,7 +1,7 @@
 """EdgeTPU constants."""
 from typing import Final
 
-COMPONENT = "edgetpu"
+COMPONENT: Final = "edgetpu"
 
 DEVICE_CPU = "cpu"
 DEFAULT_DETECTOR_CPU_MODEL = (
@@ -20,7 +20,7 @@ DEFAULT_CLASSIFIER_LABEL_PATH = "/classifiers/models/edgetpu/labels.txt"
 
 
 # Object detector config constants
-CONFIG_OBJECT_DETECTOR = "object_detector"
+CONFIG_OBJECT_DETECTOR: Final = "object_detector"
 CONFIG_MODEL_PATH = "model_path"
 CONFIG_LABEL_PATH = "label_path"
 CONFIG_DEVICE = "device"
@@ -39,7 +39,7 @@ DESC_DEVICE = (
 )
 
 # Image classification config constants
-CONFIG_IMAGE_CLASSIFICATION = "image_classification"
+CONFIG_IMAGE_CLASSIFICATION: Final = "image_classification"
 CONFIG_CROP_CORRECTION = "crop_correction"
 
 DESC_IMAGE_CLASSIFICATION = "Image classification domain config."

--- a/viseron/components/edgetpu/image_classification.py
+++ b/viseron/components/edgetpu/image_classification.py
@@ -49,10 +49,8 @@ def setup(vis: Viseron, config, identifier) -> bool:
 class ImageClassification(AbstractImageClassification):
     """Perform EdgeTPU image classification."""
 
-    def __init__(self, vis, component, config, camera_identifier) -> None:
-        self._edgetpu: EdgeTPUClassification = vis.data[COMPONENT][
-            CONFIG_IMAGE_CLASSIFICATION
-        ]
+    def __init__(self, vis: Viseron, component, config, camera_identifier) -> None:
+        self._edgetpu = vis.data[COMPONENT][CONFIG_IMAGE_CLASSIFICATION]
         self._classification_result_queue: Queue[
             list[ImageClassificationResult]
         ] = Queue(maxsize=1)

--- a/viseron/components/edgetpu/object_detector.py
+++ b/viseron/components/edgetpu/object_detector.py
@@ -44,7 +44,7 @@ class ObjectDetector(AbstractObjectDetector):
         self._config = config
         self._camera_identifier = camera_identifier
 
-        self._edgetpu: EdgeTPUDetection = vis.data[COMPONENT][CONFIG_OBJECT_DETECTOR]
+        self._edgetpu = vis.data[COMPONENT][CONFIG_OBJECT_DETECTOR]
         self._object_result_queue: Queue[list[DetectedObject]] = Queue(maxsize=1)
 
         super().__init__(vis, COMPONENT, config, camera_identifier)

--- a/viseron/components/edgetpu/types.py
+++ b/viseron/components/edgetpu/types.py
@@ -1,0 +1,14 @@
+"""Types for the EdgeTPU component."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict
+
+if TYPE_CHECKING:
+    from viseron.components.edgetpu import EdgeTPUClassification, EdgeTPUDetection
+
+
+class EdgeTPUViseronData(TypedDict, total=False):
+    """TypedDict for EdgeTPU Viseron data."""
+
+    image_classification: EdgeTPUClassification
+    object_detector: EdgeTPUDetection

--- a/viseron/components/ffmpeg/__init__.py
+++ b/viseron/components/ffmpeg/__init__.py
@@ -27,7 +27,6 @@ LOGGER = logging.getLogger(__name__)
 def setup(vis: Viseron, config: dict[str, Any]) -> bool:
     """Set up the ffmpeg component."""
     config = config[COMPONENT]
-    vis.data[COMPONENT] = {}
 
     for camera_identifier, camera_config in config[CONFIG_CAMERA].items():
         pruned_config = {}

--- a/viseron/components/ffmpeg/camera.py
+++ b/viseron/components/ffmpeg/camera.py
@@ -352,7 +352,6 @@ class Camera(AbstractCamera):
 
         if cv2.ocl.haveOpenCL():
             cv2.ocl.setUseOpenCL(True)
-        vis.data[COMPONENT][self.identifier] = self
         self._recorder = Recorder(vis, config, self)
 
         self.initialize_camera()

--- a/viseron/components/go2rtc/__init__.py
+++ b/viseron/components/go2rtc/__init__.py
@@ -26,7 +26,7 @@ CONFIG_SCHEMA = vol.Schema(
 
 
 def setup(vis: Viseron, config: dict[str, Any]) -> bool:
-    """Set up the logger component."""
+    """Set up the go2rtc component."""
     vis.data[COMPONENT] = Go2RTC(vis, config)
 
     return True
@@ -61,7 +61,7 @@ class Go2RTC:
         return list(cameras)
 
     def restart(self) -> None:
-        """Restart the go2rtc."""
+        """Restart go2rtc."""
         LOGGER.debug("Restarting go2rtc")
         try:
             response = requests.post("http://localhost:1984/api/restart", timeout=5)

--- a/viseron/components/go2rtc/const.py
+++ b/viseron/components/go2rtc/const.py
@@ -1,6 +1,8 @@
 """go2rtc constants."""
 
-COMPONENT = "go2rtc"
+from typing import Final
+
+COMPONENT: Final = "go2rtc"
 
 GO2RTC_CONFIG = "/tmp/go2rtc.yaml"
 

--- a/viseron/components/gstreamer/__init__.py
+++ b/viseron/components/gstreamer/__init__.py
@@ -25,7 +25,6 @@ LOGGER = logging.getLogger(__name__)
 def setup(vis: Viseron, config) -> bool:
     """Set up the gstreamer component."""
     config = config[COMPONENT]
-    vis.data[COMPONENT] = {}
 
     for camera_identifier, camera_config in config[CONFIG_CAMERA].items():
         pruned_config = {}

--- a/viseron/components/gstreamer/camera.py
+++ b/viseron/components/gstreamer/camera.py
@@ -300,7 +300,6 @@ class Camera(AbstractCamera):
 
         if cv2.ocl.haveOpenCL():
             cv2.ocl.setUseOpenCL(True)
-        vis.data[COMPONENT][self.identifier] = self
         self._recorder = Recorder(vis, config, self)
 
         self.initialize_camera()

--- a/viseron/components/hailo/const.py
+++ b/viseron/components/hailo/const.py
@@ -1,7 +1,7 @@
 """Constants for the Hailo component."""
 from typing import Final
 
-COMPONENT = "hailo"
+COMPONENT: Final = "hailo"
 
 HAILO8_DEFAULT_URL = (
     "https://hailo-model-zoo.s3.eu-west-2.amazonaws.com/"

--- a/viseron/components/hailo/object_detector.py
+++ b/viseron/components/hailo/object_detector.py
@@ -11,7 +11,6 @@ from .const import COMPONENT, CONFIG_OBJECT_DETECTOR
 
 if TYPE_CHECKING:
     from viseron import Viseron
-    from viseron.components.hailo import Hailo8Detector
     from viseron.domains.object_detector.detected_object import DetectedObject
 
 
@@ -32,7 +31,7 @@ class ObjectDetector(AbstractObjectDetector):
         super().__init__(
             vis, COMPONENT, config[CONFIG_OBJECT_DETECTOR], camera_identifier
         )
-        self._hailo8: Hailo8Detector = vis.data[COMPONENT]
+        self._hailo8 = vis.data[COMPONENT]
         self._object_result_queue: Queue[list[DetectedObject]] = Queue(maxsize=1)
 
     def preprocess(self, frame):

--- a/viseron/components/logger/const.py
+++ b/viseron/components/logger/const.py
@@ -1,12 +1,12 @@
 """Logger constants."""
 from typing import Final
 
-COMPONENT = "logger"
+COMPONENT: Final = "logger"
 
 
 # CONFIG_SCHEMA constants
 CONFIG_DEFAULT_LEVEL = "default_level"
-CONFIG_LOGS = "logs"
+CONFIG_LOGS: Final = "logs"
 CONFIG_CAMERAS = "cameras"
 
 DEFAULT_LOG_LEVEL = "info"

--- a/viseron/components/mqtt/const.py
+++ b/viseron/components/mqtt/const.py
@@ -1,7 +1,7 @@
 """mqtt component constants."""
 from typing import Final
 
-COMPONENT = "mqtt"
+COMPONENT: Final = "mqtt"
 DESC_COMPONENT = "MQTT configuration."
 
 MQTT_RC = {

--- a/viseron/components/mqtt/entity/__init__.py
+++ b/viseron/components/mqtt/entity/__init__.py
@@ -12,7 +12,6 @@ from viseron.helpers.json import JSONEncoder
 
 if TYPE_CHECKING:
     from viseron import Viseron
-    from viseron.components.mqtt import MQTT
 
 T = TypeVar("T", bound=Entity)
 
@@ -25,7 +24,7 @@ class MQTTEntity(Generic[T]):
         self._config = config
         self.entity = entity
 
-        self._mqtt: MQTT = vis.data[MQTT_COMPONENT]
+        self._mqtt = vis.data[MQTT_COMPONENT]
 
     @property
     def state_topic(self) -> str:

--- a/viseron/components/mqtt/homeassistant/__init__.py
+++ b/viseron/components/mqtt/homeassistant/__init__.py
@@ -21,7 +21,6 @@ from .switch import HassMQTTSwitch
 
 if TYPE_CHECKING:
     from viseron import Event, Viseron
-    from viseron.components.mqtt import MQTT
     from viseron.components.mqtt.entity import MQTTEntity
 
 LOGGER = logging.getLogger(__name__)
@@ -41,7 +40,7 @@ class HassMQTTInterface:
         self._vis = vis
         self._config = config
 
-        self._mqtt: MQTT = vis.data[COMPONENT]
+        self._mqtt = vis.data[COMPONENT]
 
         self._hass_entity_creation_lock = threading.Lock()
         self._hass_entities: dict[str, HassMQTTEntity] = {}

--- a/viseron/components/mqtt/homeassistant/entity.py
+++ b/viseron/components/mqtt/homeassistant/entity.py
@@ -18,7 +18,6 @@ from viseron.components.mqtt.helpers import PublishPayload
 
 if TYPE_CHECKING:
     from viseron import Viseron
-    from viseron.components.mqtt import MQTT
 
 T = TypeVar("T", bound=MQTTEntity)
 
@@ -33,7 +32,7 @@ class HassMQTTEntity(ABC, Generic[T]):
         self._config = config
         self._mqtt_entity = mqtt_entity
 
-        self._mqtt: MQTT = vis.data[MQTT_COMPONENT]
+        self._mqtt = vis.data[MQTT_COMPONENT]
 
     @property
     def availability(self):

--- a/viseron/components/nvr/nvr.py
+++ b/viseron/components/nvr/nvr.py
@@ -55,7 +55,6 @@ from .const import (
 
 if TYPE_CHECKING:
     from viseron import Viseron
-    from viseron.components.data_stream import DataStream
     from viseron.domains.camera import AbstractCamera, EventFrameBytesData
     from viseron.domains.camera.recorder import ManualRecording
     from viseron.domains.camera.shared_frames import SharedFrame
@@ -260,7 +259,7 @@ class NVR(AbstractNVR):
         self._manual_recording: ManualRecording | None = None
         self._start_manual_recording = False
         self._kill_received = False
-        self._data_stream: DataStream = vis.data[DATA_STREAM_COMPONENT]
+        self._data_stream = vis.data[DATA_STREAM_COMPONENT]
         self._removal_timers: list[threading.Timer] = []
         self._operation_state = None
 

--- a/viseron/components/storage/const.py
+++ b/viseron/components/storage/const.py
@@ -7,7 +7,7 @@ from typing import Any, Final
 
 from sqlalchemy import create_engine
 
-COMPONENT = "storage"
+COMPONENT: Final = "storage"
 
 DATABASE_URL = os.getenv(
     "POSTGRES_DATABASE_URL", "postgresql://postgres@localhost/viseron"

--- a/viseron/components/storage/tier_handler.py
+++ b/viseron/components/storage/tier_handler.py
@@ -120,8 +120,8 @@ class TierHandler(FileSystemEventHandler):
         super().__init__()
 
         self._vis = vis
-        self._storage: Storage = vis.data[COMPONENT]
-        self._webserver: Webserver = self._vis.data[WEBSERVER_COMPONENT]
+        self._storage = vis.data[COMPONENT]
+        self._webserver = self._vis.data[WEBSERVER_COMPONENT]
         self._camera = camera
         self._tier_id = tier_id
         self._category = category

--- a/viseron/components/webserver/__init__.py
+++ b/viseron/components/webserver/__init__.py
@@ -421,7 +421,6 @@ class Webserver(threading.Thread):
             if self._cleanup_task and not self._cleanup_task.done():
                 self._cleanup_task.cancel()
 
-            connection: WebSocketHandler
             for connection in self._vis.data[WEBSOCKET_CONNECTIONS]:
                 LOGGER.debug("Closing websocket connection, %s", connection)
                 await connection.force_close()

--- a/viseron/components/webserver/api/v1/publicimage.py
+++ b/viseron/components/webserver/api/v1/publicimage.py
@@ -1,8 +1,10 @@
 """Public image API Handler."""
+from __future__ import annotations
 
 import logging
 import os
 from http import HTTPStatus
+from typing import TYPE_CHECKING
 
 import voluptuous as vol
 
@@ -17,6 +19,9 @@ ALLOWED_EXTENSIONS = {
     ".jpeg": "image/jpeg",
     ".png": "image/png",
 }
+
+if TYPE_CHECKING:
+    from viseron.components.webserver import Webserver
 
 
 class PublicimageAPIHandler(BaseAPIHandler):
@@ -41,6 +46,7 @@ class PublicimageAPIHandler(BaseAPIHandler):
         token = self.request_arguments["token"]
 
         # Try to get token from memory first
+        self._webserver: Webserver
         public_image_token = self._webserver.public_image_tokens.get(token)
 
         # If token not in memory, try to find file on disk (survives restart)

--- a/viseron/components/webserver/const.py
+++ b/viseron/components/webserver/const.py
@@ -5,7 +5,7 @@ from typing import Final
 
 from viseron.const import CONFIG_DIR
 
-COMPONENT = "webserver"
+COMPONENT: Final = "webserver"
 
 WEBSERVER_STORAGE_KEY = "webserver"
 AUTH_STORAGE_KEY = "auth"
@@ -93,7 +93,7 @@ WS_ERROR_UNAUTHORIZED = "unauthorized"
 
 
 # Viseron data constants
-WEBSOCKET_COMMANDS = "websocket_commands"
-WEBSOCKET_CONNECTIONS = "websocket_connections"
-DOWNLOAD_TOKENS = "download_tokens"
-PUBLIC_IMAGE_TOKENS = "public_image_tokens"
+WEBSOCKET_COMMANDS: Final = "websocket_commands"
+WEBSOCKET_CONNECTIONS: Final = "websocket_connections"
+DOWNLOAD_TOKENS: Final = "download_tokens"
+PUBLIC_IMAGE_TOKENS: Final = "public_image_tokens"

--- a/viseron/components/webserver/request_handler.py
+++ b/viseron/components/webserver/request_handler.py
@@ -25,7 +25,6 @@ from viseron.helpers import get_utc_offset, utcnow
 if TYPE_CHECKING:
     from viseron import Viseron
     from viseron.components.nvr.nvr import NVR
-    from viseron.components.storage import Storage
     from viseron.components.webserver import Webserver
     from viseron.components.webserver.auth import RefreshToken, User
     from viseron.domains.camera import AbstractCamera, FailedCamera
@@ -41,8 +40,8 @@ class ViseronRequestHandler(tornado.web.RequestHandler):
     def initialize(self, vis: Viseron) -> None:
         """Initialize request handler."""
         self._vis = vis
-        self._webserver: Webserver = vis.data[COMPONENT]
-        self._storage: Storage = vis.data[STORAGE_COMPONENT]
+        self._webserver = vis.data[COMPONENT]
+        self._storage = vis.data[STORAGE_COMPONENT]
         self.current_user = None
         # Manually set xsrf cookie
         self.xsrf_token  # pylint: disable=pointless-statement

--- a/viseron/components/webserver/stream_handler.py
+++ b/viseron/components/webserver/stream_handler.py
@@ -1,8 +1,11 @@
 """Handles different kind of browser streams."""
+from __future__ import annotations
+
 import asyncio
 import logging
 from dataclasses import dataclass
 from http import HTTPStatus
+from typing import TYPE_CHECKING
 
 import cv2
 import imutils
@@ -13,11 +16,10 @@ from tornado.queues import Queue
 
 from viseron.components.nvr import COMPONENT as NVR_COMPONENT
 from viseron.components.nvr.const import EVENT_PROCESSED_FRAME_TOPIC
-from viseron.components.nvr.nvr import NVR, EventProcessedFrame
 from viseron.const import TOPIC_STATIC_MJPEG_STREAMS
 from viseron.domains.camera.config import MJPEG_STREAM_SCHEMA
 from viseron.domains.motion_detector import AbstractMotionDetectorScanner
-from viseron.events import Event, EventData
+from viseron.events import EventData
 from viseron.helpers import (
     draw_contours,
     draw_motion_mask,
@@ -32,6 +34,10 @@ from .request_handler import ViseronRequestHandler
 LOGGER = logging.getLogger(__name__)
 
 BOUNDARY = "--jpgboundary"
+
+if TYPE_CHECKING:
+    from viseron.components.nvr.nvr import NVR, EventProcessedFrame
+    from viseron.events import Event
 
 
 class StreamHandler(ViseronRequestHandler):
@@ -179,7 +185,7 @@ class DynamicStreamHandler(StreamHandler):
                 await asyncio.sleep(1)
                 continue
 
-            nvr: NVR = self._vis.data[NVR_COMPONENT].get(camera, None)
+            nvr = self._vis.data[NVR_COMPONENT].get(camera, None)
             if not nvr:
                 tries += 1
                 await asyncio.sleep(1)
@@ -268,7 +274,7 @@ class StaticStreamHandler(StreamHandler):
                 await asyncio.sleep(1)
                 continue
 
-            nvr: NVR = self._vis.data[NVR_COMPONENT].get(camera, None)
+            nvr = self._vis.data[NVR_COMPONENT].get(camera, None)
             if not nvr:
                 tries += 1
                 await asyncio.sleep(1)

--- a/viseron/domains/__init__.py
+++ b/viseron/domains/__init__.py
@@ -10,7 +10,6 @@ from viseron.const import LOADING
 
 if TYPE_CHECKING:
     from viseron import Viseron
-    from viseron.components import Component
     from viseron.types import SupportedDomains
 
 
@@ -72,7 +71,7 @@ def setup_domain(
     optional_domains: list[OptionalDomain] | None = None,
 ) -> None:
     """Set up single domain."""
-    component_instance: Component = vis.data[LOADING][component]
+    component_instance = vis.data[LOADING][component]
     component_instance.add_domain_to_setup(
         domain, config, identifier, require_domains, optional_domains
     )

--- a/viseron/domains/camera/__init__.py
+++ b/viseron/domains/camera/__init__.py
@@ -76,11 +76,8 @@ from .shared_frames import SharedFrames
 
 if TYPE_CHECKING:
     from viseron import Viseron
-    from viseron.components.go2rtc import Go2RTC
     from viseron.components.nvr.nvr import FrameIntervalCalculator
-    from viseron.components.storage import Storage
     from viseron.components.storage.models import TriggerTypes
-    from viseron.components.webserver import Webserver
     from viseron.domains.object_detector.detected_object import DetectedObject
 
     from .recorder import AbstractRecorder
@@ -154,7 +151,7 @@ class AbstractCamera(AbstractDomain):
             self.update_token, "interval", minutes=UPDATE_TOKEN_INTERVAL_MINUTES
         )
 
-        self._storage: Storage = vis.data[STORAGE_COMPONENT]
+        self._storage = vis.data[STORAGE_COMPONENT]
         self.event_clips_folder: str = self._storage.get_event_clips_path(self)
         self.segments_folder: str = self._storage.get_segments_path(self)
         self.thumbnails_folder: str = self._storage.get_thumbnails_path(self)
@@ -421,7 +418,6 @@ class AbstractCamera(AbstractDomain):
     @property
     def live_stream_available(self) -> bool:
         """Return if live stream is available."""
-        go2rtc: Go2RTC
         if go2rtc := self._vis.data.get(GO2RTC_COMPONENT, None):
             if self.identifier in go2rtc.configured_cameras():
                 return True
@@ -557,8 +553,8 @@ class FailedCamera:
         self._entry = entry
         self._config: dict[str, Any] = entry.config[entry.identifier]
 
-        self._storage: Storage = vis.data[STORAGE_COMPONENT]
-        self._webserver: Webserver = vis.data[WEBSERVER_COMPONENT]
+        self._storage = vis.data[STORAGE_COMPONENT]
+        self._webserver = vis.data[WEBSERVER_COMPONENT]
         self._recorder = FailedCameraRecorder(vis, self._config, self)
 
         # Try to guess the path to the camera recordings

--- a/viseron/domains/camera/fragmenter.py
+++ b/viseron/domains/camera/fragmenter.py
@@ -472,7 +472,7 @@ class Fragmenter:
         self._logger = logging.getLogger(f"{self.__module__}.{camera.identifier}")
         self._vis = vis
         self._camera = camera
-        self._storage: Storage = vis.data[STORAGE_COMPONENT]
+        self._storage = vis.data[STORAGE_COMPONENT]
         os.makedirs(camera.temp_segments_folder, exist_ok=True)
         if camera.temp_timelapse_folder is not None:
             os.makedirs(camera.temp_timelapse_folder, exist_ok=True)

--- a/viseron/domains/camera/recorder.py
+++ b/viseron/domains/camera/recorder.py
@@ -47,7 +47,6 @@ from .shared_frames import SharedFrame
 
 if TYPE_CHECKING:
     from viseron import Viseron
-    from viseron.components.storage import Storage
     from viseron.components.storage.models import TriggerTypes
     from viseron.domains.camera import AbstractCamera, FailedCamera
 
@@ -140,7 +139,7 @@ class RecorderBase:
         self._config = config
         self._camera = camera
 
-        self._storage: Storage = vis.data[STORAGE_COMPONENT]
+        self._storage = vis.data[STORAGE_COMPONENT]
 
     def get_recordings(
         self, utc_offset: datetime.timedelta, date=None, subpath: str = ""
@@ -209,7 +208,7 @@ class AbstractRecorder(ABC, RecorderBase):
 
     def __init__(self, vis: Viseron, component, config, camera: AbstractCamera) -> None:
         super().__init__(vis, config, camera)
-        self._storage: Storage = vis.data[STORAGE_COMPONENT]
+        self._storage = vis.data[STORAGE_COMPONENT]
         self._camera: AbstractCamera = camera
 
         self.is_recording = False

--- a/viseron/domains/motion_detector/__init__.py
+++ b/viseron/domains/motion_detector/__init__.py
@@ -75,7 +75,6 @@ from viseron.watchdog.thread_watchdog import RestartableThread
 if TYPE_CHECKING:
     from viseron import Event, Viseron
     from viseron.components.nvr.nvr import EventFrameToScan, EventScanFrames
-    from viseron.components.storage import Storage
     from viseron.domains.camera import AbstractCamera
     from viseron.domains.camera.shared_frames import SharedFrame
 
@@ -165,7 +164,7 @@ class AbstractMotionDetector(AbstractDomain):
         self._vis = vis
         self._config = config
         self._camera_identifier = camera_identifier
-        self._storage: Storage = vis.data[STORAGE_COMPONENT]
+        self._storage = vis.data[STORAGE_COMPONENT]
 
         self._camera: AbstractCamera = vis.get_registered_domain(
             CAMERA_DOMAIN, camera_identifier

--- a/viseron/domains/object_detector/__init__.py
+++ b/viseron/domains/object_detector/__init__.py
@@ -115,7 +115,6 @@ from .zone import Zone
 if TYPE_CHECKING:
     from viseron import Event, Viseron
     from viseron.components.nvr.nvr import EventFrameToScan, EventScanFrames
-    from viseron.components.storage import Storage
     from viseron.domains.camera import AbstractCamera
 
 
@@ -268,7 +267,7 @@ class AbstractObjectDetector(AbstractDomain):
         camera_identifier: str,
     ) -> None:
         self._vis = vis
-        self._storage: Storage = vis.data[STORAGE_COMPONENT]
+        self._storage = vis.data[STORAGE_COMPONENT]
         self._config = config
         self._camera_identifier = camera_identifier
         self._camera: AbstractCamera = vis.get_registered_domain(

--- a/viseron/domains/post_processor/__init__.py
+++ b/viseron/domains/post_processor/__init__.py
@@ -11,7 +11,6 @@ import numpy as np
 import voluptuous as vol
 from sqlalchemy import insert
 
-from viseron.components.storage import Storage
 from viseron.components.storage.const import COMPONENT as STORAGE_COMPONENT
 from viseron.components.storage.models import PostProcessorResults
 from viseron.const import VISERON_SIGNAL_SHUTDOWN
@@ -92,7 +91,7 @@ class AbstractPostProcessor(AbstractDomain):
 
     def __init__(self, vis: Viseron, config, camera_identifier) -> None:
         self._vis = vis
-        self._storage: Storage = vis.data[STORAGE_COMPONENT]
+        self._storage = vis.data[STORAGE_COMPONENT]
         self._config = config
         self._camera_identifier = camera_identifier
         self._camera = vis.get_registered_domain(CAMERA_DOMAIN, camera_identifier)

--- a/viseron/types.py
+++ b/viseron/types.py
@@ -3,7 +3,68 @@
 from __future__ import annotations
 
 import enum
-from typing import Literal
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Literal, TypedDict
+
+import voluptuous as vol
+
+if TYPE_CHECKING:
+
+    from sklearn.neighbors import KNeighborsClassifier
+
+    from viseron.components import Component
+    from viseron.components.compreface.face_recognition import CompreFaceService
+    from viseron.components.darknet import BaseDarknet
+    from viseron.components.data_stream import DataStream
+    from viseron.components.edgetpu.types import EdgeTPUViseronData
+    from viseron.components.go2rtc import Go2RTC
+    from viseron.components.hailo import Hailo8Detector
+    from viseron.components.mqtt import MQTT
+    from viseron.components.nvr.nvr import NVR
+    from viseron.components.storage import Storage
+    from viseron.components.webserver import Webserver
+    from viseron.components.webserver.download_token import DownloadToken
+    from viseron.components.webserver.public_image_token import PublicImageToken
+    from viseron.components.webserver.websocket_api import WebSocketHandler
+
+
+class ViseronData(TypedDict, total=False):
+    """TypedDict for Viseron data storage.
+
+    If a component saves anything to vis.data, it is REQUIRED to be typed here.
+    When mypy adds support for TypedDict with extra_items, this can be changed to
+    optional.
+
+    Note that the type hint for vis.data has not been changed to ViseronData yet,
+    to not break existing components. Once all components have been updated to
+    include their data here, the type hint for vis.data can be changed.
+    """
+
+    # Viseron core
+    loading: dict[str, Component]
+    loaded: dict[str, Component]
+    failed: dict[str, Component]
+
+    # Viseron core components
+    data_stream: DataStream
+    logger: dict[Literal["logs"], dict[str, str]]
+    storage: Storage
+    webserver: Webserver
+    websocket_commands: dict[str, tuple[Callable[[], Awaitable[None]], vol.Schema]]
+    websocket_connections: list[WebSocketHandler]
+    download_tokens: dict[str, DownloadToken]
+    public_image_tokens: dict[str, PublicImageToken]
+
+    # Components
+    compreface: dict[Literal["face_recognition"], CompreFaceService]
+    darknet: BaseDarknet
+    dlib: dict[Literal["classifier"], KNeighborsClassifier | None]
+    edgetpu: EdgeTPUViseronData
+    go2rtc: Go2RTC
+    hailo: Hailo8Detector
+    mqtt: MQTT
+    nvr: dict[str, NVR]
+
 
 SupportedDomains = Literal[
     "camera",


### PR DESCRIPTION
Introduces the TypedDict `ViseronData` in order to fully type the `vis.data` object.

Not the type hint for `vis.data` has not changed yet in order to not break type checking during migration.
When all components have their type properly setup in `ViseronData`, the type hint will be changed.

For this reason type coverage is slightly lower until this is fully complete