### PR TITLE
frontend: add interactive polygon mask and zone editor

### DIFF
--- a/frontend/src/components/player/liveplayer/LivePlayer.tsx
+++ b/frontend/src/components/player/liveplayer/LivePlayer.tsx
@@ -91,6 +91,8 @@ interface LivePlayerProps extends React.HTMLAttributes<HTMLElement> {
   isMenuOpen?: boolean;
   flipView?: boolean;
   onPlayerFullscreenChange?: (isFullscreen: boolean) => void;
+  overlay?: React.ReactNode;
+  containerRefCallback?: (ref: React.RefObject<HTMLDivElement | null>) => void;
 }
 
 export function LivePlayer({
@@ -102,6 +104,8 @@ export function LivePlayer({
   isMenuOpen = false,
   flipView = false,
   onPlayerFullscreenChange,
+  overlay,
+  containerRefCallback,
 }: LivePlayerProps) {
   const _elementRef = useRef<VideoRTC>(null);
   const elementRef = playerRef || _elementRef;
@@ -114,6 +118,12 @@ export function LivePlayer({
     hasError,
     isLoading,
   } = usePlayerStatus(elementRef);
+
+  useEffect(() => {
+    if (containerRefCallback) {
+      containerRefCallback(containerRef);
+    }
+  }, [containerRefCallback, containerRef]);
 
   const {
     handlePlayPause,
@@ -353,6 +363,7 @@ export function LivePlayer({
             </Box>
           )}
       </div>
+      {overlay}
       <CameraNameOverlay
         camera_identifier={camera.identifier}
         extraStatusText={

--- a/frontend/src/components/player/mjpegplayer/MjpegPlayer.tsx
+++ b/frontend/src/components/player/mjpegplayer/MjpegPlayer.tsx
@@ -104,6 +104,8 @@ interface MjpegPlayerProps extends React.HTMLAttributes<HTMLElement> {
   isMenuOpen?: boolean;
   flipView?: boolean;
   onPlayerFullscreenChange?: (isFullscreen: boolean) => void;
+  overlay?: React.ReactNode;
+  containerRefCallback?: (ref: React.RefObject<HTMLDivElement | null>) => void;
 }
 
 export function MjpegPlayer({
@@ -120,6 +122,8 @@ export function MjpegPlayer({
   isMenuOpen = false,
   flipView = false,
   onPlayerFullscreenChange,
+  overlay,
+  containerRefCallback,
 }: MjpegPlayerProps) {
   const theme = useTheme();
   const canHover = useCanHover();
@@ -165,6 +169,12 @@ export function MjpegPlayer({
     zoomSpeed: 0.2,
     disabled: isZoomPanDisabled,
   });
+
+  useEffect(() => {
+    if (containerRefCallback) {
+      containerRefCallback(containerRef);
+    }
+  }, [containerRefCallback, containerRef]);
 
   return (
     <div
@@ -368,6 +378,7 @@ export function MjpegPlayer({
           </Box>
         )}
       </div>
+      {overlay}
       <CameraNameOverlay
         camera_identifier={camera.identifier}
         extraStatusText={

--- a/frontend/src/components/player/polygon-editor/PolygonCanvas.tsx
+++ b/frontend/src/components/player/polygon-editor/PolygonCanvas.tsx
@@ -1,0 +1,272 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  drawPolygons,
+  findNearEdgeMidpoint,
+  findNearVertex,
+  findPolygonAtPoint,
+} from "./canvasRenderer";
+import { CoordinateTransform, Point, Polygon } from "./types";
+import { usePolygonEditorStore } from "./usePolygonEditorStore";
+
+const EDGE_SNAP_THRESHOLD = 15; // pixels in camera coords to snap to edge
+
+interface PolygonCanvasProps {
+  containerRef: React.RefObject<HTMLElement | null>;
+  transform: CoordinateTransform;
+  polygons: Polygon[];
+  isEditing: boolean;
+  cameraWidth: number;
+  cameraHeight: number;
+}
+
+/**
+ * Clamp to image bounds and snap to edges when close.
+ */
+function clampAndSnap(
+  point: Point,
+  cameraWidth: number,
+  cameraHeight: number,
+): Point {
+  let { x, y } = point;
+
+  // Clamp
+  x = Math.max(0, Math.min(cameraWidth, x));
+  y = Math.max(0, Math.min(cameraHeight, y));
+
+  // Snap to edges
+  if (x < EDGE_SNAP_THRESHOLD) x = 0;
+  if (x > cameraWidth - EDGE_SNAP_THRESHOLD) x = cameraWidth;
+  if (y < EDGE_SNAP_THRESHOLD) y = 0;
+  if (y > cameraHeight - EDGE_SNAP_THRESHOLD) y = cameraHeight;
+
+  return { x: Math.round(x), y: Math.round(y) };
+}
+
+export function PolygonCanvas({
+  containerRef,
+  transform,
+  polygons,
+  isEditing,
+  cameraWidth,
+  cameraHeight,
+}: PolygonCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [dragging, setDragging] = useState<{
+    polygonId: string;
+    vertexIndex: number;
+  } | null>(null);
+  const draggingRef = useRef(dragging);
+  draggingRef.current = dragging;
+
+  const {
+    selectedPolygonId,
+    hoveredVertexInfo,
+    selectPolygon,
+    moveVertex,
+    addVertex,
+    deleteVertex,
+  } = usePolygonEditorStore();
+
+  // Resize canvas to match container
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!canvas || !container) return () => {};
+
+    const observer = new ResizeObserver(() => {
+      const rect = container.getBoundingClientRect();
+      canvas.width = rect.width;
+      canvas.height = rect.height;
+    });
+
+    observer.observe(container);
+    const rect = container.getBoundingClientRect();
+    canvas.width = rect.width;
+    canvas.height = rect.height;
+
+    return () => observer.disconnect();
+  }, [containerRef]);
+
+  // Redraw on any change
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    drawPolygons(ctx, polygons, transform, selectedPolygonId, hoveredVertexInfo);
+  }, [polygons, transform, selectedPolygonId, hoveredVertexInfo]);
+
+  const getCanvasPos = useCallback(
+    (e: React.PointerEvent | React.MouseEvent) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return { x: 0, y: 0 };
+      const rect = canvas.getBoundingClientRect();
+      return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+    },
+    [],
+  );
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (!isEditing || e.button !== 0) return;
+      const pos = getCanvasPos(e);
+
+      // If a polygon is selected, check for vertex drag
+      if (selectedPolygonId) {
+        const polygon = polygons.find((p) => p.id === selectedPolygonId);
+        if (polygon) {
+          const vertexIdx = findNearVertex(pos.x, pos.y, polygon, transform);
+          if (vertexIdx >= 0) {
+            setDragging({ polygonId: polygon.id, vertexIndex: vertexIdx });
+            // Capture pointer for tracking outside canvas/window
+            (e.target as HTMLElement).setPointerCapture(e.pointerId);
+            e.preventDefault();
+            return;
+          }
+
+          // Check edge midpoints for adding a vertex
+          const edgeIdx = findNearEdgeMidpoint(
+            pos.x,
+            pos.y,
+            polygon,
+            transform,
+          );
+          if (edgeIdx >= 0) {
+            const cameraPoint = clampAndSnap(
+              transform.toCamera(pos.x, pos.y),
+              cameraWidth,
+              cameraHeight,
+            );
+            addVertex(polygon.id, edgeIdx, cameraPoint);
+            e.preventDefault();
+            return;
+          }
+        }
+      }
+
+      // Click on a polygon to select it
+      const clickedId = findPolygonAtPoint(pos.x, pos.y, polygons, transform);
+      selectPolygon(clickedId);
+    },
+    [
+      isEditing,
+      selectedPolygonId,
+      polygons,
+      transform,
+      cameraWidth,
+      cameraHeight,
+      getCanvasPos,
+      selectPolygon,
+      addVertex,
+    ],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!isEditing) return;
+      const pos = getCanvasPos(e);
+
+      if (draggingRef.current) {
+        const raw = transform.toCamera(pos.x, pos.y);
+        const cameraPoint = clampAndSnap(raw, cameraWidth, cameraHeight);
+        moveVertex(
+          draggingRef.current.polygonId,
+          draggingRef.current.vertexIndex,
+          cameraPoint,
+        );
+        return;
+      }
+
+      // Update hover state for vertex highlighting
+      if (selectedPolygonId) {
+        const polygon = polygons.find((p) => p.id === selectedPolygonId);
+        if (polygon) {
+          const vertexIdx = findNearVertex(pos.x, pos.y, polygon, transform);
+          if (vertexIdx >= 0) {
+            usePolygonEditorStore.setState({
+              hoveredVertexInfo: {
+                polygonId: polygon.id,
+                vertexIndex: vertexIdx,
+              },
+            });
+            return;
+          }
+        }
+      }
+      usePolygonEditorStore.setState({ hoveredVertexInfo: null });
+    },
+    [
+      isEditing,
+      selectedPolygonId,
+      polygons,
+      transform,
+      cameraWidth,
+      cameraHeight,
+      getCanvasPos,
+      moveVertex,
+    ],
+  );
+
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent) => {
+      if (draggingRef.current) {
+        (e.target as HTMLElement).releasePointerCapture(e.pointerId);
+      }
+      setDragging(null);
+    },
+    [],
+  );
+
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent) => {
+      if (!isEditing || !selectedPolygonId) return;
+      e.preventDefault();
+
+      const pos = getCanvasPos(e);
+      const polygon = polygons.find((p) => p.id === selectedPolygonId);
+      if (!polygon) return;
+
+      const vertexIdx = findNearVertex(pos.x, pos.y, polygon, transform);
+      if (vertexIdx >= 0 && polygon.points.length > 3) {
+        deleteVertex(polygon.id, vertexIdx);
+      }
+    },
+    [
+      isEditing,
+      selectedPolygonId,
+      polygons,
+      transform,
+      getCanvasPos,
+      deleteVertex,
+    ],
+  );
+
+  return (
+    <canvas
+      ref={canvasRef}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onContextMenu={handleContextMenu}
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        height: "100%",
+        zIndex: isEditing ? 4 : 2,
+        pointerEvents: isEditing ? "auto" : "none",
+        touchAction: "none",
+        cursor: dragging
+          ? "grabbing"
+          : hoveredVertexInfo
+            ? "grab"
+            : isEditing
+              ? "crosshair"
+              : "default",
+      }}
+    />
+  );
+}

