### PR TITLE
fix(reload): an unloaded domains component should not be marked as affected

### DIFF
--- a/tests/domains/test__init__.py
+++ b/tests/domains/test__init__.py
@@ -419,7 +419,7 @@ class TestUnloadDomainChain:
     """Test unload_domain_chain function."""
 
     def test_returns_affected_components(self, vis: MockViseron):
-        """Test that all component names touched by the chain are returned."""
+        """Test that only dependent component names are returned, not the root's."""
         registry = vis.domain_registry
         registry.register(
             component_name="camera_comp",
@@ -442,7 +442,8 @@ class TestUnloadDomainChain:
 
         affected = unload_domain_chain(vis, "camera", "cam1")
 
-        assert affected == {"camera_comp", "nvr_comp"}
+        # camera_comp owns the root domain being unloaded and is intentionally excluded.
+        assert affected == {"nvr_comp"}
         assert registry.get("camera", "cam1") is None
         assert registry.get("nvr", "cam1") is None
 
@@ -532,7 +533,7 @@ class TestUnloadDomain:
         assert vis.domain_registry.get("camera", "cam2") is None
 
     def test_returns_affected_components(self, vis: MockViseron):
-        """Test that the set of affected component names is returned."""
+        """Test that only dependent component names are returned."""
         MockComponent(vis, "test_comp")
         self._register_domain(vis, identifier="cam1")
 
@@ -554,7 +555,7 @@ class TestUnloadDomain:
             result = unload_domain(vis, "test_comp", "camera")
 
         assert result is not None
-        assert "test_comp" in result
+        assert "test_comp" not in result
         assert "nvr_comp" in result
 
     def test_calls_domain_module_unload(self, vis: MockViseron):

--- a/viseron/domains/__init__.py
+++ b/viseron/domains/__init__.py
@@ -543,11 +543,17 @@ def unload_domain_identifier(
 def unload_domain_chain(
     vis: Viseron, domain: SupportedDomains, identifier: str
 ) -> set[str]:
-    """Unload a domain and all its dependents in the correct order."""
+    """Unload a domain and all its dependents in the correct order.
+
+    Returns the component names of dependents that need re-setup.
+    The root domain's own component is intentionally excluded.
+    """
     unload_order = get_unload_order(vis, domain, identifier)
     affected_components = set()
     for entry in unload_order:
-        affected_components.add(entry.component_name)
+        # Only dependents need to be re-setup, not the root being unloaded.
+        if entry.domain != domain or entry.identifier != identifier:
+            affected_components.add(entry.component_name)
         unload_domain_identifier(vis, entry.domain, entry.identifier)
     return affected_components
 

--- a/viseron/reload.py
+++ b/viseron/reload.py
@@ -212,6 +212,8 @@ def _handle_removed_components(vis: Viseron, diff: ConfigDiff, plan: SetupPlan) 
     for component_name in diff.get_removed_components():
         affected_components = unload_component(vis, component_name)
         if affected_components:
+            # Ensure the removed component is never queued for re-setup.
+            affected_components.discard(component_name)
             plan.domain_components.update(affected_components)
             LOGGER.debug(
                 f"Components affected by unloading {component_name}: "
@@ -292,6 +294,9 @@ def _handle_cancelled_retries(
             f"Unloading retrying domain {entry.domain} with identifier "
             f"{entry.identifier} that was cancelled during reload"
         )
+        # Explicitly add the retrying domain's component.
+        # unload_domain_chain only returns dependents, not the root's own component.
+        plan.domain_components.add(entry.component_name)
         plan.domain_components.update(
             unload_domain_chain(vis, entry.domain, entry.identifier)
         )
@@ -318,6 +323,9 @@ def _unload_dependents_of_pending_domains(vis: Viseron, plan: SetupPlan) -> None
                 f"because its dependency {entry.domain} "
                 f"with identifier {entry.identifier} is now available"
             )
+            # Explicitly add the dependents component.
+            # unload_domain_chain only returns dependents of dep, not deps component.
+            plan.domain_components.add(dep.component_name)
             plan.domain_components.update(
                 unload_domain_chain(vis, dep.domain, dep.identifier)
             )


### PR DESCRIPTION
The root component in an domain chain unload was marked as affected, causing it to be re-setup. This is problematic when removing a component/domain entirely