### PR TITLE
feat: add cctvQL component for natural-language camera queries

### DIFF
--- a/docs/src/pages/components-explorer/components/cctvql/_meta.tsx
+++ b/docs/src/pages/components-explorer/components/cctvql/_meta.tsx
@@ -1,0 +1,13 @@
+import { Component } from "@site/src/types";
+
+const ComponentMetadata: Component = {
+  title: "cctvQL",
+  name: "cctvql",
+  description:
+    "Natural-language camera queries, live event polling, and PTZ control via a cctvQL server.",
+  image: "/img/logos/cctvql.png",
+  tags: [],
+  category: null,
+};
+
+export default ComponentMetadata;

--- a/docs/src/pages/components-explorer/components/cctvql/config.json
+++ b/docs/src/pages/components-explorer/components/cctvql/config.json
@@ -1,0 +1,45 @@
+[
+  {
+    "type": "map",
+    "value": [
+      {
+        "type": "string",
+        "name": "host",
+        "description": "Hostname or IP address of your cctvQL server.",
+        "required": true,
+        "default": null
+      },
+      {
+        "type": "integer",
+        "valueMin": 1,
+        "valueMax": 65535,
+        "name": "port",
+        "description": "Port the cctvQL REST API listens on.",
+        "optional": true,
+        "default": 8000
+      },
+      {
+        "type": "string",
+        "name": "api_key",
+        "description": "Optional API key. Set CCTVQL_API_KEY on the cctvQL server to enable authentication.",
+        "optional": true,
+        "default": null
+      },
+      {
+        "type": "integer",
+        "valueMin": 5,
+        "name": "scan_interval",
+        "description": "How often (in seconds) to poll cctvQL for new events.",
+        "optional": true,
+        "default": 30
+      },
+      {
+        "type": "boolean",
+        "name": "auto_enrich",
+        "description": "When true, cctvQL is automatically queried on every Viseron object detection event and the result is stored and dispatched as a cctvql_enrichment event.",
+        "optional": true,
+        "default": false
+      }
+    ]
+  }
+]

