### PR TITLE
fix(ffmpeg): use -stimeout on Jetson Nano for RTSP streams (#617)

### DIFF
--- a/tests/components/ffmpeg/test_stream.py
+++ b/tests/components/ffmpeg/test_stream.py
@@ -17,6 +17,8 @@ from viseron.components.ffmpeg.const import (
     CONFIG_FPS,
     CONFIG_HEIGHT,
     CONFIG_HOST,
+    CONFIG_HWACCEL_ARGS,
+    CONFIG_INPUT_ARGS,
     CONFIG_PASSWORD,
     CONFIG_PATH,
     CONFIG_PIX_FMT,
@@ -25,6 +27,7 @@ from viseron.components.ffmpeg.const import (
     CONFIG_RECORDER,
     CONFIG_RECORDER_AUDIO_CODEC,
     CONFIG_RECORDER_CODEC,
+    CONFIG_RTSP_TRANSPORT,
     CONFIG_STREAM_FORMAT,
     CONFIG_SUBSTREAM,
     CONFIG_USERNAME,
@@ -36,6 +39,7 @@ from viseron.components.ffmpeg.const import (
     DEFAULT_PASSWORD,
     DEFAULT_PROTOCOL,
     DEFAULT_RECORDER_AUDIO_CODEC,
+    DEFAULT_RTSP_TRANSPORT,
     DEFAULT_STREAM_FORMAT,
     DEFAULT_USERNAME,
     DEFAULT_WIDTH,
@@ -243,6 +247,55 @@ class TestStream:
             stream = Stream(CONFIG, mocked_camera, "test_camera_identifier")
             stream._config = config
             assert stream.get_stream_url(config) == expected_url
+
+    @pytest.mark.parametrize(
+        "stream_format, jetson_nano, expected_timeout_option",
+        [
+            ("rtsp", True, ["-stimeout", "5000000"]),
+            ("mjpeg", True, ["-timeout", "5000000"]),
+            ("rtmp", True, ["-rw_timeout", "5000000"]),
+            ("rtsp", False, ["-timeout", "5000000"]),
+        ],
+    )
+    def test_stream_command_jetson_nano_timeout_option(
+        self, monkeypatch, stream_format, jetson_nano, expected_timeout_option
+    ) -> None:
+        """Test stream-format timeout options on Jetson Nano."""
+        config = {
+            **CONFIG,
+            CONFIG_STREAM_FORMAT: stream_format,
+            CONFIG_INPUT_ARGS: None,
+            CONFIG_HWACCEL_ARGS: [],
+            CONFIG_RTSP_TRANSPORT: DEFAULT_RTSP_TRANSPORT,
+        }
+
+        if jetson_nano:
+            monkeypatch.setenv(ENV_JETSON_NANO, "true")
+        else:
+            monkeypatch.delenv(ENV_JETSON_NANO, raising=False)
+
+        with (
+            patch.object(Stream, "__init__", MagicMock(spec=Stream, return_value=None)),
+            patch.object(Stream, "get_decoder_codec", MagicMock(return_value=[])),
+        ):
+            stream = Stream(
+                config, MockCamera(identifier="test_camera_identifier"), "test_camera"
+            )
+            result = stream.stream_command(config, "h264", "test_stream_url")
+
+        timeout_option_index = result.index(expected_timeout_option[0])
+        assert (
+            result[timeout_option_index : timeout_option_index + 2]
+            == expected_timeout_option
+        )
+
+        if jetson_nano and stream_format == "rtsp":
+            assert "-timeout" not in result
+        if stream_format == "mjpeg":
+            assert "-stimeout" not in result
+        if stream_format == "rtmp":
+            assert "-stimeout" not in result
+            assert "-timeout" not in result
 
     def test_get_stream_information(self):
         """Test that the correct stream information is returned."""

--- a/viseron/components/ffmpeg/stream.py
+++ b/viseron/components/ffmpeg/stream.py
@@ -337,9 +337,19 @@ class Stream:
         if stream_config[CONFIG_INPUT_ARGS]:
             input_args = stream_config[CONFIG_INPUT_ARGS]
         else:
-            input_args = CAMERA_INPUT_ARGS + list(
+            timeout_option = list(
                 STREAM_FORMAT_MAP[stream_config[CONFIG_STREAM_FORMAT]]["timeout_option"]
             )
+            # Issue #617: Jetson Nano uses ffmpeg 4.x, where the RTSP-specific
+            # timeout option is -stimeout. Other images use ffmpeg 5.x and -timeout.
+            if (
+                os.getenv(ENV_JETSON_NANO) == "true"
+                and stream_config[CONFIG_STREAM_FORMAT] == "rtsp"
+                and timeout_option
+                and timeout_option[0] == "-timeout"
+            ):
+                timeout_option[0] = "-stimeout"
+            input_args = CAMERA_INPUT_ARGS + timeout_option
 
         return (
             input_args


### PR DESCRIPTION
## What

When `VISERON_JETSON_NANO=true` and the stream format is RTSP, rewrite the `-timeout` option to `-stimeout` before handing input args to ffmpeg.

Other stream formats (mjpeg/http, rtmp) and other platforms are unaffected.

## Why

The Jetson Nano image installs ffmpeg from `apt` and is pinned to `n4.2.2-15-g6878ea5a44`. In ffmpeg 4.x, the RTSP-specific socket timeout option is `-stimeout` (microseconds); ffmpeg 5.x renamed this to `-timeout`. Other viseron containers run ffmpeg 5.1.2 and correctly use `-timeout`.

The current code uses `-timeout` unconditionally. On Jetson Nano this triggers https://trac.ffmpeg.org/ticket/2294, and RTSP streams die at startup with "Cannot assign requested address". The maintainer acknowledged this in the issue: "The Jetson Nano version will stay at 4.2.2 since it is installed from apt. The other containers have FFmpeg 5.1.2. Will make sure to fix this in a coming release."

## How

`viseron/components/ffmpeg/stream.py`'s `stream_command()` already pulls the timeout option from `STREAM_FORMAT_MAP`. After fetching it, check `os.getenv(ENV_JETSON_NANO) == "true"` (same env-var check used at line 304 for the hwaccel codec map) AND `stream_format == "rtsp"` AND `timeout_option[0] == "-timeout"`. If all three hold, rewrite to `-stimeout`.

The RTSP gate is necessary because `-stimeout` is an RTSP demuxer option in ffmpeg 4.x and is not a valid `-i http://...` option for MJPEG/HTTP inputs (ffmpeg would error out with "Unrecognized option 'stimeout'").

`STREAM_FORMAT_MAP` is unchanged in shape, so any external consumer reading the map still sees the original options.

## Testing

Added parametrized test `test_stream_command_jetson_nano_timeout_option` covering:

- `rtsp` + Jetson Nano: input args contain `-stimeout 5000000`, do not contain `-timeout`
- `mjpeg` + Jetson Nano: input args contain `-timeout 5000000` (unchanged from current behavior)
- `rtmp` + Jetson Nano: input args contain `-rw_timeout 5000000` (unchanged)
- `rtsp` + non-Jetson: input args contain `-timeout 5000000` (unchanged)

Closes #617
