### PR TITLE
fix: X-Client-UTC-Offset header and respect timezone for local folder

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -229,11 +229,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
     Intl.DateTimeFormat().resolvedOptions().timeZone;
   if (getDefaultTimezone() !== userTimezone) {
     dayjsSetDefaultTimezone(userTimezone);
-    // Update api client UTC offset header
-    viseronAPI.defaults.headers.common["X-Client-UTC-Offset"] = getDayjs()
-      .utcOffset()
-      .toString();
   }
+  // Update api client UTC offset header
+  viseronAPI.defaults.headers.common["X-Client-UTC-Offset"] = getDayjs()
+    .utcOffset()
+    .toString();
 
   // Set global date format based on user preference
   const userDateFormat =

--- a/frontend/src/lib/websockets.ts
+++ b/frontend/src/lib/websockets.ts
@@ -213,7 +213,7 @@ export class Connection {
       return;
     }
 
-    document.cookie = `X-Client-UTC-Offset=${getDayjs().utcOffset()}; path=${BASE_PATH}/websocket`;
+    document.cookie = `X-Client-UTC-Offset=${getDayjs().utcOffset()}; path=${BASE_PATH}/`;
     const wsURL = `${
       window.location.protocol === "https:" ? "wss://" : "ws://"
     }${location.host}${BASE_PATH}/websocket`;

--- a/viseron/domains/camera/recorder.py
+++ b/viseron/domains/camera/recorder.py
@@ -414,9 +414,10 @@ class AbstractRecorder(ABC, RecorderBase):
         # Create filename
         video_name = self.video_name(recording.start_time)
 
-        # Create foldername
+        # Create foldername using server-local date (consistent with filename)
         full_path = os.path.join(
-            self._camera.event_clips_folder, recording.start_time.date().isoformat()
+            self._camera.event_clips_folder,
+            (recording.start_time + get_utc_offset()).date().isoformat(),
         )
 
         clip_path = os.path.join(full_path, video_name)


### PR DESCRIPTION
This PR contains 3 fixes:

* Move the `X-Client-UTC-Offset` header assignment outside the if (`getDefaultTimezone()` !== `userTimezone`) block so it is always set on every render, regardless of whether the timezone changed from the default. This ensures the backend always receives the correct client UTC offset for REST API calls.
* Broaden the `X-Client-UTC-Offset` cookie path from `${BASE_PATH}/websocket` to `${BASE_PATH}/`, so the cookie is sent with all requests (not just WebSocket connections).
* change the event clip folder date from `recording.start_time.date().isoformat()` (UTC date) to (`recording.start_time + get_utc_offset()).date().isoformat()` (server-local date), making it consistent with the filename which already uses local time.

Fixes #1316 