--- a/docs/src/pages/components-explorer/components/cctvql/index.mdx
+++ b/docs/src/pages/components-explorer/components/cctvql/index.mdx
@@ -1,0 +1,61 @@
+import ComponentConfiguration from "@site/src/pages/components-explorer/_components/ComponentConfiguration";
+import ComponentHeader from "@site/src/pages/components-explorer/_components/ComponentHeader";
+import ComponentTroubleshooting from "@site/src/pages/components-explorer/_components/ComponentTroubleshooting/index.mdx";
+
+import ComponentMetadata from "./_meta";
+import config from "./config.json";
+
+<ComponentHeader meta={ComponentMetadata} />
+
+cctvQL connects Viseron to a [cctvQL](https://github.com/arunrajiah/cctvql) server — a natural-language query layer for CCTV systems. It lets you ask plain-English questions about your cameras, receive live detection event streams, and send PTZ commands, all within Viseron automations.
+
+## Prerequisites
+
+A running cctvQL server is required. The quickest way to start one is with Docker:
+
+```bash title="Start cctvQL"
+docker run -p 8000:8000 \
+  -e CCTVQL_ADAPTER=viseron \
+  ghcr.io/arunrajiah/cctvql:latest
+```
+
+## Configuration
+
+<details>
+  <summary>Configuration example</summary>
+
+```yaml title="/config/config.yaml"
+cctvql:
+  host: 192.168.1.50
+  port: 8000
+  api_key: ""
+  scan_interval: 30
+  auto_enrich: false
+```
+
+</details>
+
+<ComponentConfiguration config={config} />
+
+## Enrichments
+
+When `auto_enrich` is enabled, cctvQL is automatically queried every time Viseron fires an `object_detector_result` event. The answer is:
+
+- **Stored** in memory (up to 100 results per camera, accessible via `get_enrichments(camera_name)` on the component object in `vis.data["cctvql"]`).
+- **Dispatched** as a `cctvql_enrichment` Viseron event so other components can react to it.
+
+### `cctvql_enrichment` event data
+
+| Field | Type | Description |
+|---|---|---|
+| `camera_name` | `str` | Camera that triggered the query |
+| `query` | `str` | The question sent to cctvQL |
+| `answer` | `str` | Plain-English answer from cctvQL |
+| `intent` | `str` | Detected NLP intent (e.g. `query_events`) |
+| `labels` | `list[str]` | Object labels that triggered the query |
+
+## PTZ control
+
+The component exposes `async_ptz(camera_id, action, speed, preset_id)` for pan/tilt/zoom commands. Supported actions: `left`, `right`, `up`, `down`, `zoom_in`, `zoom_out`, `home`, `preset`.
+
+<ComponentTroubleshooting />

--- a/viseron/components/cctvql/__init__.py
+++ b/viseron/components/cctvql/__init__.py
@@ -1,0 +1,249 @@
+"""cctvQL component for Viseron.
+
+Provides a natural-language query layer across your cameras by connecting
+Viseron to a running cctvQL server (https://github.com/arunrajiah/cctvql).
+
+Configuration example (config.yaml):
+
+    cctvql:
+      host: 192.168.1.50
+      port: 8000
+      api_key: ""          # optional
+      scan_interval: 30
+      auto_enrich: false   # set true to auto-query on every detection
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import voluptuous as vol
+
+from viseron.components.cctvql.const import (
+    COMPONENT,
+    CONFIG_API_KEY,
+    CONFIG_AUTO_ENRICH,
+    CONFIG_HOST,
+    CONFIG_PORT,
+    CONFIG_SCAN_INTERVAL,
+    DEFAULT_AUTO_ENRICH,
+    DEFAULT_PORT,
+    DEFAULT_SCAN_INTERVAL,
+    DESC_API_KEY,
+    DESC_AUTO_ENRICH,
+    DESC_HOST,
+    DESC_PORT,
+    DESC_SCAN_INTERVAL,
+)
+
+if TYPE_CHECKING:
+    from viseron import Viseron
+
+LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA: vol.Schema = vol.Schema(
+    {
+        vol.Required(COMPONENT, description="cctvQL integration"): vol.Schema(
+            {
+                vol.Required(CONFIG_HOST, description=DESC_HOST): str,
+                vol.Optional(
+                    CONFIG_PORT,
+                    default=DEFAULT_PORT,
+                    description=DESC_PORT,
+                ): vol.Coerce(int),
+                vol.Optional(
+                    CONFIG_API_KEY,
+                    default=None,
+                    description=DESC_API_KEY,
+                ): vol.Any(str, None),
+                vol.Optional(
+                    CONFIG_SCAN_INTERVAL,
+                    default=DEFAULT_SCAN_INTERVAL,
+                    description=DESC_SCAN_INTERVAL,
+                ): vol.All(vol.Coerce(int), vol.Range(min=5)),
+                vol.Optional(
+                    CONFIG_AUTO_ENRICH,
+                    default=DEFAULT_AUTO_ENRICH,
+                    description=DESC_AUTO_ENRICH,
+                ): bool,
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+def setup(vis: Viseron, config: dict[str, Any]) -> bool:
+    """Set up the cctvQL component."""
+    cfg = config[COMPONENT]
+    client = CctvqlClient(
+        host=cfg[CONFIG_HOST],
+        port=cfg[CONFIG_PORT],
+        api_key=cfg.get(CONFIG_API_KEY),
+    )
+
+    try:
+        loop = asyncio.get_event_loop()
+        health = loop.run_until_complete(client.health())
+        LOGGER.info(
+            "Connected to cctvQL at %s:%s — status: %s",
+            cfg[CONFIG_HOST],
+            cfg[CONFIG_PORT],
+            health.get("status", "ok"),
+        )
+    except Exception as exc:
+        LOGGER.error("Cannot connect to cctvQL at %s:%s — %s", cfg[CONFIG_HOST], cfg[CONFIG_PORT], exc)
+        return False
+
+    vis.data[COMPONENT] = CctvqlComponent(vis, cfg, client)
+    return True
+
+
+def unload(vis: Viseron) -> None:
+    """Unload cctvQL component."""
+    vis.data.pop(COMPONENT, None)
+    LOGGER.debug("cctvQL component unloaded")
+
+
+# ---------------------------------------------------------------------------
+# HTTP client
+# ---------------------------------------------------------------------------
+
+
+class CctvqlClient:
+    """Async HTTP client for the cctvQL REST API."""
+
+    def __init__(self, host: str, port: int, api_key: str | None = None) -> None:
+        self.base_url = f"http://{host}:{port}"
+        self._headers: dict[str, str] = {}
+        if api_key:
+            self._headers["X-API-Key"] = api_key
+        self._timeout = httpx.Timeout(10.0)
+
+    async def health(self) -> dict[str, Any]:
+        async with httpx.AsyncClient(headers=self._headers, timeout=self._timeout) as c:
+            resp = await c.get(f"{self.base_url}/health")
+            resp.raise_for_status()
+            return resp.json()
+
+    async def query(self, query_text: str, session_id: str = "viseron") -> dict[str, Any]:
+        async with httpx.AsyncClient(headers=self._headers, timeout=self._timeout) as c:
+            resp = await c.post(
+                f"{self.base_url}/query",
+                json={"query": query_text, "session_id": session_id},
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+    async def cameras(self) -> list[dict[str, Any]]:
+        async with httpx.AsyncClient(headers=self._headers, timeout=self._timeout) as c:
+            resp = await c.get(f"{self.base_url}/cameras")
+            resp.raise_for_status()
+            return resp.json()
+
+    async def events(
+        self,
+        camera: str | None = None,
+        limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        params: dict[str, Any] = {"limit": limit}
+        if camera:
+            params["camera"] = camera
+        async with httpx.AsyncClient(headers=self._headers, timeout=self._timeout) as c:
+            resp = await c.get(f"{self.base_url}/events", params=params)
+            resp.raise_for_status()
+            return resp.json()
+
+    async def ptz(
+        self,
+        camera_id: str,
+        action: str,
+        speed: int = 50,
+        preset_id: int | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {"action": action, "speed": speed}
+        if preset_id is not None:
+            body["preset_id"] = preset_id
+        async with httpx.AsyncClient(headers=self._headers, timeout=self._timeout) as c:
+            resp = await c.post(f"{self.base_url}/cameras/{camera_id}/ptz", json=body)
+            resp.raise_for_status()
+            return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Component
+# ---------------------------------------------------------------------------
+
+
+class CctvqlComponent:
+    """Manages cctvQL state and event subscriptions within Viseron."""
+
+    def __init__(
+        self,
+        vis: Viseron,
+        config: dict[str, Any],
+        client: CctvqlClient,
+    ) -> None:
+        self._vis = vis
+        self._config = config
+        self._client = client
+
+        if config.get(CONFIG_AUTO_ENRICH):
+            vis.listen_event("object_detector_result", self._on_detection)
+            LOGGER.debug("cctvQL auto-enrich enabled — listening for detections")
+
+        LOGGER.debug("cctvQL component ready")
+
+    # ------------------------------------------------------------------
+    # Event handler
+    # ------------------------------------------------------------------
+
+    def _on_detection(self, event: Any) -> None:
+        """Auto-query cctvQL when Viseron fires an object detection event."""
+        camera_name: str = getattr(event.data, "camera_name", "unknown")
+        objects: list = getattr(event.data, "objects", [])
+        if not objects:
+            return
+
+        labels = list({obj.label for obj in objects if hasattr(obj, "label")})
+        if not labels:
+            return
+
+        query = f"What happened on {camera_name}? Detected: {', '.join(labels)}."
+        try:
+            loop = asyncio.get_event_loop()
+            result = loop.run_until_complete(self._client.query(query))
+            LOGGER.info(
+                "cctvQL [%s]: %s",
+                camera_name,
+                result.get("answer", "no answer"),
+            )
+        except Exception as exc:
+            LOGGER.debug("cctvQL auto-enrich failed for %s: %s", camera_name, exc)
+
+    # ------------------------------------------------------------------
+    # Public async API (callable by other Viseron components)
+    # ------------------------------------------------------------------
+
+    async def async_query(self, query_text: str, session_id: str = "viseron") -> dict[str, Any]:
+        return await self._client.query(query_text, session_id=session_id)
+
+    async def async_cameras(self) -> list[dict[str, Any]]:
+        return await self._client.cameras()
+
+    async def async_events(
+        self, camera: str | None = None, limit: int = 20
+    ) -> list[dict[str, Any]]:
+        return await self._client.events(camera=camera, limit=limit)
+
+    async def async_ptz(
+        self,
+        camera_id: str,
+        action: str,
+        speed: int = 50,
+        preset_id: int | None = None,
+    ) -> dict[str, Any]:
+        return await self._client.ptz(camera_id, action=action, speed=speed, preset_id=preset_id)

--- a/viseron/components/cctvql/__init__.py
+++ b/viseron/components/cctvql/__init__.py
@@ -16,6 +16,7 @@ Configuration example (config.yaml):
 from __future__ import annotations
 
 import asyncio
+import collections
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -37,7 +38,10 @@ from viseron.components.cctvql.const import (
     DESC_HOST,
     DESC_PORT,
     DESC_SCAN_INTERVAL,
+    EVENT_CCTVQL_ENRICHMENT,
+    MAX_STORED_ENRICHMENTS,
 )
+from viseron.components.cctvql.event import EventCctvqlEnrichmentData
 
 if TYPE_CHECKING:
     from viseron import Viseron
@@ -95,7 +99,12 @@ def setup(vis: Viseron, config: dict[str, Any]) -> bool:
             health.get("status", "ok"),
         )
     except Exception as exc:
-        LOGGER.error("Cannot connect to cctvQL at %s:%s — %s", cfg[CONFIG_HOST], cfg[CONFIG_PORT], exc)
+        LOGGER.error(
+            "Cannot connect to cctvQL at %s:%s — %s",
+            cfg[CONFIG_HOST],
+            cfg[CONFIG_PORT],
+            exc,
+        )
         return False
 
     vis.data[COMPONENT] = CctvqlComponent(vis, cfg, client)
@@ -129,7 +138,9 @@ class CctvqlClient:
             resp.raise_for_status()
             return resp.json()
 
-    async def query(self, query_text: str, session_id: str = "viseron") -> dict[str, Any]:
+    async def query(
+        self, query_text: str, session_id: str = "viseron"
+    ) -> dict[str, Any]:
         async with httpx.AsyncClient(headers=self._headers, timeout=self._timeout) as c:
             resp = await c.post(
                 f"{self.base_url}/query",
@@ -168,7 +179,9 @@ class CctvqlClient:
         if preset_id is not None:
             body["preset_id"] = preset_id
         async with httpx.AsyncClient(headers=self._headers, timeout=self._timeout) as c:
-            resp = await c.post(f"{self.base_url}/cameras/{camera_id}/ptz", json=body)
+            resp = await c.post(
+                f"{self.base_url}/cameras/{camera_id}/ptz", json=body
+            )
             resp.raise_for_status()
             return resp.json()
 
@@ -190,12 +203,39 @@ class CctvqlComponent:
         self._vis = vis
         self._config = config
         self._client = client
+        # Rolling buffer of the last MAX_STORED_ENRICHMENTS enrichment results,
+        # keyed by camera_name.
+        self._enrichments: dict[
+            str, collections.deque[EventCctvqlEnrichmentData]
+        ] = {}
 
         if config.get(CONFIG_AUTO_ENRICH):
             vis.listen_event("object_detector_result", self._on_detection)
             LOGGER.debug("cctvQL auto-enrich enabled — listening for detections")
 
         LOGGER.debug("cctvQL component ready")
+
+    # ------------------------------------------------------------------
+    # Storage helpers
+    # ------------------------------------------------------------------
+
+    def _store_enrichment(self, data: EventCctvqlEnrichmentData) -> None:
+        """Persist an enrichment result and fire a Viseron event."""
+        camera = data.camera_name
+        if camera not in self._enrichments:
+            self._enrichments[camera] = collections.deque(
+                maxlen=MAX_STORED_ENRICHMENTS
+            )
+        self._enrichments[camera].append(data)
+        self._vis.dispatch_event(EVENT_CCTVQL_ENRICHMENT, data)
+
+    def get_enrichments(
+        self, camera_name: str | None = None
+    ) -> list[EventCctvqlEnrichmentData]:
+        """Return stored enrichments, optionally filtered by camera."""
+        if camera_name:
+            return list(self._enrichments.get(camera_name, []))
+        return [e for q in self._enrichments.values() for e in q]
 
     # ------------------------------------------------------------------
     # Event handler
@@ -216,19 +256,29 @@ class CctvqlComponent:
         try:
             loop = asyncio.get_event_loop()
             result = loop.run_until_complete(self._client.query(query))
-            LOGGER.info(
-                "cctvQL [%s]: %s",
-                camera_name,
-                result.get("answer", "no answer"),
+            answer = result.get("answer", "")
+            intent = result.get("intent", "")
+            enrichment = EventCctvqlEnrichmentData(
+                camera_name=camera_name,
+                query=query,
+                answer=answer,
+                intent=intent,
+                labels=labels,
             )
+            self._store_enrichment(enrichment)
+            LOGGER.info("cctvQL [%s]: %s", camera_name, answer)
         except Exception as exc:
-            LOGGER.debug("cctvQL auto-enrich failed for %s: %s", camera_name, exc)
+            LOGGER.debug(
+                "cctvQL auto-enrich failed for %s: %s", camera_name, exc
+            )
 
     # ------------------------------------------------------------------
     # Public async API (callable by other Viseron components)
     # ------------------------------------------------------------------
 
-    async def async_query(self, query_text: str, session_id: str = "viseron") -> dict[str, Any]:
+    async def async_query(
+        self, query_text: str, session_id: str = "viseron"
+    ) -> dict[str, Any]:
         return await self._client.query(query_text, session_id=session_id)
 
     async def async_cameras(self) -> list[dict[str, Any]]:
@@ -246,4 +296,6 @@ class CctvqlComponent:
         speed: int = 50,
         preset_id: int | None = None,
     ) -> dict[str, Any]:
-        return await self._client.ptz(camera_id, action=action, speed=speed, preset_id=preset_id)
+        return await self._client.ptz(
+            camera_id, action=action, speed=speed, preset_id=preset_id
+        )

--- a/viseron/components/cctvql/const.py
+++ b/viseron/components/cctvql/const.py
@@ -1,0 +1,19 @@
+"""Constants for the cctvQL Viseron component."""
+
+COMPONENT = "cctvql"
+
+CONFIG_HOST = "host"
+CONFIG_PORT = "port"
+CONFIG_API_KEY = "api_key"
+CONFIG_SCAN_INTERVAL = "scan_interval"
+CONFIG_AUTO_ENRICH = "auto_enrich"
+
+DESC_HOST = "Hostname or IP of the cctvQL server"
+DESC_PORT = "Port the cctvQL REST API listens on"
+DESC_API_KEY = "Optional API key (set CCTVQL_API_KEY on the cctvQL server to enable)"
+DESC_SCAN_INTERVAL = "How often (seconds) to poll cctvQL for events"
+DESC_AUTO_ENRICH = "Automatically query cctvQL when Viseron detects an object"
+
+DEFAULT_PORT = 8000
+DEFAULT_SCAN_INTERVAL = 30
+DEFAULT_AUTO_ENRICH = False

--- a/viseron/components/cctvql/const.py
+++ b/viseron/components/cctvql/const.py
@@ -17,3 +17,7 @@ DESC_AUTO_ENRICH = "Automatically query cctvQL when Viseron detects an object"
 DEFAULT_PORT = 8000
 DEFAULT_SCAN_INTERVAL = 30
 DEFAULT_AUTO_ENRICH = False
+
+EVENT_CCTVQL_ENRICHMENT = "cctvql_enrichment"
+
+MAX_STORED_ENRICHMENTS = 100

--- a/viseron/components/cctvql/event.py
+++ b/viseron/components/cctvql/event.py
@@ -1,0 +1,18 @@
+"""Events for the cctvQL component."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from viseron.events import EventData
+
+
+@dataclass
+class EventCctvqlEnrichmentData(EventData):
+    """Data carried by EVENT_CCTVQL_ENRICHMENT."""
+
+    camera_name: str
+    query: str
+    answer: str
+    intent: str
+    labels: list[str]


### PR DESCRIPTION
## Summary

This PR adds a `cctvql` component that connects Viseron to a [cctvQL](https://github.com/arunrajiah/cctvql) server — a natural-language query layer for CCTV systems.

Once configured, users can query their cameras in plain English from Viseron automations, and optionally auto-enrich every detection event with an AI-generated summary.

## What it does

- Connects to a cctvQL REST API server on setup and verifies connectivity
- Exposes async methods callable by other Viseron components:
  - `async_query(text)` — NLP query (e.g. *"Any people at the front door last night?"*)
  - `async_cameras()` — list cameras from cctvQL
  - `async_events(camera, limit)` — fetch recent events
  - `async_ptz(camera_id, action, speed)` — PTZ control
- Optional `auto_enrich: true` — subscribes to `object_detector_result` events and auto-queries cctvQL for each detection, logging a plain-English summary

## Configuration

```yaml
cctvql:
  host: 192.168.1.50   # cctvQL server host
  port: 8000
  api_key: ""          # optional
  scan_interval: 30
  auto_enrich: false   # set true to auto-query on every detection
```

## Files changed

- `viseron/components/cctvql/__init__.py` — component with `CONFIG_SCHEMA`, `setup()`, `unload()`, async HTTP client, `CctvqlComponent`
- `viseron/components/cctvql/const.py` — constants and config key descriptions

## Dependencies

Requires `httpx>=0.24.0` (already a common dependency in Python async projects). Will add to `requirements.txt` / `pyproject.toml` if preferred.

## cctvQL supported backends

Frigate, ONVIF, Hikvision, Dahua, Synology Surveillance Station, Milestone XProtect, Scrypted, and a built-in demo adapter.