--- a/frontend/src/components/player/polygon-editor/PolygonEditorButton.tsx
+++ b/frontend/src/components/player/polygon-editor/PolygonEditorButton.tsx
@@ -1,0 +1,59 @@
+import TuneIcon from "@mui/icons-material/Tune";
+import { useCallback, useContext } from "react";
+
+import { CustomFab } from "components/player/CustomControls";
+import { ViseronContext } from "context/ViseronContext";
+import { useToast } from "hooks/UseToast";
+import * as commands from "lib/commands";
+import * as types from "lib/types";
+
+import { parsePolygonsFromConfig } from "./configParser";
+import { usePolygonEditorStore } from "./usePolygonEditorStore";
+
+interface PolygonEditorButtonProps {
+  camera: types.Camera | types.FailedCamera;
+}
+
+export function PolygonEditorButton({ camera }: PolygonEditorButtonProps) {
+  const viseron = useContext(ViseronContext);
+  const toast = useToast();
+  const { isEditing, startEditing, stopEditing } = usePolygonEditorStore();
+
+  const handleClick = useCallback(
+    async (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.stopPropagation();
+
+      if (isEditing) {
+        stopEditing();
+        return;
+      }
+
+      if (!viseron.connection) {
+        toast.error("Not connected to Viseron");
+        return;
+      }
+
+      try {
+        const config = await commands.getConfig(viseron.connection);
+        const polygons = parsePolygonsFromConfig(config, camera.identifier);
+        startEditing(camera.identifier, config, polygons);
+      } catch (error) {
+        toast.error(`Failed to load config: ${error}`);
+      }
+    },
+    [
+      isEditing,
+      viseron.connection,
+      camera.identifier,
+      startEditing,
+      stopEditing,
+      toast,
+    ],
+  );
+
+  return (
+    <CustomFab onClick={handleClick}>
+      <TuneIcon />
+    </CustomFab>
+  );
+}

--- a/frontend/src/components/player/polygon-editor/PolygonEditorOverlay.tsx
+++ b/frontend/src/components/player/polygon-editor/PolygonEditorOverlay.tsx
@@ -1,0 +1,39 @@
+import { PolygonCanvas } from "./PolygonCanvas";
+import { PolygonEditorToolbar } from "./PolygonEditorToolbar";
+import { CoordinateTransform } from "./types";
+import { usePolygonEditorStore } from "./usePolygonEditorStore";
+
+interface PolygonEditorOverlayProps {
+  containerRef: React.RefObject<HTMLElement | null>;
+  transform: CoordinateTransform;
+  cameraWidth: number;
+  cameraHeight: number;
+}
+
+export function PolygonEditorOverlay({
+  containerRef,
+  transform,
+  cameraWidth,
+  cameraHeight,
+}: PolygonEditorOverlayProps) {
+  const { isEditing, polygons } = usePolygonEditorStore();
+
+  if (!isEditing) return null;
+
+  return (
+    <>
+      <PolygonCanvas
+        containerRef={containerRef}
+        transform={transform}
+        polygons={polygons}
+        isEditing={isEditing}
+        cameraWidth={cameraWidth}
+        cameraHeight={cameraHeight}
+      />
+      <PolygonEditorToolbar
+        cameraWidth={cameraWidth}
+        cameraHeight={cameraHeight}
+      />
+    </>
+  );
+}

