### PR TITLE
fix(reload): properly reload domain level changes

### DIFF
--- a/tests/domains/test__init__.py
+++ b/tests/domains/test__init__.py
@@ -1,9 +1,11 @@
 """Tests for domains module."""
+
 from __future__ import annotations
 
 import logging
 from concurrent.futures import Future, ThreadPoolExecutor
 from logging import DEBUG
+from typing import TYPE_CHECKING, Any, Literal
 from unittest.mock import Mock, patch
 
 import pytest
@@ -19,14 +21,19 @@ from viseron.domains import (
     _submit_domain_setup,
     _wait_for_dependencies,
     get_unload_order,
-    reload_domain,
     setup_domains,
     unload_domain,
+    unload_domain_chain,
+    unload_domain_identifier,
 )
 from viseron.exceptions import DomainNotReady
 
-from tests.common import MockDomainModule
-from tests.conftest import MockViseron
+from tests.common import MockComponent, MockDomainModule
+
+if TYPE_CHECKING:
+    from viseron.viseron_types import SupportedDomains
+
+    from tests.conftest import MockViseron
 
 
 class TestGetUnloadOrder:
@@ -148,7 +155,7 @@ class TestGetUnloadOrder:
         assert len(result) == 0
 
     @pytest.mark.parametrize(
-        "target_domain,target_id,expected_count",
+        ("target_domain", "target_id", "expected_count"),
         [
             ("camera", "cam1", 2),  # nvr depends on cam1
             ("camera", "cam2", 1),  # No dependents on cam2
@@ -156,7 +163,11 @@ class TestGetUnloadOrder:
         ],
     )
     def test_different_identifiers(
-        self, vis: MockViseron, target_domain, target_id, expected_count
+        self,
+        vis: MockViseron,
+        target_domain: SupportedDomains,
+        target_id: str,
+        expected_count: int,
     ):
         """Test that identifier matching works correctly."""
         registry = vis.domain_registry
@@ -220,8 +231,8 @@ class TestGetUnloadOrder:
         assert result[1].domain == "camera"
 
 
-class TestUnloadDomain:
-    """Test unload_domain function."""
+class TestUnloadDomainIdentifier:
+    """Test unload_domain_identifier function."""
 
     def test_unload_domain_success(self, vis: MockViseron):
         """Test successful domain unload."""
@@ -240,7 +251,7 @@ class TestUnloadDomain:
         registry.set_state("camera", "cam1", DomainState.LOADED)
         registry.set_instance("camera", "cam1", mock_instance)
 
-        result = unload_domain(vis, "camera", "cam1")
+        result = unload_domain_identifier(vis, "camera", "cam1")
         assert result is not None
         assert result.domain == "camera"
         assert result.identifier == "cam1"
@@ -266,7 +277,7 @@ class TestUnloadDomain:
         registry.set_state("camera", "cam1", DomainState.LOADED)
         registry.set_instance("camera", "cam1", mock_instance)
 
-        result = unload_domain(vis, "camera", "cam1")
+        result = unload_domain_identifier(vis, "camera", "cam1")
         assert result is not None
         assert result.domain == "camera"
         assert result.identifier == "cam1"
@@ -290,7 +301,7 @@ class TestUnloadDomain:
         registry.set_state("camera", "cam1", DomainState.LOADED)
         registry.set_instance("camera", "cam1", mock_instance)
 
-        result = unload_domain(vis, "camera", "cam1")
+        result = unload_domain_identifier(vis, "camera", "cam1")
         assert result is not None
         assert registry.get("camera", "cam1") is None
         mock_instance.unload.assert_called_once()
@@ -298,13 +309,13 @@ class TestUnloadDomain:
     def test_unload_removes_entities(self, vis: MockViseron):
         """Test that entities are removed during unload."""
         # Set up entity ownership structure
