### PR TITLE
fix: use curl for the migration to Postgres 16

### DIFF
--- a/rootfs/etc/cont-init.d/80-postgres
+++ b/rootfs/etc/cont-init.d/80-postgres
@@ -45,8 +45,12 @@ upgrade_db() {
 
   log_info "Installing PostgreSQL $old_version..."
   echo "deb https://apt.postgresql.org/pub/repos/apt ${UBUNTU_CODENAME}-pgdg main" > /etc/apt/sources.list.d/pgdg.list
-  wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-  apt-get update && apt-get install -y --no-install-recommends postgresql-$old_version
+  curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg
+  echo "deb [signed-by=/usr/share/keyrings/postgresql-archive-keyring.gpg] https://apt.postgresql.org/pub/repos/apt ${UBUNTU_CODENAME}-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+  if ! apt-get update || ! apt-get install -y --no-install-recommends postgresql-$old_version; then
+    log_error "Failed to install PostgreSQL $old_version. Aborting upgrade to preserve data."
+    return 1
+  fi
 
   new_db_path=/tmp/postgresql
   mkdir -p $new_db_path
@@ -76,7 +80,11 @@ upgrade_db() {
 
   log_info "Running pg_upgrade..."
   cd $new_db_path
-  s6-setuidgid postgres $PG_BIN/pg_upgrade -b /usr/lib/postgresql/$old_version/bin -B $PG_BIN -d $PGDATA -D $new_db_path
+  if ! s6-setuidgid postgres $PG_BIN/pg_upgrade -b /usr/lib/postgresql/$old_version/bin -B $PG_BIN -d $PGDATA -D $new_db_path; then
+    log_error "pg_upgrade failed. Aborting upgrade to preserve data."
+    rm -rf $new_db_path
+    return 1
+  fi
 
   log_info "Cleaning up..."
   apt-get remove -y postgresql-$old_version postgresql-client-$old_version


### PR DESCRIPTION
Two fixes:
* use curl for the migration to Postgres 16
* interrupt migration in case of failure

I verified that without this fix the migration from 14 to 16 never happens and Viseron gets stuck in this loop, with no data:
```
[s6-init] making user provided files available at /var/run/s6/etc...exited 0.
[s6-init] ensuring user provided files have correct perms...exited 0.
[fix-attrs.d] applying ownership & permissions fixes...
[fix-attrs.d] done.
[cont-init.d] executing container initialization scripts...
[cont-init.d] 10-adduser: executing... 
************************ UID/GID *************************
Changing ownership of files to abc:abc, this may take a while...
User uid:    0
User gid:    0
************************** Done **************************
[cont-init.d] 10-adduser: exited 0.
[cont-init.d] 20-gid-video-device: executing... 
[cont-init.d] 20-gid-video-device: exited 0.
[cont-init.d] 30-edgetpu-permission: executing... 
[...]
[cont-init.d] 80-postgres: executing... 
***************** Preparing PostgreSQL *******************
Database has already been initialized.
Database version (14) is not the same as the installed PostgreSQL version (16).
Upgrading database to new PostgreSQL version...
Installing PostgreSQL 14...
/var/run/s6/etc/cont-init.d/80-postgres: line 48: wget: command not found
Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
gpg: no valid OpenPGP data found.
Get:1 http://ports.ubuntu.com/ubuntu-ports noble InRelease [256 kB]
Get:2 https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu noble InRelease [17.8 kB]
Get:3 http://ports.ubuntu.com/ubuntu-ports noble-updates InRelease [126 kB]
Get:4 http://ports.ubuntu.com/ubuntu-ports noble-backports InRelease [126 kB]
Get:5 https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu noble/main arm64 Packages [40.5 kB]
Get:6 https://apt.postgresql.org/pub/repos/apt noble-pgdg InRelease [180 kB]
Get:7 http://ports.ubuntu.com/ubuntu-ports noble-security InRelease [126 kB]
Get:8 http://ports.ubuntu.com/ubuntu-ports noble/main arm64 Packages [1776 kB]
Get:9 https://packages.cloud.google.com/apt coral-edgetpu-stable InRelease [1423 B]
Get:10 http://ports.ubuntu.com/ubuntu-ports noble/restricted arm64 Packages [113 kB]
Get:11 http://ports.ubuntu.com/ubuntu-ports noble/universe arm64 Packages [19.0 MB]
Get:12 http://ports.ubuntu.com/ubuntu-ports noble/multiverse arm64 Packages [274 kB]
Get:13 http://ports.ubuntu.com/ubuntu-ports noble-updates/restricted arm64 Packages [5519 kB]
Get:14 http://ports.ubuntu.com/ubuntu-ports noble-updates/universe arm64 Packages [2132 kB]
Get:15 http://ports.ubuntu.com/ubuntu-ports noble-updates/main arm64 Packages [2594 kB]
Get:16 http://ports.ubuntu.com/ubuntu-ports noble-updates/multiverse arm64 Packages [67.4 kB]
Get:17 http://ports.ubuntu.com/ubuntu-ports noble-backports/multiverse arm64 Packages [671 B]
Get:18 http://ports.ubuntu.com/ubuntu-ports noble-backports/universe arm64 Packages [36.3 kB]
Get:19 http://ports.ubuntu.com/ubuntu-ports noble-backports/main arm64 Packages [48.9 kB]
Get:20 http://ports.ubuntu.com/ubuntu-ports noble-security/restricted arm64 Packages [5154 kB]
Err:6 https://apt.postgresql.org/pub/repos/apt noble-pgdg InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 7FCC7D46ACCC4CF8
Get:21 http://ports.ubuntu.com/ubuntu-ports noble-security/multiverse arm64 Packages [49.3 kB]
Get:22 http://ports.ubuntu.com/ubuntu-ports noble-security/universe arm64 Packages [1530 kB]
Get:23 http://ports.ubuntu.com/ubuntu-ports noble-security/main arm64 Packages [2197 kB]
Get:24 https://packages.cloud.google.com/apt coral-edgetpu-stable/main arm64 Packages [6381 B]
Get:25 https://packages.cloud.google.com/apt coral-edgetpu-stable/main all Packages [1865 B]
Reading package lists...
W: GPG error: https://apt.postgresql.org/pub/repos/apt noble-pgdg InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 7FCC7D46ACCC4CF8
E: The repository 'https://apt.postgresql.org/pub/repos/apt noble-pgdg InRelease' is not signed.
W: https://packages.cloud.google.com/apt/dists/coral-edgetpu-stable/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
Database has not been initialized. Initializing...
The files belonging to this database system will be owned by user "postgres".
This user must also own the server process.

The database cluster will be initialized with locale "C.UTF-8".
The default database encoding has accordingly been set to "UTF8".
The default text search configuration will be set to "english".

Data page checksums are disabled.

fixing permissions on existing directory /tmp/postgresql ... ok
creating subdirectories ... ok
selecting dynamic shared memory implementation ... posix
selecting default max_connections ... 100
selecting default shared_buffers ... 128MB
selecting default time zone ... Etc/UTC
creating configuration files ... ok
running bootstrap script ... ok
performing post-bootstrap initialization ... ok
syncing data to disk ... ok

initdb: warning: enabling "trust" authentication for local connections
initdb: hint: You can change this by editing pg_hba.conf or using the option -A, or --auth-local and --auth-host, the next time you run initdb.

Success. You can now start the database server using:

    /usr/lib/postgresql/16/bin/pg_ctl -D /tmp/postgresql -l logfile start

Starting PostgreSQL...
s6-applyuidgid: fatal: unable to exec /usr/lib/postgresql/14/bin/pg_ctl: No such file or directory
psql: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory
	Is the server running locally and accepting connections on that socket?
Changing superuser role name to postgres...
Creating temporary superuser...
psql: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory
	Is the server running locally and accepting connections on that socket?
Dropping old postgres user...
psql: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory
	Is the server running locally and accepting connections on that socket?
Renaming old superuser to postgres...
psql: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory
	Is the server running locally and accepting connections on that socket?
Dropping temporary superuser...
psql: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory
	Is the server running locally and accepting connections on that socket?
Create abc user
createuser: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory
	Is the server running locally and accepting connections on that socket?
Stopping PostgreSQL...
s6-applyuidgid: fatal: unable to exec /usr/lib/postgresql/14/bin/pg_ctl: No such file or directory
Running pg_upgrade...

check for "/usr/lib/postgresql/14/bin" failed: No such file or directory
Failure, exiting
Cleaning up...
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package postgresql-14
E: Unable to locate package postgresql-client-14
Reading package lists...
Building dependency tree...
Reading state information...
0 upgraded, 0 newly installed, 0 to remove and 38 not upgraded.
Upgrade complete. It is recommended to remove the old database files: /config/postgresql-14
*********************** Done *****************************
[cont-init.d] 80-postgres: exited 0.
[cont-init.d] done.
[services.d] starting services
[services.d] done.
Starting PostgreSQL Server...
Starting nginx...
/var/run/postgresql:5432 - no response
Waiting for PostgreSQL Server to start...
Starting go2rtc...
2026-05-16 22:28:12.692 CEST [1021] LOG:  starting PostgreSQL 16.13 (Ubuntu 16.13-0ubuntu0.24.04.1) on aarch64-unknown-linux-gnu, compiled by gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0, 64-bit
2026-05-16 22:28:12.693 CEST [1021] LOG:  listening on IPv6 address "::1", port 5432
2026-05-16 22:28:12.693 CEST [1021] LOG:  listening on IPv4 address "127.0.0.1", port 5432
2026-05-16 22:28:12.699 CEST [1021] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2026-05-16 22:28:12.702 CEST [1036] LOG:  database system was shut down at 2026-05-16 22:28:07 CEST
2026-05-16 22:28:12.708 CEST [1021] LOG:  database system is ready to accept connections
22:28:12.765 INF go2rtc platform=linux/arm64 revision=fa580c5 version=1.9.9
22:28:12.765 INF config path=/tmp/go2rtc.yaml
22:28:12.766 INF [api] listen addr=:1984
22:28:12.766 INF [rtsp] listen addr=:8554
22:28:12.766 INF [webrtc] listen addr=:8555
2026-05-16 22:28:13.688 CEST [1048] FATAL:  database "viseron" does not exist
/var/run/postgresql:5432 - accepting connections
PostgreSQL Server has started!
2026-05-16 22:28:17.275 [INFO    ] [viseron.core] - -------------------------------------------
2026-05-16 22:28:17.275 [INFO    ] [viseron.core] - Initializing Viseron dev
2026-05-16 22:28:17.308 [INFO    ] [viseron.components] - Setting up component data_stream
2026-05-16 22:28:17.310 [INFO    ] [viseron.components] - Setup of component data_stream took 0.0 seconds
2026-05-16 22:28:17.310 [INFO    ] [viseron.components] - Setting up component storage
2026-05-16 22:28:17.316 CEST [1067] FATAL:  database "viseron" does not exist
2026-05-16 22:28:17.316 [WARNING ] [viseron.components.storage] - Database not ready (attempt 1/30): (psycopg2.OperationalError) connection to server at "localhost" (::1), port 5432 failed: FATAL:  database "viseron" does not exist

(Background on this error at: https://sqlalche.me/e/20/e3q8). Retrying in 1.0 seconds...
2026-05-16 22:28:18.319 CEST [1068] FATAL:  database "viseron" does not exist
2026-05-16 22:28:18.319 [WARNING ] [viseron.components.storage] - Database not ready (attempt 2/30): (psycopg2.OperationalError) connection to server at "localhost" (::1), port 5432 failed: FATAL:  database "viseron" does not exist

(Background on this error at: https://sqlalche.me/e/20/e3q8). Retrying in 1.0 seconds...
2026-05-16 22:28:19.322 CEST [1069] FATAL:  database "viseron" does not exist
2026-05-16 22:28:19.323 [WARNING ] [viseron.components.storage] - Database not ready (attempt 3/30): (psycopg2.OperationalError) connection to server at "localhost" (::1), port 5432 failed: FATAL:  database "viseron" does not exist

(Background on this error at: https://sqlalche.me/e/20/e3q8). Retrying in 1.0 seconds...
2026-05-16 22:28:20.326 CEST [1070] FATAL:  database "viseron" does not exist
2026-05-16 22:28:20.326 [WARNING ] [viseron.components.storage] - Database not ready (attempt 4/30): (psycopg2.OperationalError) connection to server at "localhost" (::1), port 5432 failed: FATAL:  database "viseron" does not exist
```