--- a/frontend/src/components/player/polygon-editor/PolygonEditorToolbar.tsx
+++ b/frontend/src/components/player/polygon-editor/PolygonEditorToolbar.tsx
@@ -1,0 +1,365 @@
+import AddIcon from "@mui/icons-material/Add";
+import CloseIcon from "@mui/icons-material/Close";
+import DeleteIcon from "@mui/icons-material/Delete";
+import RestartAltIcon from "@mui/icons-material/RestartAlt";
+import SaveIcon from "@mui/icons-material/Save";
+import UndoIcon from "@mui/icons-material/Undo";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Chip from "@mui/material/Chip";
+import CircularProgress from "@mui/material/CircularProgress";
+import IconButton from "@mui/material/IconButton";
+import Paper from "@mui/material/Paper";
+import TextField from "@mui/material/TextField";
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+import { useCallback, useContext, useRef, useState } from "react";
+
+import { ViseronContext } from "context/ViseronContext";
+import { useToast } from "hooks/UseToast";
+import * as commands from "lib/commands";
+
+import {
+  createDefaultPolygon,
+  detectComponents,
+  updateConfigWithPolygons,
+} from "./configParser";
+import { CATEGORY_LABELS, CATEGORY_STROKE_COLORS, PolygonCategory } from "./types";
+import { usePolygonEditorStore } from "./usePolygonEditorStore";
+
+interface PolygonEditorToolbarProps {
+  cameraWidth: number;
+  cameraHeight: number;
+}
+
+export function PolygonEditorToolbar({
+  cameraWidth,
+  cameraHeight,
+}: PolygonEditorToolbarProps) {
+  const viseron = useContext(ViseronContext);
+  const toast = useToast();
+  const [categoryFilter, setCategoryFilter] = useState<PolygonCategory | null>(
+    null,
+  );
+  const [saved, setSaved] = useState(false);
+
+  // Draggable window state
+  const paperRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState<{ x: number; y: number }>({
+    x: 8,
+    y: 8,
+  });
+  const dragState = useRef<{
+    dragging: boolean;
+    startX: number;
+    startY: number;
+    origX: number;
+    origY: number;
+  }>({ dragging: false, startX: 0, startY: 0, origX: 0, origY: 0 });
+
+  const dragHandleRef = useRef<HTMLDivElement>(null);
+
+  const handleDragStart = useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      dragState.current = {
+        dragging: true,
+        startX: e.clientX,
+        startY: e.clientY,
+        origX: position.x,
+        origY: position.y,
+      };
+      // Capture pointer so we keep tracking even outside the element/window
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    },
+    [position],
+  );
+
+  const handleDragMove = useCallback((e: React.PointerEvent) => {
+    if (!dragState.current.dragging) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const dx = e.clientX - dragState.current.startX;
+    const dy = e.clientY - dragState.current.startY;
+    setPosition({
+      x: dragState.current.origX + dx,
+      y: dragState.current.origY + dy,
+    });
+  }, []);
+
+  const handleDragEnd = useCallback((e: React.PointerEvent) => {
+    dragState.current.dragging = false;
+    (e.target as HTMLElement).releasePointerCapture(e.pointerId);
+  }, []);
+
+  const {
+    polygons,
+    selectedPolygonId,
+    isDirty,
+    isSaving,
+    rawYamlConfig,
+    cameraIdentifier,
+    selectPolygon,
+    addPolygon,
+    deletePolygon,
+    updatePolygonName,
+    revert,
+    stopEditing,
+    setSaving,
+    setRawYamlConfig,
+  } = usePolygonEditorStore();
+
+  const selectedPolygon = polygons.find((p) => p.id === selectedPolygonId);
+
+  const filteredPolygons = categoryFilter
+    ? polygons.filter((p) => p.category === categoryFilter)
+    : polygons;
+
+  const handleAddPolygon = useCallback(() => {
+    if (!rawYamlConfig || !cameraIdentifier) return;
+
+    const category = categoryFilter || "motion_mask";
+    const { motionComponent, objectComponent } = detectComponents(
+      rawYamlConfig,
+      cameraIdentifier,
+    );
+
+    let componentKey: string;
+    if (category === "motion_mask") {
+      componentKey = motionComponent || "mog2";
+    } else {
+      componentKey = objectComponent || "codeprojectai";
+    }
+
+    const polygon = createDefaultPolygon(
+      category,
+      componentKey,
+      cameraWidth,
+      cameraHeight,
+    );
+    addPolygon(polygon);
+  }, [
+    categoryFilter,
+    rawYamlConfig,
+    cameraIdentifier,
+    cameraWidth,
+    cameraHeight,
+    addPolygon,
+  ]);
+
+  const handleSave = useCallback(async () => {
+    if (!viseron.connection || !rawYamlConfig || !cameraIdentifier) return;
+
+    setSaving(true);
+    try {
+      const updatedYaml = updateConfigWithPolygons(
+        rawYamlConfig,
+        cameraIdentifier,
+        polygons,
+      );
+      await commands.saveConfig(viseron.connection, updatedYaml);
+      setRawYamlConfig(updatedYaml);
+      setSaved(true);
+      toast.success("Configuration saved. Restart to apply changes.");
+    } catch (error) {
+      toast.error(`Failed to save: ${error}`);
+    } finally {
+      setSaving(false);
+    }
+  }, [
+    viseron.connection,
+    rawYamlConfig,
+    cameraIdentifier,
+    polygons,
+    setSaving,
+    setRawYamlConfig,
+    toast,
+  ]);
+
+  const handleRestart = useCallback(async () => {
+    if (!viseron.connection) return;
+    try {
+      await commands.restartViseron(viseron.connection);
+      toast.info("Viseron is restarting...");
+      stopEditing();
+    } catch (error) {
+      toast.error(`Failed to restart: ${error}`);
+    }
+  }, [viseron.connection, toast, stopEditing]);
+
+  const handleClose = useCallback(() => {
+    if (isDirty) {
+      if (!window.confirm("Discard unsaved changes?")) return;
+    }
+    stopEditing();
+  }, [isDirty, stopEditing]);
+
+  return (
+    <Paper
+      ref={paperRef}
+      elevation={6}
+      sx={{
+        position: "absolute",
+        top: position.y,
+        left: position.x,
+        zIndex: 5,
+        p: 1,
+        display: "flex",
+        flexDirection: "column",
+        gap: 1,
+        backgroundColor: "rgba(30, 30, 30, 0.92)",
+        backdropFilter: "blur(8px)",
+        maxHeight: "40%",
+        maxWidth: "calc(100% - 16px)",
+        minWidth: 280,
+        overflow: "auto",
+      }}
+    >
+      {/* Header — drag handle */}
+      <Box
+        ref={dragHandleRef}
+        onPointerDown={handleDragStart}
+        onPointerMove={handleDragMove}
+        onPointerUp={handleDragEnd}
+        display="flex"
+        alignItems="center"
+        justifyContent="space-between"
+        gap={1}
+        sx={{ cursor: "grab", userSelect: "none", touchAction: "none", "&:active": { cursor: "grabbing" } }}
+      >
+        <Typography variant="subtitle2" color="white" fontWeight="bold">
+          Mask / Zone Editor
+        </Typography>
+        <Box display="flex" gap={0.5}>
+          {isDirty && (
+            <Tooltip title="Revert changes">
+              <IconButton size="small" onClick={revert} sx={{ color: "white" }}>
+                <UndoIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          )}
+          <Tooltip title="Close editor">
+            <IconButton
+              size="small"
+              onClick={handleClose}
+              sx={{ color: "white" }}
+            >
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Box>
+      </Box>
+
+      {/* Category filter */}
+      <ToggleButtonGroup
+        value={categoryFilter}
+        exclusive
+        onChange={(_, val) => setCategoryFilter(val)}
+        size="small"
+        fullWidth
+      >
+        <ToggleButton value="motion_mask">Motion Mask</ToggleButton>
+        <ToggleButton value="object_mask">Object Mask</ToggleButton>
+        <ToggleButton value="zone">Zone</ToggleButton>
+      </ToggleButtonGroup>
+
+      {/* Polygon list */}
+      <Box display="flex" flexWrap="wrap" gap={0.5}>
+        {filteredPolygons.map((p) => (
+          <Chip
+            key={p.id}
+            label={
+              p.category === "zone" && p.name
+                ? p.name
+                : `${CATEGORY_LABELS[p.category]} ${filteredPolygons.indexOf(p) + 1}`
+            }
+            size="small"
+            onClick={() => selectPolygon(p.id)}
+            onDelete={
+              selectedPolygonId === p.id
+                ? () => deletePolygon(p.id)
+                : undefined
+            }
+            deleteIcon={<DeleteIcon />}
+            variant={selectedPolygonId === p.id ? "filled" : "outlined"}
+            sx={{
+              borderColor: CATEGORY_STROKE_COLORS[p.category],
+              color: "white",
+              "& .MuiChip-deleteIcon": { color: "rgba(255,80,80,0.8)" },
+              ...(selectedPolygonId === p.id
+                ? {
+                    backgroundColor: CATEGORY_STROKE_COLORS[p.category],
+                  }
+                : {}),
+            }}
+          />
+        ))}
+        <Tooltip title="Add polygon">
+          <IconButton
+            size="small"
+            onClick={handleAddPolygon}
+            sx={{ color: "white" }}
+          >
+            <AddIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      </Box>
+
+      {/* Zone name editor */}
+      {selectedPolygon?.category === "zone" && (
+        <TextField
+          size="small"
+          label="Zone name"
+          value={selectedPolygon.name || ""}
+          onChange={(e) =>
+            updatePolygonName(selectedPolygon.id, e.target.value)
+          }
+          sx={{
+            "& .MuiInputBase-root": { color: "white", fontSize: "0.8rem" },
+            "& .MuiInputLabel-root": { color: "rgba(255,255,255,0.6)" },
+          }}
+        />
+      )}
+
+      {/* Hints */}
+      <Typography
+        variant="caption"
+        color="rgba(255,255,255,0.5)"
+        sx={{ fontSize: "0.65rem" }}
+      >
+        Click polygon to select. Drag vertices to move. Click edge midpoint to
+        add vertex. Right-click vertex to delete.
+      </Typography>
+
+      {/* Action buttons */}
+      <Box display="flex" gap={1} justifyContent="flex-end">
+        {saved && (
+          <Button
+            size="small"
+            variant="outlined"
+            color="warning"
+            startIcon={<RestartAltIcon />}
+            onClick={handleRestart}
+          >
+            Restart
+          </Button>
+        )}
+        <Button
+          size="small"
+          variant="contained"
+          color="primary"
+          startIcon={
+            isSaving ? <CircularProgress size={16} /> : <SaveIcon />
+          }
+          onClick={handleSave}
+          disabled={!isDirty || isSaving}
+        >
+          Save
+        </Button>
+      </Box>
+    </Paper>
+  );
+}