-        vis.states._register_entity_owner(  # pylint: disable=protected-access
+        vis.states._register_entity_owner(
             "test_comp",
             "entity.test1",
             "camera",
             "cam1",
         )
-        vis.states._register_entity_owner(  # pylint: disable=protected-access
+        vis.states._register_entity_owner(
             "test_comp",
             "entity.test2",
             "camera",
@@ -322,7 +333,7 @@ class TestUnloadDomain:
         registry.set_state("camera", "cam1", DomainState.LOADED)
 
         with patch.object(vis.states, "unload_entity") as mock_unload_entity:
-            unload_domain(vis, "camera", "cam1")
+            unload_domain_identifier(vis, "camera", "cam1")
             assert mock_unload_entity.call_count == 2
             mock_unload_entity.assert_any_call("entity.test1")
             mock_unload_entity.assert_any_call("entity.test2")
@@ -338,10 +349,10 @@ class TestUnloadDomain:
         ],
     )
     def test_unload_handles_missing_entity_structure(
-        self, vis: MockViseron, entity_structure
+        self, vis: MockViseron, entity_structure: dict[str, Any]
     ):
         """Test unload handles missing or incomplete entity structures."""
-        vis.states._entity_owner = entity_structure  # pylint: disable=protected-access
+        vis.states._entity_owner = entity_structure
 
         registry = vis.domain_registry
         registry.register(
@@ -354,7 +365,7 @@ class TestUnloadDomain:
         registry.set_state("camera", "cam1", DomainState.LOADED)
 
         with patch.object(vis.states, "unload_entity") as mock_unload_entity:
-            result = unload_domain(vis, "camera", "cam1")
+            result = unload_domain_identifier(vis, "camera", "cam1")
             assert result is not None
             mock_unload_entity.assert_not_called()
 
@@ -374,125 +385,248 @@ class TestUnloadDomain:
         )
         registry.set_state("camera", "cam1", DomainState.LOADED)
 
-        result = unload_domain(vis, "camera", "cam1")
+        result = unload_domain_identifier(vis, "camera", "cam1")
         assert result is not None
         assert registry.get("camera", "cam1") is None
         assert "Domain camera with identifier cam1 has no unload method" in caplog.text
 
-
-class TestReloadDomain:
-    """Test reload_domain function."""
-
-    def test_reload_nonexistent_domain(
-        self, vis: MockViseron, caplog: pytest.LogCaptureFixture
+    def test_unload_nonexistent_domain_returns_none(
+        self,
+        vis: MockViseron,
     ):
-        """Test reload warns when domain doesn't exist."""
-        reload_domain(vis, "camera", "cam1")
+        """Test that unloading a domain that doesn't exist returns None."""
+        result = unload_domain_identifier(vis, "camera", "nonexistent")
+        assert result is None
 
-        assert "Domain camera with identifier cam1 not found for reload" in caplog.text
-
-    def test_reload_single_domain_no_dependents(self, vis: MockViseron):
-        """Test reloading a single domain with no dependents."""
+    def test_unload_cancels_retry(self, vis: MockViseron):
+        """Test that cancel_retry is called during unload."""
         registry = vis.domain_registry
         registry.register(
             component_name="test_comp",
             component_path="test.path",
             domain="camera",
             identifier="cam1",
-            config={"test": "config"},
+            config={},
         )
-        registry.set_state("camera", "cam1", DomainState.LOADED)
+        registry.set_state("camera", "cam1", DomainState.RETRYING)
 
-        with patch("viseron.domains.unload_domain") as mock_unload, patch(
-            "viseron.domains.setup_domains"
-        ) as mock_setup:
-            reload_domain(vis, "camera", "cam1")
+        with patch.object(registry, "cancel_retry") as mock_cancel:
+            unload_domain_identifier(vis, "camera", "cam1")
+            mock_cancel.assert_called_once_with("camera", "cam1")
 
-            mock_unload.assert_called_once_with(vis, "camera", "cam1")
-            mock_setup.assert_called_once_with(vis)
 
-    def test_reload_domain_with_dependents(self, vis: MockViseron):
-        """Test reloading a domain with dependents."""
+class TestUnloadDomainChain:
+    """Test unload_domain_chain function."""
+
+    def test_returns_affected_components(self, vis: MockViseron):
+        """Test that all component names touched by the chain are returned."""
         registry = vis.domain_registry
         registry.register(
             component_name="camera_comp",
             component_path="camera.path",
             domain="camera",
             identifier="cam1",
-            config={"camera": "config"},
+            config={},
         )
         registry.set_state("camera", "cam1", DomainState.LOADED)
 
-        # Register dependent domain
         registry.register(
             component_name="nvr_comp",
             component_path="nvr.path",
             domain="nvr",
             identifier="cam1",
-            config={"nvr": "config"},
+            config={},
             require_domains=[RequireDomain("camera", "cam1")],
         )
         registry.set_state("nvr", "cam1", DomainState.LOADED)
 
-        with patch("viseron.domains.unload_domain") as mock_unload, patch(
-            "viseron.domains.setup_domains"
-        ) as mock_setup:
-            reload_domain(vis, "camera", "cam1")
+        affected = unload_domain_chain(vis, "camera", "cam1")
 
-            calls = [call[0] for call in mock_unload.call_args_list]
-            assert calls[0] == (vis, "nvr", "cam1")
-            assert calls[1] == (vis, "camera", "cam1")
+        assert affected == {"camera_comp", "nvr_comp"}
+        assert registry.get("camera", "cam1") is None
+        assert registry.get("nvr", "cam1") is None
 
-            mock_setup.assert_called_once_with(vis)
+    def test_unloads_in_dependents_first_order(self, vis: MockViseron):
+        """Test that dependents are unloaded before their dependency."""
+        unloaded_order: list[str] = []
 
-    def test_reload_domain_optional_dependents(self, vis: MockViseron):
-        """Test reloading a domain with optional dependents."""
         registry = vis.domain_registry
         registry.register(
             component_name="camera_comp",
             component_path="camera.path",
             domain="camera",
             identifier="cam1",
-            config={"setting": "value"},
+            config={},
         )
         registry.set_state("camera", "cam1", DomainState.LOADED)
-        registry.register(
-            component_name="motion_comp",
-            component_path="motion.path",
-            domain="motion_detector",
-            identifier="cam1",
-            config={"motion_setting": "motion_value"},
-            require_domains=[RequireDomain("camera", "cam1")],
-        )
-        registry.set_state("motion_detector", "cam1", DomainState.LOADED)
 
-        require_deps = [RequireDomain("camera", "cam1")]
-        optional_deps = [OptionalDomain("motion_detector", "cam1")]
         registry.register(
             component_name="nvr_comp",
             component_path="nvr.path",
             domain="nvr",
             identifier="cam1",
-            config={"nvr_setting": "nvr_value"},
-            require_domains=require_deps,
-            optional_domains=optional_deps,
+            config={},
+            require_domains=[RequireDomain("camera", "cam1")],
         )
         registry.set_state("nvr", "cam1", DomainState.LOADED)
 
-        with patch("viseron.domains.unload_domain") as mock_unload, patch(
-            "viseron.domains.setup_domains"
+        original_unregister = registry.unregister
+
+        def _tracking_unregister(domain: str, identifier: str) -> DomainEntry | None:
+            unloaded_order.append(domain)
+            return original_unregister(domain, identifier)
+
+        with patch.object(registry, "unregister", side_effect=_tracking_unregister):
+            unload_domain_chain(vis, "camera", "cam1")
+
+        assert unloaded_order == ["nvr", "camera"]
+
+    def test_nonexistent_domain_returns_empty_set(self, vis: MockViseron):
+        """Test that a nonexistent domain returns an empty set."""
+        affected = unload_domain_chain(
+            vis,
+            "camera",
+            "nonexistent",
+        )
+        assert affected == set()
+
+
+class TestUnloadDomain:
+    """Test unload_domain function."""
+
+    def _register_domain(
+        self,
+        vis: MockViseron,
+        component_name: str = "test_comp",
+        domain: SupportedDomains = "camera",
+        identifier: str = "cam1",
+    ) -> None:
+        vis.domain_registry.register(
+            component_name=component_name,
+            component_path=f"viseron.components.{component_name}",
+            domain=domain,
+            identifier=identifier,
+            config={},
+        )
+        vis.domain_registry.set_state(domain, identifier, DomainState.LOADED)
+
+    def test_returns_none_when_component_not_found(self, vis: MockViseron):
+        """Test that None is returned when the component is not in LOADED."""
+        result = unload_domain(vis, "nonexistent_comp", "camera")
+        assert result is None
+
+    def test_unloads_all_identifiers_for_domain(self, vis: MockViseron):
+        """Test that every identifier belonging to the component/domain is unloaded."""
+        MockComponent(vis, "test_comp")
+        self._register_domain(vis, identifier="cam1")
+        self._register_domain(vis, identifier="cam2")
+
+        with patch(
+            "viseron.domains.importlib.import_module",
+            side_effect=ModuleNotFoundError,
         ):
-            reload_domain(vis, "camera", "cam1")
+            result = unload_domain(vis, "test_comp", "camera")
 
-            calls = [call[0] for call in mock_unload.call_args_list]
-            assert calls[0] == (vis, "nvr", "cam1")
-            assert calls[1] == (vis, "motion_detector", "cam1")
-            assert calls[2] == (vis, "camera", "cam1")
+        assert result is not None
+        assert vis.domain_registry.get("camera", "cam1") is None
+        assert vis.domain_registry.get("camera", "cam2") is None
 
-            # Should re-register all three
-            assert registry.get("camera", "cam1") is not None
-            assert registry.get("motion_detector", "cam1") is not None
-            assert registry.get("nvr", "cam1") is not None
+    def test_returns_affected_components(self, vis: MockViseron):
+        """Test that the set of affected component names is returned."""
+        MockComponent(vis, "test_comp")
+        self._register_domain(vis, identifier="cam1")
+
+        # Register a dependent in another component
+        vis.domain_registry.register(
+            component_name="nvr_comp",
+            component_path="viseron.components.nvr_comp",
+            domain="nvr",
+            identifier="cam1",
+            config={},
+            require_domains=[RequireDomain("camera", "cam1")],
+        )
+        vis.domain_registry.set_state("nvr", "cam1", DomainState.LOADED)
+
+        with patch(
+            "viseron.domains.importlib.import_module",
+            side_effect=ModuleNotFoundError,
+        ):
+            result = unload_domain(vis, "test_comp", "camera")
+
+        assert result is not None
+        assert "test_comp" in result
+        assert "nvr_comp" in result
+
+    def test_calls_domain_module_unload(self, vis: MockViseron):
+        """Test that the domain module's unload() is called if it exists."""
+        MockComponent(vis, "test_comp")
+        self._register_domain(vis, identifier="cam1")
+
+        unload_called: list[bool] = []
+
+        mock_module = Mock()
+        mock_module.unload = lambda _vis: unload_called.append(True)
+
+        with patch("viseron.domains.importlib.import_module", return_value=mock_module):
+            unload_domain(vis, "test_comp", "camera")
+
+        assert unload_called, "domain module's unload() was not called"
+
+    def test_no_domain_module_unload_method(
+        self, vis: MockViseron, caplog: pytest.LogCaptureFixture
+    ):
+        """Test that missing unload() on domain module is handled gracefully."""
+        caplog.set_level(DEBUG)
+        MockComponent(vis, "test_comp")
+        self._register_domain(vis, identifier="cam1")
+
+        mock_module = Mock(spec=[])  # no unload attribute
+
+        with patch("viseron.domains.importlib.import_module", return_value=mock_module):
+            result = unload_domain(vis, "test_comp", "camera")
+
+        assert result is not None
+        assert "has no unload method" in caplog.text
+
+    def test_domain_module_unload_exception_is_handled(self, vis: MockViseron):
+        """Test that an exception in domain module unload() doesn't propagate."""
+        MockComponent(vis, "test_comp")
+        self._register_domain(vis, identifier="cam1")
+
+        mock_module = Mock()
+        mock_module.unload = Mock(side_effect=RuntimeError("unload boom"))
+
+        with patch("viseron.domains.importlib.import_module", return_value=mock_module):
+            result = unload_domain(vis, "test_comp", "camera")  # must not raise
+
+        assert result is not None
+
+    def test_module_not_found_returns_affected_components(self, vis: MockViseron):
+        """Test that a missing domain module still returns accumulated affected set."""
+        MockComponent(vis, "test_comp")
+        self._register_domain(vis, identifier="cam1")
+
+        with patch(
+            "viseron.domains.importlib.import_module",
+            side_effect=ModuleNotFoundError("no module"),
+        ):
+            result = unload_domain(vis, "test_comp", "camera")
+
+        # Should return what was collected, not None
+        assert result is not None
+        assert isinstance(result, set)
+
+    def test_no_identifiers_returns_empty_set(self, vis: MockViseron):
+        """Test that a component with no registered identifiers returns an empty set."""
+        MockComponent(vis, "test_comp")
+        # No domains registered
+
+        mock_module = Mock(spec=[])  # no unload
+
+        with patch("viseron.domains.importlib.import_module", return_value=mock_module):
+            result = unload_domain(vis, "test_comp", "camera")
+
+        assert result == set()
 
 
 class TestHandleFailedDomain:
@@ -502,7 +636,9 @@ class TestHandleFailedDomain:
         "state",
         [DomainState.FAILED, DomainState.RETRYING],
     )
-    def test_handle_failed_domain_sets_state(self, vis: MockViseron, state) -> None:
+    def test_handle_failed_domain_sets_state(
+        self, vis: MockViseron, state: Literal[DomainState.FAILED, DomainState.RETRYING]
+    ) -> None:
         """Test _handle_failed_domain sets the correct state."""
         vis.domain_registry.register(
             component_name="test_comp",
@@ -529,7 +665,7 @@ class TestHandleFailedDomain:
         """Test _handle_failed_domain calls setup_failed handler."""
         error_instance = Mock()
 
-        def setup_failed_handler(_vis_arg, _entry_arg) -> Mock:
+        def setup_failed_handler(_vis_arg: MockViseron, _entry_arg: Mock) -> Mock:
             return error_instance
 
         mock_domain_module = Mock()
@@ -901,9 +1037,12 @@ class TestSetupSingleDomain:
         entry = vis.domain_registry.get("camera", "cam1")
         assert entry is not None
 
-        with patch(
-            "viseron.components.importlib.import_module", return_value=mock_domain
-        ), patch("viseron.domains.DOMAIN_RETRY_INTERVAL", 0):
+        with (
+            patch(
+                "viseron.components.importlib.import_module", return_value=mock_domain
+            ),
+            patch("viseron.domains.DOMAIN_RETRY_INTERVAL", 0),
+        ):
             result: bool = _setup_single_domain(vis, entry)
 
             assert result is True
@@ -1051,7 +1190,8 @@ class TestSetupSingleDomain:
 
         assert result is False
         assert entry.state == DomainState.FAILED
-        assert entry.error is not None and "Dependencies failed" in entry.error
+        assert entry.error is not None
+        assert "Dependencies failed" in entry.error
 
 
 class TestDomainScheduling:
@@ -1090,15 +1230,17 @@ class TestDomainScheduling:
         entry = vis.domain_registry.get("camera", "cam1")
         assert entry is not None
 
-        with patch(
-            "viseron.components.importlib.import_module", return_value=mock_domain
+        with (
+            patch(
+                "viseron.components.importlib.import_module", return_value=mock_domain
+            ),
+            ThreadPoolExecutor(max_workers=1) as executor,
         ):
-            with ThreadPoolExecutor(max_workers=1) as executor:
-                _submit_domain_setup(vis, executor, entry)
-                # Wait for completion
-                future = vis.domain_registry.get_future("camera", "cam1")
-                assert future is not None
-                future.result()
+            _submit_domain_setup(vis, executor, entry)
+            # Wait for completion
+            future = vis.domain_registry.get_future("camera", "cam1")
+            assert future is not None
+            future.result()
 
     def test_schedule_domain_setup_schedules_dependencies_first(
         self, vis: MockViseron
@@ -1127,22 +1269,22 @@ class TestDomainScheduling:
         entry = vis.domain_registry.get("camera", "cam1")
         assert entry is not None
 
-        with patch(
-            "viseron.components.importlib.import_module", return_value=mock_domain
+        with (
+            patch(
+                "viseron.components.importlib.import_module", return_value=mock_domain
+            ),
+            ThreadPoolExecutor(max_workers=2) as executor,
         ):
-            with ThreadPoolExecutor(max_workers=2) as executor:
-                _schedule_domain_setup(vis, executor, entry)
+            _schedule_domain_setup(vis, executor, entry)
 
-                cam_future = vis.domain_registry.get_future("camera", "cam1")
-                det_future = vis.domain_registry.get_future(
-                    "object_detector", "detector1"
-                )
+            cam_future = vis.domain_registry.get_future("camera", "cam1")
+            det_future = vis.domain_registry.get_future("object_detector", "detector1")
 
-                assert cam_future is not None
-                assert det_future is not None
+            assert cam_future is not None
+            assert det_future is not None
 
-                det_future.result()
-                cam_future.result()
+            det_future.result()
+            cam_future.result()
 
 
 class TestSetupDomains:

--- a/tests/test_reload.py
+++ b/tests/test_reload.py
@@ -27,7 +27,6 @@ from viseron.reload import (
     _process_identifier_changes,
     _reload_config,
     _unload_dependents_of_pending_domains,
-    _unload_domain_chain,
     _validate_config,
     reload_config,
 )
@@ -49,143 +48,6 @@ def _make_domain_entry(
         identifier=identifier,
         config={},
     )
-
-
-class TestUnloadDomainChain:
-    """Test _unload_domain_chain function."""
-
-    @patch("viseron.reload.unload_domain")
-    @patch("viseron.reload.get_unload_order", return_value=[])
-    def test_empty_unload_order(
-        self, mock_get_order: MagicMock, mock_unload: MagicMock
-    ) -> None:
-        """Test with no dependents to unload."""
-        vis = MagicMock()
-        entry = _make_domain_entry()
-        plan = SetupPlan()
-
-        _unload_domain_chain(vis, entry.domain, entry.identifier, plan)
-
-        mock_get_order.assert_called_once_with(vis, "camera", "cam1")
-        mock_unload.assert_not_called()
-        assert plan.domain_components == set()
-
-    @patch("viseron.reload.unload_domain")
-    @patch("viseron.reload.get_unload_order")
-    def test_single_entry_unloaded(
-        self, mock_get_order: MagicMock, mock_unload: MagicMock
-    ) -> None:
-        """Test unloading a single domain entry."""
-        vis = MagicMock()
-        entry = _make_domain_entry()
-        mock_get_order.return_value = [entry]
-        plan = SetupPlan()
-
-        _unload_domain_chain(vis, entry.domain, entry.identifier, plan)
-
-        mock_unload.assert_called_once_with(vis, "camera", "cam1")
-        assert plan.domain_components == {"ffmpeg"}
-
-    @patch("viseron.reload.unload_domain")
-    @patch("viseron.reload.get_unload_order")
-    def test_multiple_entries_different_components(
-        self, mock_get_order: MagicMock, mock_unload: MagicMock
-    ) -> None:
-        """Test unloading entries from different components."""
-        vis = MagicMock()
-        entry = _make_domain_entry()
-        dependent = _make_domain_entry(
-            component_name="darknet",
-            domain="object_detector",
-            identifier="cam1",
-        )
-        mock_get_order.return_value = [dependent, entry]
-        plan = SetupPlan()
-
-        _unload_domain_chain(vis, entry.domain, entry.identifier, plan)
-
-        assert mock_unload.call_count == 2
-        mock_unload.assert_has_calls(
-            [
-                call(vis, "object_detector", "cam1"),
-                call(vis, "camera", "cam1"),
-            ]
-        )
-        assert plan.domain_components == {"ffmpeg", "darknet"}
-
-    @patch("viseron.reload.unload_domain")
-    @patch("viseron.reload.get_unload_order")
-    def test_multiple_entries_same_component(
-        self, mock_get_order: MagicMock, mock_unload: MagicMock
-    ) -> None:
-        """Test that duplicate component names are deduplicated in the plan."""
-        vis = MagicMock()
-        entry1 = _make_domain_entry(identifier="cam1")
-        entry2 = _make_domain_entry(identifier="cam2")
-        mock_get_order.return_value = [entry1, entry2]
-        plan = SetupPlan()
-
-        _unload_domain_chain(vis, entry1.domain, entry1.identifier, plan)
-
-        assert mock_unload.call_count == 2
-        assert plan.domain_components == {"ffmpeg"}
-
-    @patch("viseron.reload.get_unload_order")
-    def test_preserves_existing_plan_components(
-        self,
-        mock_get_order: MagicMock,
-    ) -> None:
-        """Test that existing domain_components in the plan are preserved."""
-        vis = MagicMock()
-        entry = _make_domain_entry()
-        mock_get_order.return_value = [entry]
-        plan = SetupPlan(domain_components={"existing_component"})
-
-        with patch("viseron.reload.unload_domain"):
-            _unload_domain_chain(vis, entry.domain, entry.identifier, plan)
-
-        assert "existing_component" in plan.domain_components
-        assert "ffmpeg" in plan.domain_components
-        assert len(plan.domain_components) == 2
-
-    @patch("viseron.reload.get_unload_order")
-    def test_does_not_modify_plan_components(self, mock_get_order: MagicMock) -> None:
-        """Test that plan.components (non-domain) is not modified."""
-        vis = MagicMock()
-        entry = _make_domain_entry()
-        mock_get_order.return_value = [entry]
-        plan = SetupPlan(components={"some_component"})
-        with patch("viseron.reload.unload_domain"):
-            _unload_domain_chain(vis, entry.domain, entry.identifier, plan)
-
-        assert plan.components == {"some_component"}
-
-    @patch("viseron.reload.unload_domain")
-    @patch("viseron.reload.get_unload_order")
-    def test_unload_called_in_order(
-        self, mock_get_order: MagicMock, mock_unload: MagicMock
-    ) -> None:
-        """Test that unload_domain is called in the correct order."""
-        vis = MagicMock()
-        entry = _make_domain_entry()
-        nvr_entry = _make_domain_entry(
-            component_name="nvr", domain="nvr", identifier="cam1"
-        )
-        detector_entry = _make_domain_entry(
-            component_name="darknet",
-            domain="object_detector",
-            identifier="cam1",
-        )
-        mock_get_order.return_value = [nvr_entry, detector_entry, entry]
-        plan = SetupPlan()
-
-        _unload_domain_chain(vis, entry.domain, entry.identifier, plan)
-
-        assert mock_unload.call_args_list == [
-            call(vis, "nvr", "cam1"),
-            call(vis, "object_detector", "cam1"),
-            call(vis, "camera", "cam1"),
-        ]
 
 
 class TestProcessIdentifierChanges:
@@ -837,8 +699,8 @@ class TestHandleModifiedComponents:
 class TestHandleModifiedDomains:
     """Test _handle_modified_domains function."""
 
-    @patch("viseron.reload._unload_domain_chain")
-    def test_no_modified_domains(self, mock_chain: MagicMock) -> None:
+    @patch("viseron.reload.unload_domain")
+    def test_no_modified_domains(self, mock_unload: MagicMock) -> None:
         """Test with empty domains_to_reload."""
         vis = MagicMock()
         changes = ReloadChanges()
@@ -846,14 +708,16 @@ class TestHandleModifiedDomains:
 
         _handle_modified_domains(vis, changes, plan)
 
-        mock_chain.assert_not_called()
+        mock_unload.assert_not_called()
         assert plan.domain_components == set()
 
-    @patch("viseron.reload._unload_domain_chain")
-    def test_domain_no_entries_to_unload(self, mock_chain: MagicMock) -> None:
-        """Test domain change where registry returns no entries."""
+    @patch("viseron.reload.unload_domain")
+    def test_domain_unload_called_with_component_and_domain(
+        self, mock_unload: MagicMock
+    ) -> None:
+        """Test that unload_domain is called with component name and domain."""
         vis = MagicMock()
-        vis.domain_registry.get_by_component.return_value = None
+        mock_unload.return_value = None
         changes = ReloadChanges(
             domains_to_reload=[
                 DomainChange(
@@ -869,24 +733,37 @@ class TestHandleModifiedDomains:
         _handle_modified_domains(vis, changes, plan)
 
         assert plan.domain_components == {"darknet"}
-        vis.domain_registry.get_by_component.assert_called_once_with("darknet")
-        mock_chain.assert_not_called()
+        mock_unload.assert_called_once_with(vis, "darknet", "object_detector")
 
-    @patch("viseron.reload._unload_domain_chain")
-    def test_domain_with_entries_unloads_all(self, mock_chain: MagicMock) -> None:
-        """Test domain change with multiple entries triggers chain unload for each."""
+    @patch("viseron.reload.unload_domain")
+    def test_domain_affected_components_added_to_plan(
+        self, mock_unload: MagicMock
+    ) -> None:
+        """Test that affected components returned by unload_domain are added to plan."""
         vis = MagicMock()
-        entry1 = _make_domain_entry(
-            component_name="darknet",
-            domain="object_detector",
-            identifier="cam1",
+        mock_unload.return_value = {"nvr", "darknet"}
+        changes = ReloadChanges(
+            domains_to_reload=[
+                DomainChange(
+                    component_name="ffmpeg",
+                    domain="camera",
+                    old_config={"width": 1920},
+                    new_config={"width": 1280},
+                ),
+            ]
         )
-        entry2 = _make_domain_entry(
-            component_name="darknet",
-            domain="object_detector",
-            identifier="cam2",
-        )
-        vis.domain_registry.get_by_component.return_value = [entry1, entry2]
+        plan = SetupPlan()
+
+        _handle_modified_domains(vis, changes, plan)
+
+        assert plan.domain_components == {"ffmpeg", "nvr", "darknet"}
+        mock_unload.assert_called_once_with(vis, "ffmpeg", "camera")
+
+    @patch("viseron.reload.unload_domain")
+    def test_domain_no_affected_components(self, mock_unload: MagicMock) -> None:
+        """Test that None return from unload_domain does not update plan."""
+        vis = MagicMock()
+        mock_unload.return_value = None
         changes = ReloadChanges(
             domains_to_reload=[
                 DomainChange(
@@ -901,33 +778,14 @@ class TestHandleModifiedDomains:
 
         _handle_modified_domains(vis, changes, plan)
 
-        assert "darknet" in plan.domain_components
-        assert mock_chain.call_count == 2
-        mock_chain.assert_has_calls(
-            [
-                call(vis, entry1.domain, entry1.identifier, plan),
-                call(vis, entry2.domain, entry2.identifier, plan),
-            ]
-        )
+        # Only the direct component_name is added; no extra components
+        assert plan.domain_components == {"darknet"}
 
-    @patch("viseron.reload._unload_domain_chain")
-    def test_multiple_domain_changes(self, mock_chain: MagicMock) -> None:
-        """Test multiple domain changes accumulate components and unload all."""
+    @patch("viseron.reload.unload_domain")
+    def test_multiple_domain_changes(self, mock_unload: MagicMock) -> None:
+        """Test multiple domain changes call unload_domain for each and merge plan."""
         vis = MagicMock()
-        entry_darknet = _make_domain_entry(
-            component_name="darknet",
-            domain="object_detector",
-            identifier="cam1",
-        )
-        entry_ffmpeg = _make_domain_entry(
-            component_name="ffmpeg",
-            domain="camera",
-            identifier="cam1",
-        )
-        vis.domain_registry.get_by_component.side_effect = [
-            [entry_darknet],
-            [entry_ffmpeg],
-        ]
+        mock_unload.side_effect = [{"nvr"}, None]
         changes = ReloadChanges(
             domains_to_reload=[
                 DomainChange(
@@ -948,20 +806,16 @@ class TestHandleModifiedDomains:
 
         _handle_modified_domains(vis, changes, plan)
 
-        assert plan.domain_components == {"darknet", "ffmpeg"}
-        assert mock_chain.call_count == 2
-        mock_chain.assert_has_calls(
-            [
-                call(vis, entry_darknet.domain, entry_darknet.identifier, plan),
-                call(vis, entry_ffmpeg.domain, entry_ffmpeg.identifier, plan),
-            ]
-        )
+        assert plan.domain_components == {"darknet", "ffmpeg", "nvr"}
+        assert mock_unload.call_count == 2
+        mock_unload.assert_any_call(vis, "darknet", "object_detector")
+        mock_unload.assert_any_call(vis, "ffmpeg", "camera")
 
 
 class TestHandleModifiedIdentifiers:
     """Test _handle_modified_identifiers function."""
 
-    @patch("viseron.reload._unload_domain_chain")
+    @patch("viseron.reload.unload_domain_chain")
     def test_no_modified_identifiers(self, mock_chain: MagicMock) -> None:
         """Test with empty identifiers_to_reload."""
         vis = MagicMock()
@@ -973,7 +827,7 @@ class TestHandleModifiedIdentifiers:
         mock_chain.assert_not_called()
         assert plan.domain_components == set()
 
-    @patch("viseron.reload._unload_domain_chain")
+    @patch("viseron.reload.unload_domain_chain")
     def test_identifier_found_unloads_chain(self, mock_chain: MagicMock) -> None:
         """Test that a found identifier triggers chain unload and updates plan."""
         vis = MagicMock()
@@ -996,9 +850,9 @@ class TestHandleModifiedIdentifiers:
 
         assert "ffmpeg" in plan.domain_components
         vis.domain_registry.get_by_identifier.assert_called_once_with("camera", "cam1")
-        mock_chain.assert_called_once_with(vis, entry.domain, entry.identifier, plan)
+        mock_chain.assert_called_once_with(vis, entry.domain, entry.identifier)
 
-    @patch("viseron.reload._unload_domain_chain")
+    @patch("viseron.reload.unload_domain_chain")
     def test_identifier_not_found_no_unload(self, mock_chain: MagicMock) -> None:
         """Test that a missing identifier does not trigger chain unload."""
         vis = MagicMock()
@@ -1022,7 +876,7 @@ class TestHandleModifiedIdentifiers:
         assert "ffmpeg" in plan.domain_components
         mock_chain.assert_not_called()
 
-    @patch("viseron.reload._unload_domain_chain")
+    @patch("viseron.reload.unload_domain_chain")
     def test_multiple_identifiers_mixed(self, mock_chain: MagicMock) -> None:
         """Test multiple identifiers with mixed found/not-found results."""
         vis = MagicMock()
@@ -1055,9 +909,9 @@ class TestHandleModifiedIdentifiers:
         _handle_modified_identifiers(vis, changes, plan)
 
         assert plan.domain_components == {"darknet", "ffmpeg"}
-        mock_chain.assert_called_once_with(vis, entry.domain, entry.identifier, plan)
+        mock_chain.assert_called_once_with(vis, entry.domain, entry.identifier)
 
-    @patch("viseron.reload._unload_domain_chain")
+    @patch("viseron.reload.unload_domain_chain")
     def test_added_identifier_unloads_dependents(self, mock_chain: MagicMock) -> None:
         """Test that adding an identifier unloads its dependents via chain."""
         vis = MagicMock()
@@ -1078,9 +932,9 @@ class TestHandleModifiedIdentifiers:
         _handle_modified_identifiers(vis, changes, plan)
 
         assert "ffmpeg" in plan.domain_components
-        mock_chain.assert_called_once_with(vis, "camera", "cam1", plan)
+        mock_chain.assert_called_once_with(vis, "camera", "cam1")
 
-    @patch("viseron.reload._unload_domain_chain")
+    @patch("viseron.reload.unload_domain_chain")
     def test_modified_identifier_does_not_check_dependents(
         self, mock_chain: MagicMock
     ) -> None:
@@ -1103,15 +957,15 @@ class TestHandleModifiedIdentifiers:
 
         _handle_modified_identifiers(vis, changes, plan)
 
-        # Should only call _unload_domain_chain for the entry itself,
+        # Should only call unload_domain_chain for the entry itself,
         # not a second time since it's a modification, not addition.
-        mock_chain.assert_called_once_with(vis, entry.domain, entry.identifier, plan)
+        mock_chain.assert_called_once_with(vis, entry.domain, entry.identifier)
 
 
 class TestHandleCancelledRetries:
     """Test _handle_cancelled_retries function."""
 
-    @patch("viseron.reload._unload_domain_chain")
+    @patch("viseron.reload.unload_domain_chain")
     def test_no_cancelled_retries(self, mock_chain: MagicMock) -> None:
         """Test with an empty cancelled retries list."""
         vis = MagicMock()
@@ -1121,9 +975,10 @@ class TestHandleCancelledRetries:
 
         mock_chain.assert_not_called()
 
-    @patch("viseron.reload._unload_domain_chain")
+    @patch("viseron.reload.unload_domain_chain")
     def test_multiple_cancelled_retries(self, mock_chain: MagicMock) -> None:
         """Test that each cancelled retry triggers its own chain unload."""
+        mock_chain.return_value = set()
         vis = MagicMock()
         entry1 = _make_domain_entry(identifier="cam1")
         entry2 = _make_domain_entry(
@@ -1138,8 +993,8 @@ class TestHandleCancelledRetries:
         assert mock_chain.call_count == 2
         mock_chain.assert_has_calls(
             [
-                call(vis, entry1.domain, entry1.identifier, plan),
-                call(vis, entry2.domain, entry2.identifier, plan),
+                call(vis, entry1.domain, entry1.identifier),
+                call(vis, entry2.domain, entry2.identifier),
             ]
         )
 
@@ -1147,7 +1002,7 @@ class TestHandleCancelledRetries:
 class TestUnloadLoadedDependentsOfPendingDomains:
     """Test _unload_dependents_of_pending_domains function."""
 
-    @patch("viseron.reload._unload_domain_chain")
+    @patch("viseron.reload.unload_domain_chain")
     def test_no_pending_domains(self, mock_chain: MagicMock) -> None:
         """Test with no pending domains."""
         vis = MagicMock()
@@ -1158,7 +1013,7 @@ class TestUnloadLoadedDependentsOfPendingDomains:
 
         mock_chain.assert_not_called()
 
-    @patch("viseron.reload._unload_domain_chain")
+    @patch("viseron.reload.unload_domain_chain")
     def test_pending_domain_with_no_dependents(self, mock_chain: MagicMock) -> None:
         """Test pending domain that has no dependents."""
         vis = MagicMock()
@@ -1179,7 +1034,7 @@ class TestUnloadLoadedDependentsOfPendingDomains:
         )
         mock_chain.assert_not_called()
 
-    @patch("viseron.reload._unload_domain_chain")
+    @patch("viseron.reload.unload_domain_chain")
     def test_loaded_dependent_is_unloaded(self, mock_chain: MagicMock) -> None:
         """Test that a LOADED dependent of a pending domain is unloaded."""
         vis = MagicMock()
@@ -1202,10 +1057,10 @@ class TestUnloadLoadedDependentsOfPendingDomains:
         _unload_dependents_of_pending_domains(vis, plan)
 
         mock_chain.assert_called_once_with(
-            vis, loaded_dep.domain, loaded_dep.identifier, plan
+            vis, loaded_dep.domain, loaded_dep.identifier
         )
 
-    @patch("viseron.reload._unload_domain_chain")
+    @patch("viseron.reload.unload_domain_chain")
     def test_pending_dependents_are_skipped(self, mock_chain: MagicMock) -> None:
         """Test that PENDING dependents are not unloaded."""
         vis = MagicMock()
@@ -1229,11 +1084,12 @@ class TestUnloadLoadedDependentsOfPendingDomains:
 
         mock_chain.assert_not_called()
 
-    @patch("viseron.reload._unload_domain_chain")
+    @patch("viseron.reload.unload_domain_chain")
     def test_multiple_pending_with_loaded_dependents(
         self, mock_chain: MagicMock
     ) -> None:
         """Test multiple pending domains each with loaded dependents."""
+        mock_chain.return_value = set()
         vis = MagicMock()
         pending1 = _make_domain_entry(
             component_name="darknet",
@@ -1261,21 +1117,22 @@ class TestUnloadLoadedDependentsOfPendingDomains:
 
         _unload_dependents_of_pending_domains(vis, plan)
 
-        # NVR is found as dependent of both, but _unload_domain_chain
+        # NVR is found as dependent of both, but unload_domain_chain
         # is called for each (deduplication happens inside the chain)
         assert mock_chain.call_count == 2
         mock_chain.assert_has_calls(
             [
-                call(vis, nvr_dep.domain, nvr_dep.identifier, plan),
-                call(vis, nvr_dep.domain, nvr_dep.identifier, plan),
+                call(vis, nvr_dep.domain, nvr_dep.identifier),
+                call(vis, nvr_dep.domain, nvr_dep.identifier),
             ]
         )
 
-    @patch("viseron.reload._unload_domain_chain")
+    @patch("viseron.reload.unload_domain_chain")
     def test_mixed_loaded_and_non_loaded_dependents(
         self, mock_chain: MagicMock
     ) -> None:
         """Test that non-PENDING dependents are unloaded from a mixed set."""
+        mock_chain.return_value = set()
         vis = MagicMock()
         pending = _make_domain_entry(
             component_name="darknet",
@@ -1313,8 +1170,8 @@ class TestUnloadLoadedDependentsOfPendingDomains:
         assert mock_chain.call_count == 2
         mock_chain.assert_has_calls(
             [
-                call(vis, loaded_dep.domain, loaded_dep.identifier, plan),
-                call(vis, failed_dep.domain, failed_dep.identifier, plan),
+                call(vis, loaded_dep.domain, loaded_dep.identifier),
+                call(vis, failed_dep.domain, failed_dep.identifier),
             ]
         )
 

--- a/viseron/components/__init__.py
+++ b/viseron/components/__init__.py
@@ -31,7 +31,7 @@ from viseron.const import (
     VISERON_SIGNAL_SHUTDOWN,
 )
 from viseron.domain_registry import DomainEntry, DomainState
-from viseron.domains import get_unload_order, unload_domain
+from viseron.domains import unload_domain
 from viseron.events import EventData
 from viseron.exceptions import ComponentNotReady
 from viseron.helpers.named_timer import NamedTimer
@@ -119,6 +119,7 @@ class Component:
         self._errors: list[ComponentError] = []
         self._errors_lock = threading.Lock()
         self._validation_error: str | None = None
+        self._domains_setup: set[SupportedDomains] = set()
 
     @property
     def state(self) -> ComponentState:
@@ -162,6 +163,11 @@ class Component:
             ),
             store=False,
         )
+
+    @property
+    def domains_setup(self) -> set[SupportedDomains]:
+        """Return set of domains that this component has registered for setup."""
+        return self._domains_setup
 
     @property
     def errors(self) -> list[ComponentError]:
@@ -405,6 +411,7 @@ class Component:
         optional_domains: list[OptionalDomain] | None = None,
     ) -> DomainEntry | None:
         """Register a domain for setup."""
+        self._domains_setup.add(domain)
         registry = self._vis.domain_registry
 
         # Check if already registered (any state)
@@ -494,23 +501,12 @@ def unload_component(vis: Viseron, component: str) -> set[str] | None:
         return None
 
     # Keep track of other components that are affected by this unload
-    affected_components = set()
+    affected_components: set[str] = set()
     # Unload any domains that were registered by this component
-    domains_to_unload = vis.domain_registry.get_by_component(component)
-    if domains_to_unload:
-        LOGGER.debug(
-            "Component %s has %d domains to unload: %s",
-            component,
-            len(domains_to_unload),
-            [(e.domain, e.identifier) for e in domains_to_unload],
-        )
-
-        for entry in domains_to_unload:
-            unload_order = get_unload_order(vis, entry.domain, entry.identifier)
-            for e in unload_order:
-                unload_domain(vis, e.domain, e.identifier)
-                if e.component_name != component:
-                    affected_components.add(e.component_name)
+    for domain in component_instance.domains_setup:
+        affected = unload_domain(vis, component_instance.name, domain)
+        if affected:
+            affected_components.update(affected)
 
     # Unload component-level entities
     entity_owner = vis.states.entity_owner.get(component, None)

--- a/viseron/domain_registry.py
+++ b/viseron/domain_registry.py
@@ -367,6 +367,17 @@ class DomainRegistry:
                 if entry.component_name == component_name
             ]
 
+    def get_by_component_and_domain(
+        self, component_name: str, domain: str
+    ) -> list[DomainEntry]:
+        """Get all domains for a specific component and domain type."""
+        with self._lock:
+            return [
+                entry
+                for entry in self._domains.get(domain, {}).values()
+                if entry.component_name == component_name
+            ]
+
     def get_dependents(
         self, target_domain: str, target_identifier: str
     ) -> list[DomainEntry]:

--- a/viseron/domains/__init__.py
+++ b/viseron/domains/__init__.py
@@ -31,6 +31,7 @@ SETUP_WITH_TRIES_PARAM_COUNT = 4
 
 if TYPE_CHECKING:
     from viseron import Viseron
+    from viseron.components import Component
     from viseron.viseron_types import SupportedDomains
 
 
@@ -489,7 +490,7 @@ def get_unload_order(
     return unload_order
 
 
-def unload_domain(
+def unload_domain_identifier(
     vis: Viseron,
     domain: SupportedDomains,
     identifier: str,
@@ -539,41 +540,64 @@ def unload_domain(
     return registry.unregister(domain, identifier)
 
 
-def reload_domain(vis: Viseron, domain: SupportedDomains, identifier: str) -> None:
-    """Reload a domain and all its dependents.
+def unload_domain_chain(
+    vis: Viseron, domain: SupportedDomains, identifier: str
+) -> set[str]:
+    """Unload a domain and all its dependents in the correct order."""
+    unload_order = get_unload_order(vis, domain, identifier)
+    affected_components = set()
+    for entry in unload_order:
+        affected_components.add(entry.component_name)
+        unload_domain_identifier(vis, entry.domain, entry.identifier)
+    return affected_components
 
-    Reloading is done by unloading all dependent domains first, then
-    re-registering and setting them up again in the correct order.
-    """
-    reload_order = get_unload_order(vis, domain, identifier)
 
-    if not reload_order:
-        LOGGER.warning(
-            f"Domain {domain} with identifier {identifier} not found for reload"
-        )
-        return
+def unload_domain(
+    vis: Viseron, component: str, domain: SupportedDomains
+) -> set[str] | None:
+    """Unload a component's domain and all its identifiers."""
+    component_instance: Component | None = vis.data[LOADED].get(component, None)
+    if component_instance is None:
+        LOGGER.debug(f"Component {component} not found, can't unload domain {domain}")
+        return None
 
-    LOGGER.info(
-        f"Reloading domain {domain} with identifier {identifier}. "
-        f"Order: {[(e.domain, e.identifier) for e in reload_order]}",
-    )
-
-    # Unload in order (dependents first)
-    for entry in reload_order:
-        unload_domain(vis, entry.domain, entry.identifier)
-
-    # Re-register in original order
+    affected_components = set()
     registry = vis.domain_registry
-    for entry in reversed(reload_order):
-        registry.register(
-            component_name=entry.component_name,
-            component_path=entry.component_path,
-            domain=entry.domain,
-            identifier=entry.identifier,
-            config=entry.config,
-            require_domains=entry.require_domains,
-            optional_domains=entry.optional_domains,
+
+    # Unload any domain identifiers for this component and domain
+    domains_to_unload = registry.get_by_component_and_domain(component, domain)
+    LOGGER.debug(
+        f"Unloading all identifiers for component {component} and domain {domain}"
+    )
+    if domains_to_unload:
+        LOGGER.debug(
+            f"Component {component} "
+            f"and domain {domain} "
+            f"has {len(domains_to_unload)} identifiers to unload: "
+            f"{[(e.domain, e.identifier) for e in domains_to_unload]}"
         )
 
-    # Setup all
-    setup_domains(vis)
+        for entry in domains_to_unload:
+            affected_components.update(
+                unload_domain_chain(vis, entry.domain, entry.identifier)
+            )
+
+    # Call domain's unload method if it exists
+    try:
+        domain_module = importlib.import_module(f"{component_instance.path}.{domain}")
+    except ModuleNotFoundError as err:
+        LOGGER.error(
+            f"Failed to load domain module {component_instance.path}.{domain}: {err}"
+        )
+        return affected_components
+    if hasattr(domain_module, "unload"):
+        try:
+            domain_module.unload(vis)
+        except Exception as ex:  # pylint: disable=broad-except # noqa: BLE001
+            LOGGER.error(
+                f"Error unloading domain {domain} for component {component}: {ex}"
+            )
+    else:
+        LOGGER.debug(f"Domain {domain} for component {component} has no unload method")
+
+    return affected_components

--- a/viseron/reload.py
+++ b/viseron/reload.py
@@ -27,7 +27,11 @@ from viseron.config import (
 )
 from viseron.const import DEFAULT_COMPONENTS, FAILED, LOADED, LOADING
 from viseron.domain_registry import DomainState
-from viseron.domains import get_unload_order, setup_domains, unload_domain
+from viseron.domains import (
+    setup_domains,
+    unload_domain,
+    unload_domain_chain,
+)
 
 if TYPE_CHECKING:
     from viseron import Viseron
@@ -80,16 +84,6 @@ class SetupPlan:
 
     components: set[str] = field(default_factory=set)
     domain_components: set[str] = field(default_factory=set)
-
-
-def _unload_domain_chain(
-    vis: Viseron, domain: SupportedDomains, identifier: str, plan: SetupPlan
-) -> None:
-    """Unload a domain and all its dependents in the correct order."""
-    unload_order = get_unload_order(vis, domain, identifier)
-    for e in unload_order:
-        plan.domain_components.add(e.component_name)
-        unload_domain(vis, e.domain, e.identifier)
 
 
 def _process_identifier_changes(
@@ -251,18 +245,11 @@ def _handle_modified_domains(
     """Unload all identifiers for modified domains."""
     for domain_change in changes.domains_to_reload:
         plan.domain_components.add(domain_change.component_name)
-        domains_to_unload = vis.domain_registry.get_by_component(
-            domain_change.component_name
+        affected_components = unload_domain(
+            vis, domain_change.component_name, domain_change.domain
         )
-        if domains_to_unload:
-            LOGGER.debug(
-                f"Component {domain_change.component_name} "
-                f"has {len(domains_to_unload)} domains to unload: "
-                f"{[(e.domain, e.identifier) for e in domains_to_unload]}"
-            )
-
-            for entry in domains_to_unload:
-                _unload_domain_chain(vis, entry.domain, entry.identifier, plan)
+        if affected_components:
+            plan.domain_components.update(affected_components)
 
 
 def _handle_modified_identifiers(
@@ -275,22 +262,24 @@ def _handle_modified_identifiers(
             identifier_change.domain, identifier_change.identifier
         )
         if domain_to_unload:
-            _unload_domain_chain(
-                vis,
-                domain_to_unload.domain,
-                domain_to_unload.identifier,
-                plan,
+            plan.domain_components.update(
+                unload_domain_chain(
+                    vis,
+                    domain_to_unload.domain,
+                    domain_to_unload.identifier,
+                )
             )
 
         if identifier_change.is_added:
             # When an identifier is added (or re-added after being removed),
             # find any dependents of this identifier
             # and unload them so they can be re-setup.
-            _unload_domain_chain(
-                vis,
-                identifier_change.domain,
-                identifier_change.identifier,
-                plan,
+            plan.domain_components.update(
+                unload_domain_chain(
+                    vis,
+                    identifier_change.domain,
+                    identifier_change.identifier,
+                )
             )
 
 
@@ -303,7 +292,9 @@ def _handle_cancelled_retries(
             f"Unloading retrying domain {entry.domain} with identifier "
             f"{entry.identifier} that was cancelled during reload"
         )
-        _unload_domain_chain(vis, entry.domain, entry.identifier, plan)
+        plan.domain_components.update(
+            unload_domain_chain(vis, entry.domain, entry.identifier)
+        )
 
 
 def _unload_dependents_of_pending_domains(vis: Viseron, plan: SetupPlan) -> None:
@@ -327,7 +318,9 @@ def _unload_dependents_of_pending_domains(vis: Viseron, plan: SetupPlan) -> None
                 f"because its dependency {entry.domain} "
                 f"with identifier {entry.identifier} is now available"
             )
-            _unload_domain_chain(vis, dep.domain, dep.identifier, plan)
+            plan.domain_components.update(
+                unload_domain_chain(vis, dep.domain, dep.identifier)
+            )
 
 
 def _apply_setup_plan(vis: Viseron, new_config: dict, plan: SetupPlan) -> None:
@@ -353,7 +346,8 @@ def _apply_setup_plan(vis: Viseron, new_config: dict, plan: SetupPlan) -> None:
         new_config,
         reloading=True,
         domains_only=True,
-        components=plan.domain_components,
+        # Make sure a components setup_domains isn't called twice
+        components=plan.domain_components - plan.components,
     )
     setup_domains(vis)
 


### PR DESCRIPTION
Support domain level specific reloads.
For instance the `edgetpu` component sets up its connection to the Coral inside the `object_detector` domain, and if you change the model and reload, only its identifiers would be reloaded, not the entire component.
This caused stale reloads.