### PR TITLE
fix: snapshot dicts before serialization to prevent concurrent mutation

### DIFF
--- a/viseron/components/webserver/auth.py
+++ b/viseron/components/webserver/auth.py
@@ -580,9 +580,12 @@ class Auth:
         """Save users to storage."""
         self._auth_store.save(
             {
-                "users": self.users,
-                "refresh_tokens": self.refresh_tokens,
-                "access_tokens": {t.id: asdict(t) for t in self.access_tokens.values()},
+                "users": dict(self.users),
+                "refresh_tokens": dict(self.refresh_tokens),
+                "access_tokens": {
+                    token_id: asdict(access_token)
+                    for token_id, access_token in list(self.access_tokens.items())
+                },
             }
         )
 


### PR DESCRIPTION
See error below; I fixed the pattern also for `access_tokens` because it would still be vulnerable to the race.

```
2026-05-16 08:21:16.738 [ERROR   ] [viseron.components.webserver.api.handlers] - Error in API AuthAPIHandler.auth_login
Traceback (most recent call last):
  File "/src/viseron/components/webserver/api/handlers.py", line 378, in route_request
    return await func(*path_args, **path_kwargs)
  File "/src/viseron/components/webserver/api/v1/auth.py", line 225, in auth_login
    refresh_token = await self.run_in_executor(
  File "/src/viseron/components/webserver/request_handler.py", line 51, in run_in_executor
    return await self.ioloop.run_in_executor(None, func, *args)
  File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/src/viseron/components/webserver/auth.py", line 493, in generate_refresh_token
    self.save()
  File "/src/viseron/components/webserver/auth.py", line 469, in save
    self._auth_store.save(
  File "/src/viseron/helpers/storage.py", line 79, in save
    json_data = json.dumps(_data, indent=4, cls=JSONEncoder)
  File "/usr/lib/python3.10/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/usr/lib/python3.10/json/encoder.py", line 201, in encode
    chunks = list(chunks)
  File "/usr/lib/python3.10/json/encoder.py", line 431, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/usr/lib/python3.10/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.10/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.10/json/encoder.py", line 356, in _iterencode_dict
    for key, value in items:
RuntimeError: dictionary changed size during iteration
```