--- a/frontend/src/components/player/polygon-editor/canvasRenderer.ts
+++ b/frontend/src/components/player/polygon-editor/canvasRenderer.ts
@@ -1,0 +1,218 @@
+import {
+  CATEGORY_COLORS,
+  CATEGORY_LABELS,
+  CATEGORY_STROKE_COLORS,
+  CoordinateTransform,
+  Polygon,
+} from "./types";
+
+const VERTEX_RADIUS = 6;
+const SELECTED_VERTEX_RADIUS = 8;
+const EDGE_HIT_DISTANCE = 8;
+
+function isPointInPolygon(
+  x: number,
+  y: number,
+  points: { x: number; y: number }[],
+): boolean {
+  let inside = false;
+  for (let i = 0, j = points.length - 1; i < points.length; j = i++) {
+    const xi = points[i].x;
+    const yi = points[i].y;
+    const xj = points[j].x;
+    const yj = points[j].y;
+
+    if (yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+function drawSinglePolygon(
+  ctx: CanvasRenderingContext2D,
+  polygon: Polygon,
+  transform: CoordinateTransform,
+  isSelected: boolean,
+  hoveredVertexInfo: { polygonId: string; vertexIndex: number } | null,
+): void {
+  const displayPoints = polygon.points.map((p) => transform.toDisplay(p));
+
+  if (displayPoints.length < 2) return;
+
+  // Fill
+  ctx.beginPath();
+  ctx.moveTo(displayPoints[0].x, displayPoints[0].y);
+  for (let i = 1; i < displayPoints.length; i++) {
+    ctx.lineTo(displayPoints[i].x, displayPoints[i].y);
+  }
+  ctx.closePath();
+
+  const fillColor = isSelected
+    ? CATEGORY_COLORS[polygon.category].replace("0.35", "0.45")
+    : CATEGORY_COLORS[polygon.category];
+  ctx.fillStyle = fillColor;
+  ctx.fill();
+
+  // Stroke
+  ctx.strokeStyle = CATEGORY_STROKE_COLORS[polygon.category];
+  ctx.lineWidth = isSelected ? 3 : 2;
+  if (!isSelected) {
+    ctx.setLineDash([6, 4]);
+  } else {
+    ctx.setLineDash([]);
+  }
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  // Label
+  if (displayPoints.length >= 3) {
+    const centerX =
+      displayPoints.reduce((s, p) => s + p.x, 0) / displayPoints.length;
+    const centerY =
+      displayPoints.reduce((s, p) => s + p.y, 0) / displayPoints.length;
+
+    const label =
+      polygon.category === "zone" && polygon.name
+        ? polygon.name
+        : CATEGORY_LABELS[polygon.category];
+
+    ctx.font = "bold 12px sans-serif";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+
+    const metrics = ctx.measureText(label);
+    const textHeight = 16;
+    ctx.fillStyle = "rgba(0, 0, 0, 0.6)";
+    ctx.fillRect(
+      centerX - metrics.width / 2 - 4,
+      centerY - textHeight / 2 - 2,
+      metrics.width + 8,
+      textHeight + 4,
+    );
+
+    ctx.fillStyle = "#ffffff";
+    ctx.fillText(label, centerX, centerY);
+  }
+
+  // Vertices (only for selected polygon)
+  if (isSelected) {
+    for (let i = 0; i < displayPoints.length; i++) {
+      const isHovered =
+        hoveredVertexInfo?.polygonId === polygon.id &&
+        hoveredVertexInfo?.vertexIndex === i;
+      const radius = isHovered ? SELECTED_VERTEX_RADIUS : VERTEX_RADIUS;
+
+      ctx.beginPath();
+      ctx.arc(
+        displayPoints[i].x,
+        displayPoints[i].y,
+        radius,
+        0,
+        Math.PI * 2,
+      );
+      ctx.fillStyle = isHovered ? "#ffff00" : "#ffffff";
+      ctx.fill();
+      ctx.strokeStyle = CATEGORY_STROKE_COLORS[polygon.category];
+      ctx.lineWidth = 2;
+      ctx.stroke();
+
+      ctx.font = "bold 10px sans-serif";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillStyle = "#000000";
+      ctx.fillText(String(i), displayPoints[i].x, displayPoints[i].y);
+    }
+
+    // Edge midpoints (add vertex hint)
+    for (let i = 0; i < displayPoints.length; i++) {
+      const next = (i + 1) % displayPoints.length;
+      const midX = (displayPoints[i].x + displayPoints[next].x) / 2;
+      const midY = (displayPoints[i].y + displayPoints[next].y) / 2;
+
+      ctx.beginPath();
+      ctx.arc(midX, midY, 4, 0, Math.PI * 2);
+      ctx.fillStyle = "rgba(255, 255, 255, 0.5)";
+      ctx.fill();
+      ctx.strokeStyle = CATEGORY_STROKE_COLORS[polygon.category];
+      ctx.lineWidth = 1;
+      ctx.stroke();
+    }
+  }
+}
+
+export function drawPolygons(
+  ctx: CanvasRenderingContext2D,
+  polygons: Polygon[],
+  transform: CoordinateTransform,
+  selectedPolygonId: string | null,
+  hoveredVertexInfo: { polygonId: string; vertexIndex: number } | null,
+): void {
+  ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+
+  // Draw non-selected polygons first, then selected on top
+  const sorted = [...polygons].sort((a, b) => {
+    if (a.id === selectedPolygonId) return 1;
+    if (b.id === selectedPolygonId) return -1;
+    return 0;
+  });
+
+  sorted.forEach((polygon) => {
+    const isSelected = polygon.id === selectedPolygonId;
+    drawSinglePolygon(ctx, polygon, transform, isSelected, hoveredVertexInfo);
+  });
+}
+
+export function findNearVertex(
+  x: number,
+  y: number,
+  polygon: Polygon,
+  transform: CoordinateTransform,
+  threshold = SELECTED_VERTEX_RADIUS + 4,
+): number {
+  const displayPoints = polygon.points.map((p) => transform.toDisplay(p));
+  for (let i = 0; i < displayPoints.length; i++) {
+    const dx = x - displayPoints[i].x;
+    const dy = y - displayPoints[i].y;
+    if (Math.sqrt(dx * dx + dy * dy) <= threshold) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+export function findNearEdgeMidpoint(
+  x: number,
+  y: number,
+  polygon: Polygon,
+  transform: CoordinateTransform,
+): number {
+  const displayPoints = polygon.points.map((p) => transform.toDisplay(p));
+  for (let i = 0; i < displayPoints.length; i++) {
+    const next = (i + 1) % displayPoints.length;
+    const midX = (displayPoints[i].x + displayPoints[next].x) / 2;
+    const midY = (displayPoints[i].y + displayPoints[next].y) / 2;
+    const dx = x - midX;
+    const dy = y - midY;
+    if (Math.sqrt(dx * dx + dy * dy) <= EDGE_HIT_DISTANCE) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+export function findPolygonAtPoint(
+  x: number,
+  y: number,
+  polygons: Polygon[],
+  transform: CoordinateTransform,
+): string | null {
+  for (let pi = polygons.length - 1; pi >= 0; pi--) {
+    const polygon = polygons[pi];
+    const displayPoints = polygon.points.map((p) => transform.toDisplay(p));
+    if (isPointInPolygon(x, y, displayPoints)) {
+      return polygon.id;
+    }
+  }
+  return null;
+}

--- a/frontend/src/components/player/polygon-editor/configParser.ts
+++ b/frontend/src/components/player/polygon-editor/configParser.ts
@@ -1,0 +1,290 @@
+import yaml from "js-yaml";
+import { v4 as uuidv4 } from "uuid";
+
+import { Point, Polygon, PolygonCategory } from "./types";
+
+interface YamlCoordinate {
+  x: number;
+  y: number;
+}
+
+interface YamlMaskEntry {
+  coordinates: YamlCoordinate[];
+}
+
+interface YamlZoneEntry {
+  name: string;
+  coordinates: YamlCoordinate[];
+  labels?: Array<Record<string, unknown>>;
+}
+
+function extractPolygonsFromComponent(
+  componentKey: string,
+  component: Record<string, unknown>,
+  cameraIdentifier: string,
+  polygons: Polygon[],
+): void {
+  // Check for motion_detector
+  if (component.motion_detector) {
+    const md = component.motion_detector as Record<string, unknown>;
+    const cameras = md.cameras as Record<string, unknown> | undefined;
+    if (cameras && cameras[cameraIdentifier]) {
+      const camConfig = cameras[cameraIdentifier] as Record<string, unknown>;
+      if (Array.isArray(camConfig.mask)) {
+        for (const maskEntry of camConfig.mask as YamlMaskEntry[]) {
+          if (Array.isArray(maskEntry.coordinates)) {
+            polygons.push({
+              id: uuidv4(),
+              category: "motion_mask",
+              componentKey,
+              points: maskEntry.coordinates.map((c) => ({ x: c.x, y: c.y })),
+            });
+          }
+        }
+      }
+    }
+  }
+
+  // Check for object_detector
+  if (component.object_detector) {
+    const od = component.object_detector as Record<string, unknown>;
+    const cameras = od.cameras as Record<string, unknown> | undefined;
+    if (cameras && cameras[cameraIdentifier]) {
+      const camConfig = cameras[cameraIdentifier] as Record<string, unknown>;
+
+      if (Array.isArray(camConfig.mask)) {
+        for (const maskEntry of camConfig.mask as YamlMaskEntry[]) {
+          if (Array.isArray(maskEntry.coordinates)) {
+            polygons.push({
+              id: uuidv4(),
+              category: "object_mask",
+              componentKey,
+              points: maskEntry.coordinates.map((c) => ({ x: c.x, y: c.y })),
+            });
+          }
+        }
+      }
+
+      if (Array.isArray(camConfig.zones)) {
+        for (const zoneEntry of camConfig.zones as YamlZoneEntry[]) {
+          if (Array.isArray(zoneEntry.coordinates)) {
+            polygons.push({
+              id: uuidv4(),
+              category: "zone",
+              componentKey,
+              name: zoneEntry.name,
+              labels: zoneEntry.labels,
+              points: zoneEntry.coordinates.map((c) => ({ x: c.x, y: c.y })),
+            });
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Parse all polygons (masks and zones) for a given camera from YAML config.
+ * Scans all top-level components for motion_detector and object_detector domains.
+ */
+export function parsePolygonsFromConfig(
+  yamlString: string,
+  cameraIdentifier: string,
+): Polygon[] {
+  const config = yaml.load(yamlString) as Record<string, unknown>;
+  if (!config || typeof config !== "object") return [];
+
+  const polygons: Polygon[] = [];
+
+  Object.entries(config).forEach(([componentKey, componentValue]) => {
+    if (componentValue && typeof componentValue === "object") {
+      extractPolygonsFromComponent(
+        componentKey,
+        componentValue as Record<string, unknown>,
+        cameraIdentifier,
+        polygons,
+      );
+    }
+  });
+
+  return polygons;
+}
+
+function buildMaskArray(polygons: Polygon[]): YamlMaskEntry[] {
+  return polygons.map((p) => ({
+    coordinates: p.points.map((pt) => ({ x: pt.x, y: pt.y })),
+  }));
+}
+
+function buildZonesArray(polygons: Polygon[]): YamlZoneEntry[] {
+  return polygons.map((p) => ({
+    name: p.name || `zone_${p.id.slice(0, 6)}`,
+    coordinates: p.points.map((pt) => ({ x: pt.x, y: pt.y })),
+    ...(p.labels ? { labels: p.labels } : {}),
+  }));
+}
+
+function updateComponentMasks(
+  component: Record<string, unknown>,
+  componentKey: string,
+  cameraIdentifier: string,
+  grouped: Map<
+    string,
+    { motion_mask: Polygon[]; object_mask: Polygon[]; zone: Polygon[] }
+  >,
+): void {
+  if (component.motion_detector) {
+    const md = component.motion_detector as Record<string, unknown>;
+    const cameras = md.cameras as Record<string, unknown> | undefined;
+    if (cameras && cameras[cameraIdentifier]) {
+      const camConfig = cameras[cameraIdentifier] as Record<string, unknown>;
+      const group = grouped.get(componentKey);
+      const motionMasks = group?.motion_mask || [];
+
+      if (motionMasks.length > 0) {
+        camConfig.mask = buildMaskArray(motionMasks);
+      } else {
+        delete camConfig.mask;
+      }
+    }
+  }
+
+  if (component.object_detector) {
+    const od = component.object_detector as Record<string, unknown>;
+    const cameras = od.cameras as Record<string, unknown> | undefined;
+    if (cameras && cameras[cameraIdentifier]) {
+      const camConfig = cameras[cameraIdentifier] as Record<string, unknown>;
+      const group = grouped.get(componentKey);
+
+      const objectMasks = group?.object_mask || [];
+      if (objectMasks.length > 0) {
+        camConfig.mask = buildMaskArray(objectMasks);
+      } else {
+        delete camConfig.mask;
+      }
+
+      const zones = group?.zone || [];
+      if (zones.length > 0) {
+        camConfig.zones = buildZonesArray(zones);
+      } else {
+        delete camConfig.zones;
+      }
+    }
+  }
+}
+
+/**
+ * Update the YAML config string with modified polygons for a camera.
+ */
+export function updateConfigWithPolygons(
+  yamlString: string,
+  cameraIdentifier: string,
+  polygons: Polygon[],
+): string {
+  const config = yaml.load(yamlString) as Record<string, unknown>;
+  if (!config || typeof config !== "object") return yamlString;
+
+  const grouped = new Map<
+    string,
+    { motion_mask: Polygon[]; object_mask: Polygon[]; zone: Polygon[] }
+  >();
+
+  for (const poly of polygons) {
+    if (!grouped.has(poly.componentKey)) {
+      grouped.set(poly.componentKey, {
+        motion_mask: [],
+        object_mask: [],
+        zone: [],
+      });
+    }
+    grouped.get(poly.componentKey)![poly.category].push(poly);
+  }
+
+  Object.entries(config).forEach(([componentKey, componentValue]) => {
+    if (componentValue && typeof componentValue === "object") {
+      updateComponentMasks(
+        componentValue as Record<string, unknown>,
+        componentKey,
+        cameraIdentifier,
+        grouped,
+      );
+    }
+  });
+
+  return yaml.dump(config, {
+    indent: 2,
+    lineWidth: -1,
+    noRefs: true,
+    sortKeys: false,
+  });
+}
+
+/**
+ * Detect which components are available for each category.
+ */
+export function detectComponents(
+  yamlString: string,
+  cameraIdentifier: string,
+): {
+  motionComponent: string | null;
+  objectComponent: string | null;
+} {
+  const config = yaml.load(yamlString) as Record<string, unknown>;
+  if (!config || typeof config !== "object")
+    return { motionComponent: null, objectComponent: null };
+
+  let motionComponent: string | null = null;
+  let objectComponent: string | null = null;
+
+  Object.entries(config).forEach(([componentKey, componentValue]) => {
+    if (!componentValue || typeof componentValue !== "object") return;
+    const component = componentValue as Record<string, unknown>;
+
+    if (component.motion_detector && !motionComponent) {
+      const md = component.motion_detector as Record<string, unknown>;
+      const cameras = md.cameras as Record<string, unknown> | undefined;
+      if (cameras && cameras[cameraIdentifier]) {
+        motionComponent = componentKey;
+      }
+    }
+
+    if (component.object_detector && !objectComponent) {
+      const od = component.object_detector as Record<string, unknown>;
+      const cameras = od.cameras as Record<string, unknown> | undefined;
+      if (cameras && cameras[cameraIdentifier]) {
+        objectComponent = componentKey;
+      }
+    }
+  });
+
+  return { motionComponent, objectComponent };
+}
+
+/**
+ * Create a default polygon centered in the camera frame.
+ */
+export function createDefaultPolygon(
+  category: PolygonCategory,
+  componentKey: string,
+  cameraWidth: number,
+  cameraHeight: number,
+): Polygon {
+  const cx = Math.round(cameraWidth / 2);
+  const cy = Math.round(cameraHeight / 2);
+  const size = Math.round(Math.min(cameraWidth, cameraHeight) / 6);
+
+  const points: Point[] = [
+    { x: cx - size, y: cy - size },
+    { x: cx + size, y: cy - size },
+    { x: cx + size, y: cy + size },
+    { x: cx - size, y: cy + size },
+  ];
+
+  return {
+    id: uuidv4(),
+    category,
+    componentKey,
+    points,
+    ...(category === "zone" ? { name: `zone_${Date.now().toString(36)}` } : {}),
+  };
+}

--- a/frontend/src/components/player/polygon-editor/index.ts
+++ b/frontend/src/components/player/polygon-editor/index.ts
@@ -1,0 +1,4 @@
+export { PolygonEditorButton } from "./PolygonEditorButton";
+export { PolygonEditorOverlay } from "./PolygonEditorOverlay";
+export { usePolygonEditorStore } from "./usePolygonEditorStore";
+export { useCoordinateTransform } from "./useCoordinateTransform";

--- a/frontend/src/components/player/polygon-editor/types.ts
+++ b/frontend/src/components/player/polygon-editor/types.ts
@@ -1,0 +1,43 @@
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export type PolygonCategory = "motion_mask" | "object_mask" | "zone";
+
+export interface Polygon {
+  id: string;
+  category: PolygonCategory;
+  name?: string;
+  points: Point[];
+  // Preserve zone labels config for round-tripping
+  labels?: Array<Record<string, unknown>>;
+  // Track which component this came from
+  componentKey: string;
+}
+
+export interface CoordinateTransform {
+  toDisplay: (p: Point) => { x: number; y: number };
+  toCamera: (dx: number, dy: number) => Point;
+  scale: number;
+  offsetX: number;
+  offsetY: number;
+}
+
+export const CATEGORY_COLORS: Record<PolygonCategory, string> = {
+  motion_mask: "rgba(255, 60, 60, 0.35)",
+  object_mask: "rgba(60, 120, 255, 0.35)",
+  zone: "rgba(60, 200, 60, 0.35)",
+};
+
+export const CATEGORY_STROKE_COLORS: Record<PolygonCategory, string> = {
+  motion_mask: "rgba(255, 60, 60, 0.9)",
+  object_mask: "rgba(60, 120, 255, 0.9)",
+  zone: "rgba(60, 200, 60, 0.9)",
+};
+
+export const CATEGORY_LABELS: Record<PolygonCategory, string> = {
+  motion_mask: "Motion Mask",
+  object_mask: "Object Mask",
+  zone: "Zone",
+};

--- a/frontend/src/components/player/polygon-editor/useCoordinateTransform.ts
+++ b/frontend/src/components/player/polygon-editor/useCoordinateTransform.ts
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { CoordinateTransform, Point } from "./types";
+
+/**
+ * Computes coordinate transform between camera-resolution coordinates
+ * and display coordinates, accounting for object-fit: contain letterboxing.
+ */
+export function useCoordinateTransform(
+  containerRef: React.RefObject<HTMLElement | null>,
+  cameraWidth: number,
+  cameraHeight: number,
+): CoordinateTransform {
+  const [transform, setTransform] = useState<CoordinateTransform>({
+    toDisplay: (p: Point) => p,
+    toCamera: (dx: number, dy: number) => ({ x: dx, y: dy }),
+    scale: 1,
+    offsetX: 0,
+    offsetY: 0,
+  });
+
+  const calculate = useCallback(() => {
+    const container = containerRef.current;
+    if (!container || !cameraWidth || !cameraHeight) return;
+
+    const cw = container.clientWidth;
+    const ch = container.clientHeight;
+
+    const scale = Math.min(cw / cameraWidth, ch / cameraHeight);
+    const displayWidth = cameraWidth * scale;
+    const displayHeight = cameraHeight * scale;
+    const offsetX = (cw - displayWidth) / 2;
+    const offsetY = (ch - displayHeight) / 2;
+
+    setTransform({
+      scale,
+      offsetX,
+      offsetY,
+      toDisplay: (p: Point) => ({
+        x: p.x * scale + offsetX,
+        y: p.y * scale + offsetY,
+      }),
+      toCamera: (dx: number, dy: number) => ({
+        x: Math.round(
+          Math.max(0, Math.min(cameraWidth, (dx - offsetX) / scale)),
+        ),
+        y: Math.round(
+          Math.max(0, Math.min(cameraHeight, (dy - offsetY) / scale)),
+        ),
+      }),
+    });
+  }, [containerRef, cameraWidth, cameraHeight]);
+
+  useEffect(() => {
+    calculate();
+
+    const container = containerRef.current;
+    if (!container) return () => {};
+
+    const observer = new ResizeObserver(() => {
+      calculate();
+    });
+    observer.observe(container);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [calculate, containerRef]);
+
+  return transform;
+}

--- a/frontend/src/components/player/polygon-editor/usePolygonEditorStore.ts
+++ b/frontend/src/components/player/polygon-editor/usePolygonEditorStore.ts
@@ -1,0 +1,148 @@
+import { create } from "zustand";
+
+import { Point, Polygon } from "./types";
+
+interface PolygonEditorState {
+  isEditing: boolean;
+  polygons: Polygon[];
+  originalPolygons: Polygon[];
+  selectedPolygonId: string | null;
+  hoveredVertexInfo: { polygonId: string; vertexIndex: number } | null;
+  isDirty: boolean;
+  isSaving: boolean;
+  rawYamlConfig: string | null;
+  cameraIdentifier: string | null;
+
+  // Actions
+  startEditing: (
+    cameraId: string,
+    config: string,
+    polygons: Polygon[],
+  ) => void;
+  stopEditing: () => void;
+  selectPolygon: (id: string | null) => void;
+  moveVertex: (polygonId: string, vertexIndex: number, newPoint: Point) => void;
+  addVertex: (polygonId: string, afterIndex: number, point: Point) => void;
+  deleteVertex: (polygonId: string, vertexIndex: number) => void;
+  addPolygon: (polygon: Polygon) => void;
+  deletePolygon: (id: string) => void;
+  updatePolygonName: (id: string, name: string) => void;
+  revert: () => void;
+  setSaving: (saving: boolean) => void;
+  setRawYamlConfig: (config: string) => void;
+}
+
+export const usePolygonEditorStore = create<PolygonEditorState>((set) => ({
+  isEditing: false,
+  polygons: [],
+  originalPolygons: [],
+  selectedPolygonId: null,
+  hoveredVertexInfo: null,
+  isDirty: false,
+  isSaving: false,
+  rawYamlConfig: null,
+  cameraIdentifier: null,
+
+  startEditing: (cameraId, config, polygons) =>
+    set({
+      isEditing: true,
+      cameraIdentifier: cameraId,
+      rawYamlConfig: config,
+      polygons,
+      originalPolygons: JSON.parse(JSON.stringify(polygons)),
+      selectedPolygonId: null,
+      isDirty: false,
+      isSaving: false,
+    }),
+
+  stopEditing: () =>
+    set({
+      isEditing: false,
+      polygons: [],
+      originalPolygons: [],
+      selectedPolygonId: null,
+      hoveredVertexInfo: null,
+      isDirty: false,
+      isSaving: false,
+      rawYamlConfig: null,
+      cameraIdentifier: null,
+    }),
+
+  selectPolygon: (id) => set({ selectedPolygonId: id }),
+
+  moveVertex: (polygonId, vertexIndex, newPoint) =>
+    set((state) => ({
+      polygons: state.polygons.map((p) =>
+        p.id === polygonId
+          ? {
+              ...p,
+              points: p.points.map((pt, i) =>
+                i === vertexIndex ? newPoint : pt,
+              ),
+            }
+          : p,
+      ),
+      isDirty: true,
+    })),
+
+  addVertex: (polygonId, afterIndex, point) =>
+    set((state) => ({
+      polygons: state.polygons.map((p) =>
+        p.id === polygonId
+          ? {
+              ...p,
+              points: [
+                ...p.points.slice(0, afterIndex + 1),
+                point,
+                ...p.points.slice(afterIndex + 1),
+              ],
+            }
+          : p,
+      ),
+      isDirty: true,
+    })),
+
+  deleteVertex: (polygonId, vertexIndex) =>
+    set((state) => ({
+      polygons: state.polygons.map((p) => {
+        if (p.id !== polygonId || p.points.length <= 3) return p;
+        return {
+          ...p,
+          points: p.points.filter((_, i) => i !== vertexIndex),
+        };
+      }),
+      isDirty: true,
+    })),
+
+  addPolygon: (polygon) =>
+    set((state) => ({
+      polygons: [...state.polygons, polygon],
+      selectedPolygonId: polygon.id,
+      isDirty: true,
+    })),
+
+  deletePolygon: (id) =>
+    set((state) => ({
+      polygons: state.polygons.filter((p) => p.id !== id),
+      selectedPolygonId:
+        state.selectedPolygonId === id ? null : state.selectedPolygonId,
+      isDirty: true,
+    })),
+
+  updatePolygonName: (id, name) =>
+    set((state) => ({
+      polygons: state.polygons.map((p) => (p.id === id ? { ...p, name } : p)),
+      isDirty: true,
+    })),
+
+  revert: () =>
+    set((state) => ({
+      polygons: JSON.parse(JSON.stringify(state.originalPolygons)),
+      selectedPolygonId: null,
+      isDirty: false,
+    })),
+
+  setSaving: (saving) => set({ isSaving: saving }),
+
+  setRawYamlConfig: (config) => set({ rawYamlConfig: config }),
+}));

--- a/frontend/src/pages/Live.tsx
+++ b/frontend/src/pages/Live.tsx
@@ -53,6 +53,12 @@ import { LivePlayer } from "components/player/liveplayer/LivePlayer";
 import { VideoRTC } from "components/player/liveplayer/video-rtc";
 import { MjpegPlayer } from "components/player/mjpegplayer/MjpegPlayer";
 import { ViewSpeedDial } from "components/player/view/ViewSpeedDial";
+import {
+  PolygonEditorButton,
+  PolygonEditorOverlay,
+  useCoordinateTransform,
+  usePolygonEditorStore,
+} from "components/player/polygon-editor";
 import { useFullscreen } from "context/FullscreenContext";
 import { useHasCamerasConfigured } from "hooks/UseHasCamerasConfigured";
 import { useTitle } from "hooks/UseTitle";
@@ -676,6 +682,10 @@ const CameraPlayer = memo(
       () => playerRef || createRef<VideoRTC>(),
       [playerRef],
     );
+    const playerContainerRef = useRef<React.RefObject<HTMLDivElement | null>>(
+      null,
+    );
+    const [, forceUpdate] = useState(0);
 
     const handleMenuOpen = useCallback(
       (event: React.MouseEvent<HTMLElement>) => {
@@ -715,7 +725,6 @@ const CameraPlayer = memo(
       flipView,
     } = usePlayerSettingsStore(
       useShallow((state) => ({
-        // mjpegPlayer defaults to true if live_stream_available is false, otherwise true
         mjpegPlayer: !camera.live_stream_available
           ? true
           : (state.mjpegPlayerMap[camera.identifier] ?? false),
@@ -730,10 +739,53 @@ const CameraPlayer = memo(
       })),
     );
 
+    const isEditing = usePolygonEditorStore((s) => s.isEditing);
+    const editingCameraId = usePolygonEditorStore((s) => s.cameraIdentifier);
+    const isEditingThisCamera =
+      isEditing && editingCameraId === camera.identifier;
+
+    const handleContainerRef = useCallback(
+      (ref: React.RefObject<HTMLDivElement | null>) => {
+        playerContainerRef.current = ref;
+        forceUpdate((n) => n + 1);
+      },
+      [],
+    );
+
+    const transform = useCoordinateTransform(
+      playerContainerRef.current || { current: null },
+      camera.width,
+      camera.height,
+    );
+
+    const editorButton = useMemo(
+      () => <PolygonEditorButton camera={camera} />,
+      [camera],
+    );
+
     const playerMenuButton = useMemo(
       () => <PlayerMenu onMenuOpen={handleMenuOpen} />,
       [handleMenuOpen],
     );
+
+    const extraButtons = useMemo(
+      () => (
+        <>
+          {editorButton}
+          {playerMenuButton}
+        </>
+      ),
+      [editorButton, playerMenuButton],
+    );
+
+    const overlay = isEditingThisCamera ? (
+      <PolygonEditorOverlay
+        containerRef={playerContainerRef.current || { current: null }}
+        transform={transform}
+        cameraWidth={camera.width}
+        cameraHeight={camera.height}
+      />
+    ) : null;
 
     return mjpegPlayer ? (
       <div
@@ -761,9 +813,11 @@ const CameraPlayer = memo(
           drawZones={drawZones}
           drawPostProcessorMask={drawPostProcessorMask}
           flipView={flipView}
-          isMenuOpen={isMenuOpen}
-          extraButtons={playerMenuButton}
+          isMenuOpen={isMenuOpen || isEditingThisCamera}
+          extraButtons={extraButtons}
           onPlayerFullscreenChange={handlePlayerFullscreenChange}
+          overlay={overlay}
+          containerRefCallback={handleContainerRef}
         />
       </div>
     ) : (
@@ -787,9 +841,11 @@ const CameraPlayer = memo(
             backgroundColor: theme.palette.background.default,
           }}
           flipView={flipView}
-          isMenuOpen={isMenuOpen}
-          extraButtons={playerMenuButton}
+          isMenuOpen={isMenuOpen || isEditingThisCamera}
+          extraButtons={extraButtons}
           onPlayerFullscreenChange={handlePlayerFullscreenChange}
+          overlay={overlay}
+          containerRefCallback={handleContainerRef}
         />
       </div>
     );


### PR DESCRIPTION
## Summary

Adds a visual editor overlaid on each camera's live view for editing **motion masks, object detector masks, and zones** directly in the browser, instead of hand-editing `config.yaml`.

A settings button on each player opens a draggable toolbar and a canvas overlay drawn over the live stream showing the existing polygons. Vertices can be:

- **dragged** (with pointer capture, so tracking continues outside the canvas),
- **added** by clicking edge midpoints,
- **removed** via right-click.

Coordinates are clamped to image bounds and snap to edges when close. Saving serializes the updated polygons back into the config and persists it via the existing `save_config` websocket command, then restarts Viseron to apply.

## Implementation

Frontend-only. New, self-contained module under `frontend/src/components/player/polygon-editor/` (canvas, toolbar, button, overlay, config parser, zustand store, coordinate-transform hook, types). Three existing files are wired to mount the overlay/toolbar:

- `LivePlayer.tsx` / `MjpegPlayer.tsx` — new optional `overlay` and `containerRefCallback` props (no behavior change when unset).
- `Live.tsx` — opens the editor per camera and feeds the overlay.

It reuses the existing `get_config` / `save_config` / `restart_viseron` websocket commands — no backend changes.

## Testing

- `npm run build` (`tsc && vite build`) passes.
- `npm run lint:eslint` passes (0 errors).

## Notes for reviewers

- **Config persistence is a full-file overwrite.** `save_config` writes the entire `config.yaml`, so the editor's config parser round-trips the whole file. Reviewers may want to confirm comment/formatting preservation is acceptable for their setup.
- `PolygonEditorToolbar.tsx` uses `window.confirm` for a destructive action (flagged by `no-alert` as a warning); happy to swap it for an MUI dialog if preferred.
- Maintainers: this was developed against an earlier `dev` and rebased onto current `dev`; I'd appreciate a sanity check on the merge into the reworked player components.