### PR TITLE
Add camera configuration UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { lazy } from "react";
 import { Navigate, useRoutes } from "react-router-dom";
 
 const Cameras = lazy(() => import("pages/Cameras"));
+const CamerasSettings = lazy(() => import("pages/settings/Cameras"));
 const Tuning = lazy(() => import("pages/Tuning"));
 const CameraRecordings = lazy(
   () => import("pages/recordings/CameraRecordings"),
@@ -91,6 +92,10 @@ function App() {
                 {
                   path: "/settings/configuration",
                   element: <Configuration />,
+                },
+                {
+                  path: "/settings/cameras",
+                  element: <CamerasSettings />,
                 },
                 {
                   path: "/settings/users",

--- a/frontend/src/components/camera/AddCameraDialog.tsx
+++ b/frontend/src/components/camera/AddCameraDialog.tsx
@@ -27,11 +27,37 @@ type AddCameraDialogProps = {
 };
 
 const PATH_PRESETS = [
-  { label: "Hikvision main", value: "/Streaming/Channels/101/" },
-  { label: "Hikvision sub", value: "/Streaming/Channels/102/" },
-  { label: "Dahua main", value: "/cam/realmonitor?channel=1&subtype=0" },
-  { label: "Dahua sub", value: "/cam/realmonitor?channel=1&subtype=1" },
-  { label: "Generic", value: "/" },
+  {
+    label: "Mobotix HTTP live",
+    path: "/control/faststream.jpg?stream=full&fps=10",
+    port: 80,
+    stream_format: "mjpeg" as const,
+  },
+  {
+    label: "Hikvision main",
+    path: "/Streaming/Channels/101/",
+    port: 554,
+    stream_format: "rtsp" as const,
+  },
+  {
+    label: "Hikvision sub",
+    path: "/Streaming/Channels/102/",
+    port: 554,
+    stream_format: "rtsp" as const,
+  },
+  {
+    label: "Dahua main",
+    path: "/cam/realmonitor?channel=1&subtype=0",
+    port: 554,
+    stream_format: "rtsp" as const,
+  },
+  {
+    label: "Dahua sub",
+    path: "/cam/realmonitor?channel=1&subtype=1",
+    port: 554,
+    stream_format: "rtsp" as const,
+  },
+  { label: "Generic", path: "/", port: 554, stream_format: "rtsp" as const },
 ];
 
 const identifierFromName = (name: string) =>
@@ -162,15 +188,32 @@ export function AddCameraDialog({ open, onClose }: AddCameraDialogProps) {
           </Grid>
           <Grid size={{ xs: 12, md: 5 }}>
             <FormControl fullWidth>
-              <InputLabel id="camera-path-preset-label">RTSP Path</InputLabel>
+              <InputLabel id="camera-path-preset-label">Preset</InputLabel>
               <Select
                 labelId="camera-path-preset-label"
-                label="RTSP Path"
-                value={form.path}
-                onChange={(event) => updateForm("path", event.target.value)}
+                label="Preset"
+                value={
+                  PATH_PRESETS.find(
+                    (preset) =>
+                      preset.path === form.path &&
+                      preset.port === form.port &&
+                      preset.stream_format === form.stream_format,
+                  )?.label || ""
+                }
+                onChange={(event) => {
+                  const preset = PATH_PRESETS.find(
+                    (item) => item.label === event.target.value,
+                  );
+                  if (!preset) {
+                    return;
+                  }
+                  updateForm("path", preset.path);
+                  updateForm("port", preset.port);
+                  updateForm("stream_format", preset.stream_format);
+                }}
               >
                 {PATH_PRESETS.map((preset) => (
-                  <MenuItem key={preset.label} value={preset.value}>
+                  <MenuItem key={preset.label} value={preset.label}>
                     {preset.label}
                   </MenuItem>
                 ))}
@@ -184,6 +227,27 @@ export function AddCameraDialog({ open, onClose }: AddCameraDialogProps) {
               fullWidth
               onChange={(event) => updateForm("path", event.target.value)}
             />
+          </Grid>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <FormControl fullWidth>
+              <InputLabel id="camera-stream-format-label">
+                Stream format
+              </InputLabel>
+              <Select
+                labelId="camera-stream-format-label"
+                label="Stream format"
+                value={form.stream_format}
+                onChange={(event) =>
+                  updateForm(
+                    "stream_format",
+                    event.target.value as AddCameraConfigPayload["stream_format"],
+                  )
+                }
+              >
+                <MenuItem value="rtsp">RTSP</MenuItem>
+                <MenuItem value="mjpeg">MJPEG / HTTP</MenuItem>
+              </Select>
+            </FormControl>
           </Grid>
           <Grid size={{ xs: 12, md: 6 }}>
             <TextField

--- a/frontend/src/components/camera/AddCameraDialog.tsx
+++ b/frontend/src/components/camera/AddCameraDialog.tsx
@@ -1,0 +1,288 @@
+import { Add, Checkmark, Close } from "@carbon/icons-react";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Checkbox from "@mui/material/Checkbox";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import FormControl from "@mui/material/FormControl";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import Grid from "@mui/material/Grid";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+import TextField from "@mui/material/TextField";
+import { useState } from "react";
+
+import { LoadingButton } from "components/buttons/LoadingButton";
+import {
+  AddCameraConfigPayload,
+  useAddCameraConfig,
+} from "lib/api/cameras";
+
+type AddCameraDialogProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+const PATH_PRESETS = [
+  { label: "Hikvision main", value: "/Streaming/Channels/101/" },
+  { label: "Hikvision sub", value: "/Streaming/Channels/102/" },
+  { label: "Dahua main", value: "/cam/realmonitor?channel=1&subtype=0" },
+  { label: "Dahua sub", value: "/cam/realmonitor?channel=1&subtype=1" },
+  { label: "Generic", value: "/" },
+];
+
+const identifierFromName = (name: string) =>
+  name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .replace(/_+/g, "_");
+
+const initialForm: AddCameraConfigPayload = {
+  identifier: "",
+  name: "",
+  host: "",
+  port: 554,
+  path: "/Streaming/Channels/101/",
+  stream_format: "rtsp",
+  username: "",
+  password: "",
+  substream_path: "",
+  substream_port: 554,
+  substream_stream_format: "rtsp",
+  idle_timeout: 5,
+  enable_recorder: true,
+  enable_nvr: true,
+  reload: true,
+};
+
+export function AddCameraDialog({ open, onClose }: AddCameraDialogProps) {
+  const [form, setForm] = useState<AddCameraConfigPayload>(initialForm);
+  const [identifierEdited, setIdentifierEdited] = useState(false);
+
+  const addCamera = useAddCameraConfig({
+    onSuccess: () => {
+      setForm(initialForm);
+      setIdentifierEdited(false);
+      onClose();
+    },
+  });
+
+  const updateForm = <K extends keyof AddCameraConfigPayload>(
+    key: K,
+    value: AddCameraConfigPayload[K],
+  ) => {
+    setForm((current) => ({ ...current, [key]: value }));
+  };
+
+  const close = () => {
+    if (!addCamera.isPending) {
+      onClose();
+    }
+  };
+
+  const submit = () => {
+    addCamera.mutate({
+      ...form,
+      identifier: form.identifier.trim(),
+      name: form.name.trim(),
+      host: form.host.trim(),
+      path: form.path.trim(),
+      username: form.username?.trim() || null,
+      password: form.password || null,
+      substream_path: form.substream_path?.trim() || null,
+    });
+  };
+
+  const valid =
+    /^[A-Za-z0-9_]+$/.test(form.identifier) &&
+    form.name.trim().length > 0 &&
+    form.host.trim().length > 0 &&
+    form.path.trim().length > 0;
+
+  return (
+    <Dialog open={open} onClose={close} fullWidth maxWidth="md">
+      <DialogTitle>Add Camera</DialogTitle>
+      <DialogContent>
+        <Grid container spacing={2} sx={{ mt: 0.5 }}>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TextField
+              label="Name"
+              value={form.name}
+              fullWidth
+              autoFocus
+              onChange={(event) => {
+                const value = event.target.value;
+                updateForm("name", value);
+                if (!identifierEdited) {
+                  updateForm("identifier", identifierFromName(value));
+                }
+              }}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TextField
+              label="Identifier"
+              value={form.identifier}
+              fullWidth
+              helperText="Letters, numbers, and underscores"
+              error={
+                form.identifier.length > 0 &&
+                !/^[A-Za-z0-9_]+$/.test(form.identifier)
+              }
+              onChange={(event) => {
+                setIdentifierEdited(true);
+                updateForm("identifier", event.target.value);
+              }}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 8 }}>
+            <TextField
+              label="Host"
+              value={form.host}
+              fullWidth
+              onChange={(event) => updateForm("host", event.target.value)}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 4 }}>
+            <TextField
+              label="Port"
+              type="number"
+              value={form.port}
+              fullWidth
+              slotProps={{ htmlInput: { min: 1, max: 65535 } }}
+              onChange={(event) =>
+                updateForm("port", Number(event.target.value))
+              }
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 5 }}>
+            <FormControl fullWidth>
+              <InputLabel id="camera-path-preset-label">RTSP Path</InputLabel>
+              <Select
+                labelId="camera-path-preset-label"
+                label="RTSP Path"
+                value={form.path}
+                onChange={(event) => updateForm("path", event.target.value)}
+              >
+                {PATH_PRESETS.map((preset) => (
+                  <MenuItem key={preset.label} value={preset.value}>
+                    {preset.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
+          <Grid size={{ xs: 12, md: 7 }}>
+            <TextField
+              label="Path"
+              value={form.path}
+              fullWidth
+              onChange={(event) => updateForm("path", event.target.value)}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TextField
+              label="Username"
+              value={form.username}
+              fullWidth
+              onChange={(event) => updateForm("username", event.target.value)}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TextField
+              label="Password"
+              type="password"
+              value={form.password}
+              fullWidth
+              onChange={(event) => updateForm("password", event.target.value)}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 8 }}>
+            <TextField
+              label="Substream Path"
+              value={form.substream_path}
+              fullWidth
+              onChange={(event) =>
+                updateForm("substream_path", event.target.value)
+              }
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 4 }}>
+            <TextField
+              label="Substream Port"
+              type="number"
+              value={form.substream_port}
+              fullWidth
+              slotProps={{ htmlInput: { min: 1, max: 65535 } }}
+              onChange={(event) =>
+                updateForm("substream_port", Number(event.target.value))
+              }
+            />
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={form.enable_recorder}
+                    onChange={(event) =>
+                      updateForm("enable_recorder", event.target.checked)
+                    }
+                  />
+                }
+                label="Recorder"
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={form.enable_nvr}
+                    onChange={(event) =>
+                      updateForm("enable_nvr", event.target.checked)
+                    }
+                  />
+                }
+                label="NVR"
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={form.reload}
+                    onChange={(event) =>
+                      updateForm("reload", event.target.checked)
+                    }
+                  />
+                }
+                label="Reload"
+              />
+            </Box>
+          </Grid>
+        </Grid>
+      </DialogContent>
+      <DialogActions>
+        <Button startIcon={<Close />} onClick={close}>
+          Cancel
+        </Button>
+        <LoadingButton
+          icon={addCamera.isSuccess ? <Checkmark /> : <Add />}
+          text="Add Camera"
+          state={
+            addCamera.isPending
+              ? "loading"
+              : addCamera.isError
+                ? "error"
+                : addCamera.isSuccess
+                  ? "success"
+                  : "normal"
+          }
+          variant="contained"
+          onClick={valid ? submit : undefined}
+        />
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/camera/CameraEditDialog.tsx
+++ b/frontend/src/components/camera/CameraEditDialog.tsx
@@ -1,0 +1,614 @@
+import { Checkmark, Close, Save, TrashCan } from "@carbon/icons-react";
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Checkbox from "@mui/material/Checkbox";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import FormControl from "@mui/material/FormControl";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import Grid from "@mui/material/Grid";
+import InputLabel from "@mui/material/InputLabel";
+import ListItemText from "@mui/material/ListItemText";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import { useEffect, useMemo, useState } from "react";
+
+import { LoadingButton } from "components/buttons/LoadingButton";
+import { ErrorMessage } from "components/error/ErrorMessage";
+import { Loading } from "components/loading/Loading";
+import {
+  useCameraAccessConfig,
+  useSaveCameraAccessConfig,
+} from "lib/api/cameraAccess";
+import {
+  CameraConfigPayload,
+  useCameraConfig,
+  useDeleteCameraConfig,
+  useUpdateCameraConfig,
+} from "lib/api/cameras";
+import * as types from "lib/types";
+
+type CameraEditDialogProps = {
+  camera: types.Camera | types.FailedCamera;
+  onClose: () => void;
+};
+
+const PATH_PRESETS = [
+  {
+    label: "Mobotix HTTP live",
+    path: "/control/faststream.jpg?stream=full&fps=10",
+    port: 80,
+    stream_format: "mjpeg" as const,
+  },
+  {
+    label: "Mobotix snapshot",
+    path: "/record/current.jpg",
+    port: 80,
+    stream_format: "mjpeg" as const,
+  },
+  {
+    label: "Hikvision main",
+    path: "/Streaming/Channels/101/",
+    port: 554,
+    stream_format: "rtsp" as const,
+  },
+  {
+    label: "Hikvision sub",
+    path: "/Streaming/Channels/102/",
+    port: 554,
+    stream_format: "rtsp" as const,
+  },
+  {
+    label: "Dahua main",
+    path: "/cam/realmonitor?channel=1&subtype=0",
+    port: 554,
+    stream_format: "rtsp" as const,
+  },
+  {
+    label: "Dahua sub",
+    path: "/cam/realmonitor?channel=1&subtype=1",
+    port: 554,
+    stream_format: "rtsp" as const,
+  },
+];
+
+const EMPTY_FORM: CameraConfigPayload = {
+  name: "",
+  host: "",
+  port: 554,
+  path: "",
+  stream_format: "rtsp",
+  username: "",
+  password: "",
+  substream_path: "",
+  substream_port: 554,
+  substream_stream_format: "rtsp",
+  fps: null,
+  idle_timeout: 5,
+  enable_recorder: true,
+  enable_nvr: true,
+  record_only: false,
+  width: null,
+  height: null,
+  video_filters: [],
+  reload: true,
+};
+
+function videoFiltersToText(videoFilters: string[] | undefined) {
+  return (videoFilters || []).join("\n");
+}
+
+function textToVideoFilters(value: string) {
+  return value
+    .split("\n")
+    .map((videoFilter) => videoFilter.trim())
+    .filter(Boolean);
+}
+
+function numberOrNull(value: string) {
+  if (value.trim() === "") {
+    return null;
+  }
+  return Number(value);
+}
+
+function updateCameraGroups(
+  config: types.CameraAccessConfig,
+  cameraIdentifier: string,
+  selectedGroupIds: string[],
+) {
+  const selected = new Set(selectedGroupIds);
+  return {
+    ...config,
+    camera_groups: config.camera_groups.map((group) => {
+      const cameras = new Set(group.cameras);
+      if (selected.has(group.id)) {
+        cameras.add(cameraIdentifier);
+      } else {
+        cameras.delete(cameraIdentifier);
+      }
+      return { ...group, cameras: Array.from(cameras).sort() };
+    }),
+  };
+}
+
+export function CameraEditDialog({ camera, onClose }: CameraEditDialogProps) {
+  const cameraConfig = useCameraConfig(camera.identifier);
+  const cameraAccessConfig = useCameraAccessConfig();
+  const updateCameraConfig = useUpdateCameraConfig();
+  const deleteCameraConfig = useDeleteCameraConfig();
+  const saveCameraAccessConfig = useSaveCameraAccessConfig();
+  const [form, setForm] = useState<CameraConfigPayload>(EMPTY_FORM);
+  const [selectedGroupIds, setSelectedGroupIds] = useState<string[]>([]);
+  const [videoFiltersText, setVideoFiltersText] = useState("");
+  const cameraGroups = cameraAccessConfig.data?.config.camera_groups || [];
+
+  useEffect(() => {
+    if (!cameraConfig.data?.config) {
+      return;
+    }
+    const {
+      identifier: _identifier,
+      password_set: _passwordSet,
+      ...config
+    } = cameraConfig.data.config;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setForm({
+      ...EMPTY_FORM,
+      ...config,
+      password: "",
+    });
+    setVideoFiltersText(videoFiltersToText(config.video_filters));
+  }, [cameraConfig.data]);
+
+  useEffect(() => {
+    if (!cameraAccessConfig.data?.config) {
+      return;
+    }
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setSelectedGroupIds(
+      cameraAccessConfig.data.config.camera_groups
+        .filter((group) => group.cameras.includes(camera.identifier))
+        .map((group) => group.id),
+    );
+  }, [camera.identifier, cameraAccessConfig.data]);
+
+  const updateForm = <K extends keyof CameraConfigPayload>(
+    key: K,
+    value: CameraConfigPayload[K],
+  ) => {
+    setForm((current) => ({ ...current, [key]: value }));
+  };
+
+  const selectedPreset = useMemo(
+    () =>
+      PATH_PRESETS.find(
+        (preset) =>
+          preset.path === form.path &&
+          preset.port === form.port &&
+          preset.stream_format === form.stream_format,
+      )?.label || "",
+    [form.path, form.port, form.stream_format],
+  );
+
+  const valid =
+    form.name.trim().length > 0 &&
+    form.host.trim().length > 0 &&
+    form.path.trim().length > 0 &&
+    form.port >= 1 &&
+    form.port <= 65535;
+
+  const isSaving =
+    updateCameraConfig.isPending ||
+    saveCameraAccessConfig.isPending ||
+    deleteCameraConfig.isPending;
+
+  const save = async () => {
+    const payload: CameraConfigPayload = {
+      ...form,
+      name: form.name.trim(),
+      host: form.host.trim(),
+      path: form.path.trim(),
+      username: form.username?.trim() || null,
+      password: form.password || null,
+      substream_path: form.substream_path?.trim() || null,
+      video_filters: textToVideoFilters(videoFiltersText),
+    };
+
+    await updateCameraConfig.mutateAsync({
+      cameraIdentifier: camera.identifier,
+      payload,
+    });
+
+    if (cameraAccessConfig.data?.config) {
+      await saveCameraAccessConfig.mutateAsync(
+        updateCameraGroups(
+          cameraAccessConfig.data.config,
+          camera.identifier,
+          selectedGroupIds,
+        ),
+      );
+    }
+
+    onClose();
+  };
+
+  const deleteCamera = async () => {
+    // eslint-disable-next-line no-alert
+    if (!window.confirm(`Delete camera ${camera.name}?`)) {
+      return;
+    }
+    await deleteCameraConfig.mutateAsync({
+      cameraIdentifier: camera.identifier,
+      reload: form.reload,
+    });
+    onClose();
+  };
+
+  const close = () => {
+    if (!isSaving) {
+      onClose();
+    }
+  };
+
+  if (cameraConfig.isLoading) {
+    return (
+      <Dialog open onClose={close} fullWidth maxWidth="md">
+        <DialogContent>
+          <Loading text="Loading camera" />
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  if (cameraConfig.isError || !cameraConfig.data) {
+    return (
+      <Dialog open onClose={close} fullWidth maxWidth="sm">
+        <DialogContent>
+          <ErrorMessage
+            text="Error loading camera"
+            subtext={cameraConfig.error?.message}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button startIcon={<Close />} onClick={close}>
+            Close
+          </Button>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Dialog open onClose={close} fullWidth maxWidth="md">
+      <DialogTitle>{camera.name}</DialogTitle>
+      <DialogContent>
+        <Grid container spacing={2} sx={{ mt: 0.5 }}>
+          <Grid size={{ xs: 12, md: 7 }}>
+            <TextField
+              label="Name"
+              value={form.name}
+              fullWidth
+              autoFocus
+              onChange={(event) => updateForm("name", event.target.value)}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 5 }}>
+            <TextField
+              label="Identifier"
+              value={camera.identifier}
+              fullWidth
+              disabled
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 8 }}>
+            <TextField
+              label="Host"
+              value={form.host}
+              fullWidth
+              onChange={(event) => updateForm("host", event.target.value)}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 4 }}>
+            <TextField
+              label="Port"
+              type="number"
+              value={form.port}
+              fullWidth
+              slotProps={{ htmlInput: { min: 1, max: 65535 } }}
+              onChange={(event) =>
+                updateForm("port", Number(event.target.value))
+              }
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 5 }}>
+            <FormControl fullWidth>
+              <InputLabel id="edit-camera-path-preset-label">Preset</InputLabel>
+              <Select
+                labelId="edit-camera-path-preset-label"
+                label="Preset"
+                value={selectedPreset}
+                onChange={(event) => {
+                  const preset = PATH_PRESETS.find(
+                    (item) => item.label === event.target.value,
+                  );
+                  if (!preset) {
+                    return;
+                  }
+                  updateForm("path", preset.path);
+                  updateForm("port", preset.port);
+                  updateForm("stream_format", preset.stream_format);
+                }}
+              >
+                {PATH_PRESETS.map((preset) => (
+                  <MenuItem key={preset.label} value={preset.label}>
+                    {preset.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
+          <Grid size={{ xs: 12, md: 7 }}>
+            <TextField
+              label="Path"
+              value={form.path}
+              fullWidth
+              onChange={(event) => updateForm("path", event.target.value)}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 4 }}>
+            <FormControl fullWidth>
+              <InputLabel id="edit-camera-stream-format-label">
+                Stream format
+              </InputLabel>
+              <Select
+                labelId="edit-camera-stream-format-label"
+                label="Stream format"
+                value={form.stream_format}
+                onChange={(event) =>
+                  updateForm(
+                    "stream_format",
+                    event.target.value as CameraConfigPayload["stream_format"],
+                  )
+                }
+              >
+                <MenuItem value="rtsp">RTSP</MenuItem>
+                <MenuItem value="mjpeg">MJPEG / HTTP</MenuItem>
+              </Select>
+            </FormControl>
+          </Grid>
+          <Grid size={{ xs: 12, md: 4 }}>
+            <TextField
+              label="FPS"
+              type="number"
+              value={form.fps ?? ""}
+              fullWidth
+              slotProps={{ htmlInput: { min: 1 } }}
+              onChange={(event) =>
+                updateForm("fps", numberOrNull(event.target.value))
+              }
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 4 }}>
+            <TextField
+              label="Idle timeout"
+              type="number"
+              value={form.idle_timeout}
+              fullWidth
+              slotProps={{ htmlInput: { min: 0 } }}
+              onChange={(event) =>
+                updateForm("idle_timeout", Number(event.target.value))
+              }
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TextField
+              label="Username"
+              value={form.username || ""}
+              fullWidth
+              onChange={(event) => updateForm("username", event.target.value)}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TextField
+              label="Password"
+              type="password"
+              value={form.password || ""}
+              placeholder={
+                cameraConfig.data.config.password_set ? "Already saved" : ""
+              }
+              fullWidth
+              onChange={(event) => updateForm("password", event.target.value)}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 8 }}>
+            <TextField
+              label="Substream Path"
+              value={form.substream_path || ""}
+              fullWidth
+              onChange={(event) =>
+                updateForm("substream_path", event.target.value)
+              }
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 4 }}>
+            <TextField
+              label="Substream Port"
+              type="number"
+              value={form.substream_port || 554}
+              fullWidth
+              slotProps={{ htmlInput: { min: 1, max: 65535 } }}
+              onChange={(event) =>
+                updateForm("substream_port", Number(event.target.value))
+              }
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TextField
+              label="Width"
+              type="number"
+              value={form.width ?? ""}
+              fullWidth
+              slotProps={{ htmlInput: { min: 1 } }}
+              onChange={(event) =>
+                updateForm("width", numberOrNull(event.target.value))
+              }
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TextField
+              label="Height"
+              type="number"
+              value={form.height ?? ""}
+              fullWidth
+              slotProps={{ htmlInput: { min: 1 } }}
+              onChange={(event) =>
+                updateForm("height", numberOrNull(event.target.value))
+              }
+            />
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <TextField
+              label="Video filters"
+              value={videoFiltersText}
+              fullWidth
+              multiline
+              minRows={2}
+              onChange={(event) => setVideoFiltersText(event.target.value)}
+            />
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={form.enable_recorder}
+                    onChange={(event) =>
+                      updateForm("enable_recorder", event.target.checked)
+                    }
+                  />
+                }
+                label="Recorder"
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={form.enable_nvr}
+                    onChange={(event) =>
+                      updateForm("enable_nvr", event.target.checked)
+                    }
+                  />
+                }
+                label="NVR"
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={Boolean(form.record_only)}
+                    onChange={(event) =>
+                      updateForm("record_only", event.target.checked)
+                    }
+                  />
+                }
+                label="Record only"
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={form.reload}
+                    onChange={(event) =>
+                      updateForm("reload", event.target.checked)
+                    }
+                  />
+                }
+                label="Reload"
+              />
+            </Box>
+          </Grid>
+
+          <Grid size={{ xs: 12 }}>
+            <Typography variant="subtitle1" sx={{ mb: 1 }}>
+              Camera groups
+            </Typography>
+            {cameraAccessConfig.isError && (
+              <Alert severity="warning">
+                Camera group assignments could not be loaded.
+              </Alert>
+            )}
+            {!cameraAccessConfig.isError && cameraGroups.length === 0 && (
+              <Alert severity="info">No camera groups configured.</Alert>
+            )}
+            {!cameraAccessConfig.isError && cameraGroups.length > 0 && (
+              <FormControl fullWidth>
+                <InputLabel id="camera-groups-label">Groups</InputLabel>
+                <Select
+                  multiple
+                  labelId="camera-groups-label"
+                  label="Groups"
+                  value={selectedGroupIds}
+                  onChange={(event) =>
+                    setSelectedGroupIds(
+                      typeof event.target.value === "string"
+                        ? event.target.value.split(",")
+                        : event.target.value,
+                    )
+                  }
+                  renderValue={(selected) =>
+                    (selected as string[])
+                      .map(
+                        (groupId) =>
+                          cameraGroups.find((group) => group.id === groupId)
+                            ?.name || groupId,
+                      )
+                      .join(", ")
+                  }
+                >
+                  {cameraGroups.map((group) => (
+                    <MenuItem key={group.id} value={group.id}>
+                      <Checkbox checked={selectedGroupIds.includes(group.id)} />
+                      <ListItemText primary={group.name} secondary={group.id} />
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+          </Grid>
+        </Grid>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          color="error"
+          startIcon={<TrashCan />}
+          disabled={isSaving}
+          onClick={deleteCamera}
+        >
+          Delete
+        </Button>
+        <Box sx={{ flexGrow: 1 }} />
+        <Button startIcon={<Close />} onClick={close} disabled={isSaving}>
+          Cancel
+        </Button>
+        <LoadingButton
+          icon={updateCameraConfig.isSuccess ? <Checkmark /> : <Save />}
+          text="Save"
+          state={
+            isSaving
+              ? "loading"
+              : updateCameraConfig.isError || saveCameraAccessConfig.isError
+                ? "error"
+                : updateCameraConfig.isSuccess
+                  ? "success"
+                  : "normal"
+          }
+          variant="contained"
+          onClick={valid ? save : undefined}
+        />
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/camera/NoCamerasConfigured.tsx
+++ b/frontend/src/components/camera/NoCamerasConfigured.tsx
@@ -1,72 +1,82 @@
+import { Add } from "@carbon/icons-react";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import ViseronLogo from "svg/viseron-logo.svg?react";
 
+import { AddCameraDialog } from "components/camera/AddCameraDialog";
+
 export function NoCamerasConfigured() {
   const navigate = useNavigate();
+  const [addCameraOpen, setAddCameraOpen] = useState(false);
 
   return (
-    <Grid
-      container
-      spacing={2}
-      alignItems="center"
-      justifyContent="center"
-      direction="column"
-      sx={{
-        position: "absolute",
-        top: "-20%",
-        bottom: 0,
-        margin: "auto 0",
-        width: "100%",
-      }}
-    >
-      <Grid>
-        <Box
-          display="flex"
-          justifyContent="center"
-          alignItems="center"
-          sx={{ width: 150, height: 150 }}
-        >
-          <ViseronLogo
-            width={150}
-            height={150}
-            role="img"
-            aria-label="Viseron Logo"
-          />
-        </Box>
-      </Grid>
-      <Grid>
-        <Typography align="center" variant="h6">
-          No cameras configured
-        </Typography>
-      </Grid>
-      <Grid>
-        <Typography align="center" color="text.secondary">
-          Add a camera component to your <Box component="code">config.yaml</Box>{" "}
-          to get started.
-        </Typography>
-      </Grid>
-      <Grid>
-        <Box sx={{ display: "flex", gap: 1, justifyContent: "center" }}>
-          <Button
-            variant="contained"
-            onClick={() => navigate("/settings/configuration")}
+    <>
+      <Grid
+        container
+        spacing={2}
+        alignItems="center"
+        justifyContent="center"
+        direction="column"
+        sx={{
+          position: "absolute",
+          top: "-20%",
+          bottom: 0,
+          margin: "auto 0",
+          width: "100%",
+        }}
+      >
+        <Grid>
+          <Box
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            sx={{ width: 150, height: 150 }}
           >
-            Open Configuration Editor
-          </Button>
-          <Button
-            variant="outlined"
-            href="https://viseron.netlify.app/docs/documentation/configuration"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            View Documentation
-          </Button>
-        </Box>
+            <ViseronLogo
+              width={150}
+              height={150}
+              role="img"
+              aria-label="Viseron Logo"
+            />
+          </Box>
+        </Grid>
+        <Grid>
+          <Typography align="center" variant="h6">
+            No cameras configured
+          </Typography>
+        </Grid>
+        <Grid>
+          <Typography align="center" color="text.secondary">
+            Add a camera component to your <Box component="code">config.yaml</Box>{" "}
+            to get started.
+          </Typography>
+        </Grid>
+        <Grid>
+          <Box sx={{ display: "flex", gap: 1, justifyContent: "center" }}>
+            <Button
+              startIcon={<Add />}
+              variant="contained"
+              onClick={() => setAddCameraOpen(true)}
+            >
+              Add Camera
+            </Button>
+            <Button
+              variant="outlined"
+              onClick={() => navigate("/settings/configuration")}
+            >
+              Open Configuration Editor
+            </Button>
+          </Box>
+        </Grid>
       </Grid>
-    </Grid>
+      <AddCameraDialog
+        open={addCameraOpen}
+        onClose={() => setAddCameraOpen(false)}
+      />
+    </>
   );
 }

--- a/frontend/src/lib/api/cameras.ts
+++ b/frontend/src/lib/api/cameras.ts
@@ -35,20 +35,33 @@ export type AddCameraConfigPayload = {
   substream_path?: string | null;
   substream_port?: number;
   substream_stream_format?: "rtsp" | "mjpeg";
+  fps?: number | null;
   idle_timeout: number;
   enable_recorder: boolean;
   enable_nvr: boolean;
+  record_only?: boolean;
+  width?: number | null;
+  height?: number | null;
+  video_filters?: string[];
   reload: boolean;
 };
 
-export type AddCameraConfigResponse = {
+export type CameraConfigPayload = Omit<AddCameraConfigPayload, "identifier">;
+
+export type CameraConfigResponse = {
+  config: AddCameraConfigPayload & {
+    password_set: boolean;
+  };
+};
+
+export type CameraConfigSaveResponse = {
   message: string;
   reloaded: boolean;
   restart_required?: boolean;
 };
 
 async function addCameraConfig(payload: AddCameraConfigPayload) {
-  const response = await viseronAPI.post<AddCameraConfigResponse>(
+  const response = await viseronAPI.post<CameraConfigSaveResponse>(
     "cameras",
     payload,
   );
@@ -58,7 +71,7 @@ async function addCameraConfig(payload: AddCameraConfigPayload) {
 export const useAddCameraConfig = (
   mutationOptions?: Omit<
     UseMutationOptions<
-      AddCameraConfigResponse,
+      CameraConfigSaveResponse,
       types.APIErrorResponse,
       AddCameraConfigPayload
     >,
@@ -86,6 +99,130 @@ export const useAddCameraConfig = (
       toast.error(
         error.response && error.response.data.error
           ? `Error adding camera: ${error.response.data.error}`
+          : `An error occurred: ${error.message}`,
+      );
+      mutationOptions?.onError?.(error, variables, onMutateResult, context);
+    },
+  });
+};
+
+async function cameraConfig(cameraIdentifier: string) {
+  const response = await viseronAPI.get<CameraConfigResponse>(
+    `cameras/${cameraIdentifier}/config`,
+  );
+  return response.data;
+}
+
+export const useCameraConfig = (cameraIdentifier: string, enabled = true) =>
+  useQuery({
+    queryKey: ["cameras", "config", cameraIdentifier],
+    queryFn: async () => cameraConfig(cameraIdentifier),
+    enabled,
+  });
+
+async function updateCameraConfig({
+  cameraIdentifier,
+  payload,
+}: {
+  cameraIdentifier: string;
+  payload: CameraConfigPayload;
+}) {
+  const response = await viseronAPI.put<CameraConfigSaveResponse>(
+    `cameras/${cameraIdentifier}/config`,
+    payload,
+  );
+  return response.data;
+}
+
+export const useUpdateCameraConfig = (
+  mutationOptions?: Omit<
+    UseMutationOptions<
+      CameraConfigSaveResponse,
+      types.APIErrorResponse,
+      { cameraIdentifier: string; payload: CameraConfigPayload }
+    >,
+    "mutationFn"
+  >,
+) => {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  return useMutation({
+    ...mutationOptions,
+    mutationFn: updateCameraConfig,
+    onSuccess: async (data, variables, onMutateResult, context) => {
+      toast.success(data.message);
+      await queryClient.invalidateQueries({ queryKey: ["cameras"] });
+      await queryClient.invalidateQueries({ queryKey: ["cameras", "failed"] });
+      await queryClient.invalidateQueries({
+        queryKey: ["cameras", "config", variables.cameraIdentifier],
+      });
+      await mutationOptions?.onSuccess?.(
+        data,
+        variables,
+        onMutateResult,
+        context,
+      );
+    },
+    onError: (error, variables, onMutateResult, context) => {
+      toast.error(
+        error.response && error.response.data.error
+          ? `Error saving camera: ${error.response.data.error}`
+          : `An error occurred: ${error.message}`,
+      );
+      mutationOptions?.onError?.(error, variables, onMutateResult, context);
+    },
+  });
+};
+
+async function deleteCameraConfig({
+  cameraIdentifier,
+  reload,
+}: {
+  cameraIdentifier: string;
+  reload: boolean;
+}) {
+  const response = await viseronAPI.delete<CameraConfigSaveResponse>(
+    `cameras/${cameraIdentifier}`,
+    { data: { reload } },
+  );
+  return response.data;
+}
+
+export const useDeleteCameraConfig = (
+  mutationOptions?: Omit<
+    UseMutationOptions<
+      CameraConfigSaveResponse,
+      types.APIErrorResponse,
+      { cameraIdentifier: string; reload: boolean }
+    >,
+    "mutationFn"
+  >,
+) => {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  return useMutation({
+    ...mutationOptions,
+    mutationFn: deleteCameraConfig,
+    onSuccess: async (data, variables, onMutateResult, context) => {
+      toast.success(data.message);
+      await queryClient.invalidateQueries({ queryKey: ["cameras"] });
+      await queryClient.invalidateQueries({ queryKey: ["cameras", "failed"] });
+      await queryClient.invalidateQueries({
+        queryKey: ["cameraaccess", "config"],
+      });
+      await mutationOptions?.onSuccess?.(
+        data,
+        variables,
+        onMutateResult,
+        context,
+      );
+    },
+    onError: (error, variables, onMutateResult, context) => {
+      toast.error(
+        error.response && error.response.data.error
+          ? `Error deleting camera: ${error.response.data.error}`
           : `An error occurred: ${error.message}`,
       );
       mutationOptions?.onError?.(error, variables, onMutateResult, context);

--- a/frontend/src/lib/api/cameras.ts
+++ b/frontend/src/lib/api/cameras.ts
@@ -1,6 +1,13 @@
-import { UseQueryOptions, useQuery } from "@tanstack/react-query";
+import {
+  UseMutationOptions,
+  UseQueryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { useMemo } from "react";
 
+import { useToast } from "hooks/UseToast";
 import { viseronAPI } from "lib/api/client";
 import { useInvalidateQueryOnEvent } from "lib/api/utils";
 import * as types from "lib/types";
@@ -15,6 +22,76 @@ async function cameras() {
   const response = await viseronAPI.get<types.Cameras>("cameras");
   return response.data;
 }
+
+export type AddCameraConfigPayload = {
+  identifier: string;
+  name: string;
+  host: string;
+  port: number;
+  path: string;
+  stream_format: "rtsp" | "mjpeg";
+  username?: string | null;
+  password?: string | null;
+  substream_path?: string | null;
+  substream_port?: number;
+  substream_stream_format?: "rtsp" | "mjpeg";
+  idle_timeout: number;
+  enable_recorder: boolean;
+  enable_nvr: boolean;
+  reload: boolean;
+};
+
+export type AddCameraConfigResponse = {
+  message: string;
+  reloaded: boolean;
+  restart_required?: boolean;
+};
+
+async function addCameraConfig(payload: AddCameraConfigPayload) {
+  const response = await viseronAPI.post<AddCameraConfigResponse>(
+    "cameras",
+    payload,
+  );
+  return response.data;
+}
+
+export const useAddCameraConfig = (
+  mutationOptions?: Omit<
+    UseMutationOptions<
+      AddCameraConfigResponse,
+      types.APIErrorResponse,
+      AddCameraConfigPayload
+    >,
+    "mutationFn"
+  >,
+) => {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  return useMutation({
+    ...mutationOptions,
+    mutationFn: addCameraConfig,
+    onSuccess: async (data, variables, onMutateResult, context) => {
+      toast.success(data.message);
+      await queryClient.invalidateQueries({ queryKey: ["cameras"] });
+      await queryClient.invalidateQueries({ queryKey: ["cameras", "failed"] });
+      await mutationOptions?.onSuccess?.(
+        data,
+        variables,
+        onMutateResult,
+        context,
+      );
+    },
+    onError: (error, variables, onMutateResult, context) => {
+      toast.error(
+        error.response && error.response.data.error
+          ? `Error adding camera: ${error.response.data.error}`
+          : `An error occurred: ${error.message}`,
+      );
+      mutationOptions?.onError?.(error, variables, onMutateResult, context);
+    },
+  });
+};
 
 export const useCameras = ({ configOptions }: CamerasVariables) => {
   useInvalidateQueryOnEvent([

--- a/frontend/src/pages/settings/Cameras.tsx
+++ b/frontend/src/pages/settings/Cameras.tsx
@@ -1,0 +1,107 @@
+import { Add, Video } from "@carbon/icons-react";
+import Avatar from "@mui/material/Avatar";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Container from "@mui/material/Container";
+import List from "@mui/material/List";
+import ListItemAvatar from "@mui/material/ListItemAvatar";
+import ListItemText from "@mui/material/ListItemText";
+import Paper from "@mui/material/Paper";
+import Typography from "@mui/material/Typography";
+import { useState } from "react";
+
+import { AddCameraDialog } from "components/camera/AddCameraDialog";
+import { Loading } from "components/loading/Loading";
+import { useTitle } from "hooks/UseTitle";
+import { useCamerasAll } from "lib/api/cameras";
+import * as types from "lib/types";
+
+function cameraSecondaryText(camera: types.Camera | types.FailedCamera) {
+  if (camera.failed) {
+    return camera.error;
+  }
+
+  if (!camera.connected) {
+    return "Disconnected";
+  }
+
+  return camera.is_recording ? "Recording" : "Connected";
+}
+
+function CamerasSettings() {
+  useTitle("Cameras");
+  const [addCameraOpen, setAddCameraOpen] = useState(false);
+  const cameras = useCamerasAll();
+  const cameraEntries = Object.values(cameras.combinedData);
+
+  if (cameras.isLoading) {
+    return <Loading text="Loading Cameras" />;
+  }
+
+  return (
+    <Container maxWidth="md" sx={{ py: 2 }}>
+      <Box
+        sx={{
+          alignItems: "center",
+          display: "flex",
+          gap: 2,
+          justifyContent: "space-between",
+          mb: 2,
+        }}
+      >
+        <Typography variant="h5">Cameras</Typography>
+        <Button
+          startIcon={<Add />}
+          variant="contained"
+          onClick={() => setAddCameraOpen(true)}
+        >
+          Add Camera
+        </Button>
+      </Box>
+
+      <Paper variant="outlined">
+        <List>
+          {cameraEntries.length === 0 ? (
+            <ListItemText
+              sx={{ px: 2, py: 3 }}
+              primary="No cameras configured"
+              secondary="Add Camera"
+            />
+          ) : (
+            cameraEntries.map((camera) => (
+              <Box
+                key={camera.identifier}
+                sx={{
+                  alignItems: "center",
+                  display: "flex",
+                  px: 2,
+                  py: 1,
+                }}
+              >
+                <ListItemAvatar>
+                  <Avatar
+                    sx={{
+                      bgcolor: camera.failed ? "error.main" : "primary.main",
+                    }}
+                  >
+                    <Video size={22} />
+                  </Avatar>
+                </ListItemAvatar>
+                <ListItemText
+                  primary={camera.name}
+                  secondary={cameraSecondaryText(camera)}
+                />
+              </Box>
+            ))
+          )}
+        </List>
+      </Paper>
+      <AddCameraDialog
+        open={addCameraOpen}
+        onClose={() => setAddCameraOpen(false)}
+      />
+    </Container>
+  );
+}
+
+export default CamerasSettings;

--- a/frontend/src/pages/settings/Cameras.tsx
+++ b/frontend/src/pages/settings/Cameras.tsx
@@ -5,12 +5,14 @@ import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import List from "@mui/material/List";
 import ListItemAvatar from "@mui/material/ListItemAvatar";
+import ListItemButton from "@mui/material/ListItemButton";
 import ListItemText from "@mui/material/ListItemText";
 import Paper from "@mui/material/Paper";
 import Typography from "@mui/material/Typography";
 import { useState } from "react";
 
 import { AddCameraDialog } from "components/camera/AddCameraDialog";
+import { CameraEditDialog } from "components/camera/CameraEditDialog";
 import { Loading } from "components/loading/Loading";
 import { useTitle } from "hooks/UseTitle";
 import { useCamerasAll } from "lib/api/cameras";
@@ -31,6 +33,9 @@ function cameraSecondaryText(camera: types.Camera | types.FailedCamera) {
 function CamerasSettings() {
   useTitle("Cameras");
   const [addCameraOpen, setAddCameraOpen] = useState(false);
+  const [selectedCamera, setSelectedCamera] = useState<
+    types.Camera | types.FailedCamera | null
+  >(null);
   const cameras = useCamerasAll();
   const cameraEntries = Object.values(cameras.combinedData);
 
@@ -69,8 +74,9 @@ function CamerasSettings() {
             />
           ) : (
             cameraEntries.map((camera) => (
-              <Box
+              <ListItemButton
                 key={camera.identifier}
+                onClick={() => setSelectedCamera(camera)}
                 sx={{
                   alignItems: "center",
                   display: "flex",
@@ -91,7 +97,7 @@ function CamerasSettings() {
                   primary={camera.name}
                   secondary={cameraSecondaryText(camera)}
                 />
-              </Box>
+              </ListItemButton>
             ))
           )}
         </List>
@@ -100,6 +106,12 @@ function CamerasSettings() {
         open={addCameraOpen}
         onClose={() => setAddCameraOpen(false)}
       />
+      {selectedCamera && (
+        <CameraEditDialog
+          camera={selectedCamera}
+          onClose={() => setSelectedCamera(null)}
+        />
+      )}
     </Container>
   );
 }

--- a/frontend/src/pages/settings/index.tsx
+++ b/frontend/src/pages/settings/index.tsx
@@ -5,6 +5,7 @@ import {
   SettingsEdit,
   Trigger,
   UserMultiple,
+  Video,
 } from "@carbon/icons-react";
 import { ListItemButton } from "@mui/material";
 import Avatar from "@mui/material/Avatar";
@@ -34,6 +35,15 @@ function Settings() {
       path: "/settings/configuration",
       icon: <SettingsEdit size={23} />,
       color: "blue",
+      disabled: false,
+      disabledReason: null,
+    },
+    {
+      name: "Cameras",
+      description: "Add and review cameras",
+      path: "/settings/cameras",
+      icon: <Video size={23} />,
+      color: "indigo",
       disabled: false,
       disabledReason: null,
     },

--- a/viseron/components/webserver/api/v1/cameras.py
+++ b/viseron/components/webserver/api/v1/cameras.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import voluptuous as vol
 from ruamel.yaml import YAML, YAMLError
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
 from viseron.components.webserver.api.handlers import BaseAPIHandler
 from viseron.components.webserver.auth import Role
@@ -18,6 +19,38 @@ LOGGER = logging.getLogger(__name__)
 
 CAMERA_IDENTIFIER_SCHEMA = vol.All(str, vol.Match(r"^[A-Za-z0-9_]+$"))
 STREAM_FORMATS = ["rtsp", "mjpeg"]
+
+CAMERA_CONFIG_BODY_SCHEMA = {
+    vol.Required("name"): vol.All(str, vol.Length(min=1)),
+    vol.Required("host"): vol.All(str, vol.Length(min=1)),
+    vol.Optional("port", default=554): vol.All(
+        vol.Coerce(int), vol.Range(min=1, max=65535)
+    ),
+    vol.Required("path"): vol.All(str, vol.Length(min=1)),
+    vol.Optional("stream_format", default="rtsp"): vol.In(STREAM_FORMATS),
+    vol.Optional("username", default=None): vol.Maybe(str),
+    vol.Optional("password", default=None): vol.Maybe(str),
+    vol.Optional("substream_path", default=None): vol.Maybe(str),
+    vol.Optional("substream_port", default=554): vol.All(
+        vol.Coerce(int), vol.Range(min=1, max=65535)
+    ),
+    vol.Optional("substream_stream_format", default="rtsp"): vol.In(STREAM_FORMATS),
+    vol.Optional("fps", default=None): vol.Maybe(
+        vol.All(vol.Coerce(int), vol.Range(min=1))
+    ),
+    vol.Optional("idle_timeout", default=5): vol.All(vol.Coerce(int), vol.Range(min=0)),
+    vol.Optional("enable_recorder", default=True): bool,
+    vol.Optional("enable_nvr", default=True): bool,
+    vol.Optional("record_only", default=False): bool,
+    vol.Optional("width", default=None): vol.Maybe(
+        vol.All(vol.Coerce(int), vol.Range(min=1))
+    ),
+    vol.Optional("height", default=None): vol.Maybe(
+        vol.All(vol.Coerce(int), vol.Range(min=1))
+    ),
+    vol.Optional("video_filters", default=[]): [str],
+    vol.Optional("reload", default=True): bool,
+}
 
 
 def _optional_trimmed_string(value: str | None) -> str | None:
@@ -45,31 +78,30 @@ class CamerasAPIHandler(BaseAPIHandler):
             "json_body_schema": vol.Schema(
                 {
                     vol.Required("identifier"): CAMERA_IDENTIFIER_SCHEMA,
-                    vol.Required("name"): vol.All(str, vol.Length(min=1)),
-                    vol.Required("host"): vol.All(str, vol.Length(min=1)),
-                    vol.Optional("port", default=554): vol.All(
-                        vol.Coerce(int), vol.Range(min=1, max=65535)
-                    ),
-                    vol.Required("path"): vol.All(str, vol.Length(min=1)),
-                    vol.Optional("stream_format", default="rtsp"): vol.In(
-                        STREAM_FORMATS
-                    ),
-                    vol.Optional("username", default=None): vol.Maybe(str),
-                    vol.Optional("password", default=None): vol.Maybe(str),
-                    vol.Optional("substream_path", default=None): vol.Maybe(str),
-                    vol.Optional("substream_port", default=554): vol.All(
-                        vol.Coerce(int), vol.Range(min=1, max=65535)
-                    ),
-                    vol.Optional("substream_stream_format", default="rtsp"): vol.In(
-                        STREAM_FORMATS
-                    ),
-                    vol.Optional("idle_timeout", default=5): vol.All(
-                        vol.Coerce(int), vol.Range(min=0)
-                    ),
-                    vol.Optional("enable_recorder", default=True): bool,
-                    vol.Optional("enable_nvr", default=True): bool,
-                    vol.Optional("reload", default=True): bool,
+                    **CAMERA_CONFIG_BODY_SCHEMA,
                 }
+            ),
+        },
+        {
+            "requires_role": [Role.ADMIN],
+            "path_pattern": r"/cameras/(?P<camera_identifier>[A-Za-z0-9_]+)/config",
+            "supported_methods": ["GET"],
+            "method": "get_camera_config",
+        },
+        {
+            "requires_role": [Role.ADMIN],
+            "path_pattern": r"/cameras/(?P<camera_identifier>[A-Za-z0-9_]+)/config",
+            "supported_methods": ["PUT"],
+            "method": "update_camera_config",
+            "json_body_schema": vol.Schema(CAMERA_CONFIG_BODY_SCHEMA),
+        },
+        {
+            "requires_role": [Role.ADMIN],
+            "path_pattern": r"/cameras/(?P<camera_identifier>[A-Za-z0-9_]+)",
+            "supported_methods": ["DELETE"],
+            "method": "delete_camera_config",
+            "json_body_schema": vol.Schema(
+                {vol.Optional("reload", default=True): bool}
             ),
         },
         {
@@ -99,20 +131,29 @@ class CamerasAPIHandler(BaseAPIHandler):
             self._yaml().dump(config, config_file)
 
     @staticmethod
-    def _camera_config_from_body(body: dict[str, Any]) -> dict[str, Any]:
+    def _camera_config_from_body(
+        body: dict[str, Any],
+        existing_camera_config: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
         """Build ffmpeg camera config from request body."""
-        camera_config: dict[str, Any] = {
-            "name": body["name"].strip(),
-            "host": body["host"].strip(),
-            "port": body["port"],
-            "path": body["path"].strip(),
-            "stream_format": body["stream_format"],
-        }
+        camera_config: dict[str, Any] = CommentedMap(existing_camera_config or {})
+        camera_config["name"] = body["name"].strip()
+        camera_config["host"] = body["host"].strip()
+        camera_config["port"] = body["port"]
+        camera_config["path"] = body["path"].strip()
+        camera_config["stream_format"] = body["stream_format"]
 
         if username := _optional_trimmed_string(body["username"]):
             camera_config["username"] = username
+        else:
+            camera_config.pop("username", None)
+
         if password := _optional_trimmed_string(body["password"]):
             camera_config["password"] = password
+        elif existing_camera_config and "password" in existing_camera_config:
+            camera_config["password"] = existing_camera_config["password"]
+        else:
+            camera_config.pop("password", None)
 
         if substream_path := _optional_trimmed_string(body["substream_path"]):
             camera_config["substream"] = {
@@ -120,11 +161,82 @@ class CamerasAPIHandler(BaseAPIHandler):
                 "port": body["substream_port"],
                 "stream_format": body["substream_stream_format"],
             }
+        else:
+            camera_config.pop("substream", None)
+
+        if body["fps"] is not None:
+            camera_config["fps"] = body["fps"]
+        else:
+            camera_config.pop("fps", None)
 
         if body["enable_recorder"]:
-            camera_config["recorder"] = {"idle_timeout": body["idle_timeout"]}
+            recorder_config = CommentedMap(camera_config.get("recorder") or {})
+            recorder_config["idle_timeout"] = body["idle_timeout"]
+            camera_config["recorder"] = recorder_config
+        else:
+            camera_config.pop("recorder", None)
+
+        if body["record_only"]:
+            camera_config["record_only"] = True
+        else:
+            camera_config.pop("record_only", None)
+
+        if body["width"] is not None:
+            camera_config["width"] = body["width"]
+        else:
+            camera_config.pop("width", None)
+
+        if body["height"] is not None:
+            camera_config["height"] = body["height"]
+        else:
+            camera_config.pop("height", None)
+
+        video_filters = [
+            video_filter.strip()
+            for video_filter in body["video_filters"]
+            if video_filter.strip()
+        ]
+        if video_filters:
+            camera_config["video_filters"] = CommentedSeq(video_filters)
+        else:
+            camera_config.pop("video_filters", None)
 
         return camera_config
+
+    @staticmethod
+    def _camera_config_to_response(
+        camera_identifier: str,
+        camera_config: dict[str, Any],
+        nvr_config: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Transform config.yaml camera data into API response."""
+        substream = camera_config.get("substream") or {}
+        recorder = camera_config.get("recorder") or {}
+        return {
+            "identifier": camera_identifier,
+            "name": str(camera_config.get("name") or camera_identifier),
+            "host": str(camera_config.get("host") or ""),
+            "port": int(camera_config.get("port") or 554),
+            "path": str(camera_config.get("path") or ""),
+            "stream_format": str(camera_config.get("stream_format") or "rtsp"),
+            "username": str(camera_config.get("username") or ""),
+            "password": "",
+            "password_set": "password" in camera_config,
+            "substream_path": str(substream.get("path") or ""),
+            "substream_port": int(substream.get("port") or 554),
+            "substream_stream_format": str(
+                substream.get("stream_format") or "rtsp"
+            ),
+            "fps": camera_config.get("fps"),
+            "idle_timeout": int(recorder.get("idle_timeout") or 5),
+            "enable_recorder": bool(recorder),
+            "enable_nvr": camera_identifier in nvr_config,
+            "record_only": bool(camera_config.get("record_only", False)),
+            "width": camera_config.get("width"),
+            "height": camera_config.get("height"),
+            "video_filters": list(camera_config.get("video_filters") or []),
+            "reload": True,
+        }
 
     def _add_camera_to_config(self, config: dict[str, Any]) -> None:
         """Add camera to config."""
@@ -142,6 +254,27 @@ class CamerasAPIHandler(BaseAPIHandler):
         if self.json_body["enable_nvr"]:
             config.setdefault("nvr", {})
             config["nvr"][identifier] = {}
+
+    @staticmethod
+    def _remove_camera_from_access_config(
+        config: dict[str, Any], camera_identifier: str
+    ) -> None:
+        """Remove camera from camera access config."""
+        auth_config = (config.get("webserver") or {}).get("auth") or {}
+        for camera_group in (auth_config.get("camera_groups") or {}).values():
+            if "cameras" in camera_group:
+                camera_group["cameras"] = [
+                    identifier
+                    for identifier in camera_group["cameras"]
+                    if identifier != camera_identifier
+                ]
+        for rule in auth_config.get("ldap_camera_access") or []:
+            if "cameras" in rule:
+                rule["cameras"] = [
+                    identifier
+                    for identifier in rule["cameras"]
+                    if identifier != camera_identifier
+                ]
 
     def _restore_config(self, raw_config: str) -> None:
         """Restore original config."""
@@ -184,6 +317,159 @@ class CamerasAPIHandler(BaseAPIHandler):
             return
         except (OSError, YAMLError) as error:
             LOGGER.error("Failed to add camera configuration: %s", error, exc_info=True)
+            self.response_error(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                reason=f"Failed to update configuration: {error}",
+            )
+            return
+
+        if result.get("errors"):
+            self.response_error(
+                HTTPStatus.BAD_REQUEST,
+                reason="; ".join(result["errors"]),
+            )
+            return
+
+        await self.response_success(response=result)
+
+    async def get_camera_config(self, camera_identifier: str) -> None:
+        """Return camera config from config.yaml."""
+
+        def _get_config() -> dict[str, Any]:
+            config, _raw_config = self._load_raw_config()
+            camera_config = (
+                config.get("ffmpeg", {}).get("camera", {}).get(camera_identifier)
+            )
+            if camera_config is None:
+                raise ValueError(f"Camera '{camera_identifier}' not found")
+            return self._camera_config_to_response(
+                camera_identifier, camera_config, config.get("nvr") or {}
+            )
+
+        try:
+            camera_config = await self.run_in_executor(_get_config)
+        except ValueError as error:
+            self.response_error(HTTPStatus.NOT_FOUND, reason=str(error))
+            return
+        except (OSError, YAMLError) as error:
+            LOGGER.error("Failed to load camera configuration: %s", error, exc_info=True)
+            self.response_error(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                reason=f"Failed to load configuration: {error}",
+            )
+            return
+
+        await self.response_success(response={"config": camera_config})
+
+    async def update_camera_config(self, camera_identifier: str) -> None:
+        """Update camera config in config.yaml."""
+
+        def _update_config() -> dict[str, Any]:
+            config, raw_config = self._load_raw_config()
+            cameras_config = config.get("ffmpeg", {}).get("camera", {})
+            if camera_identifier not in cameras_config:
+                raise ValueError(f"Camera '{camera_identifier}' not found")
+
+            cameras_config[camera_identifier] = self._camera_config_from_body(
+                self.json_body, cameras_config[camera_identifier]
+            )
+
+            if self.json_body["enable_nvr"]:
+                config.setdefault("nvr", {})
+                config["nvr"].setdefault(camera_identifier, {})
+            else:
+                (config.get("nvr") or {}).pop(camera_identifier, None)
+
+            self._save_config(config)
+            if not self.json_body["reload"]:
+                return {"message": "Camera configuration saved", "reloaded": False}
+
+            result = reload_config(self._vis)
+            if result.success:
+                return {
+                    "message": "Camera configuration saved and reloaded",
+                    "reloaded": True,
+                    "restart_required": result.restart_required,
+                }
+
+            self._restore_config(raw_config)
+            reload_config(self._vis)
+            errors = [error.message for error in result.errors]
+            return {
+                "message": "Camera configuration failed validation",
+                "reloaded": False,
+                "restored": True,
+                "errors": errors,
+            }
+
+        try:
+            result = await self.run_in_executor(_update_config)
+        except ValueError as error:
+            self.response_error(HTTPStatus.NOT_FOUND, reason=str(error))
+            return
+        except (OSError, YAMLError) as error:
+            LOGGER.error(
+                "Failed to update camera configuration: %s", error, exc_info=True
+            )
+            self.response_error(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                reason=f"Failed to update configuration: {error}",
+            )
+            return
+
+        if result.get("errors"):
+            self.response_error(
+                HTTPStatus.BAD_REQUEST,
+                reason="; ".join(result["errors"]),
+            )
+            return
+
+        await self.response_success(response=result)
+
+    async def delete_camera_config(self, camera_identifier: str) -> None:
+        """Delete camera from config.yaml."""
+
+        def _delete_config() -> dict[str, Any]:
+            config, raw_config = self._load_raw_config()
+            cameras_config = config.get("ffmpeg", {}).get("camera", {})
+            if camera_identifier not in cameras_config:
+                raise ValueError(f"Camera '{camera_identifier}' not found")
+
+            cameras_config.pop(camera_identifier)
+            (config.get("nvr") or {}).pop(camera_identifier, None)
+            self._remove_camera_from_access_config(config, camera_identifier)
+            self._save_config(config)
+
+            if not self.json_body["reload"]:
+                return {"message": "Camera configuration deleted", "reloaded": False}
+
+            result = reload_config(self._vis)
+            if result.success:
+                return {
+                    "message": "Camera configuration deleted and reloaded",
+                    "reloaded": True,
+                    "restart_required": result.restart_required,
+                }
+
+            self._restore_config(raw_config)
+            reload_config(self._vis)
+            errors = [error.message for error in result.errors]
+            return {
+                "message": "Camera configuration failed validation",
+                "reloaded": False,
+                "restored": True,
+                "errors": errors,
+            }
+
+        try:
+            result = await self.run_in_executor(_delete_config)
+        except ValueError as error:
+            self.response_error(HTTPStatus.NOT_FOUND, reason=str(error))
+            return
+        except (OSError, YAMLError) as error:
+            LOGGER.error(
+                "Failed to delete camera configuration: %s", error, exc_info=True
+            )
             self.response_error(
                 HTTPStatus.INTERNAL_SERVER_ERROR,
                 reason=f"Failed to update configuration: {error}",

--- a/viseron/components/webserver/api/v1/cameras.py
+++ b/viseron/components/webserver/api/v1/cameras.py
@@ -2,10 +2,30 @@
 from __future__ import annotations
 
 import logging
+from http import HTTPStatus
+from typing import Any
+
+import voluptuous as vol
+from ruamel.yaml import YAML, YAMLError
 
 from viseron.components.webserver.api.handlers import BaseAPIHandler
+from viseron.components.webserver.auth import Role
+from viseron.const import CONFIG_PATH
+from viseron.reload import reload_config
 
 LOGGER = logging.getLogger(__name__)
+
+
+CAMERA_IDENTIFIER_SCHEMA = vol.All(str, vol.Match(r"^[A-Za-z0-9_]+$"))
+STREAM_FORMATS = ["rtsp", "mjpeg"]
+
+
+def _optional_trimmed_string(value: str | None) -> str | None:
+    """Return stripped string or None."""
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
 
 
 class CamerasAPIHandler(BaseAPIHandler):
@@ -18,11 +38,166 @@ class CamerasAPIHandler(BaseAPIHandler):
             "method": "get_cameras_endpoint",
         },
         {
+            "requires_role": [Role.ADMIN],
+            "path_pattern": r"/cameras",
+            "supported_methods": ["POST"],
+            "method": "post_camera_config",
+            "json_body_schema": vol.Schema(
+                {
+                    vol.Required("identifier"): CAMERA_IDENTIFIER_SCHEMA,
+                    vol.Required("name"): vol.All(str, vol.Length(min=1)),
+                    vol.Required("host"): vol.All(str, vol.Length(min=1)),
+                    vol.Optional("port", default=554): vol.All(
+                        vol.Coerce(int), vol.Range(min=1, max=65535)
+                    ),
+                    vol.Required("path"): vol.All(str, vol.Length(min=1)),
+                    vol.Optional("stream_format", default="rtsp"): vol.In(
+                        STREAM_FORMATS
+                    ),
+                    vol.Optional("username", default=None): vol.Maybe(str),
+                    vol.Optional("password", default=None): vol.Maybe(str),
+                    vol.Optional("substream_path", default=None): vol.Maybe(str),
+                    vol.Optional("substream_port", default=554): vol.All(
+                        vol.Coerce(int), vol.Range(min=1, max=65535)
+                    ),
+                    vol.Optional("substream_stream_format", default="rtsp"): vol.In(
+                        STREAM_FORMATS
+                    ),
+                    vol.Optional("idle_timeout", default=5): vol.All(
+                        vol.Coerce(int), vol.Range(min=0)
+                    ),
+                    vol.Optional("enable_recorder", default=True): bool,
+                    vol.Optional("enable_nvr", default=True): bool,
+                    vol.Optional("reload", default=True): bool,
+                }
+            ),
+        },
+        {
             "path_pattern": r"/cameras/failed",
             "supported_methods": ["GET"],
             "method": "get_failed_cameras_endpoint",
         },
     ]
+
+    @staticmethod
+    def _yaml() -> YAML:
+        """Return configured YAML parser."""
+        yaml = YAML(typ="rt")
+        yaml.preserve_quotes = True
+        return yaml
+
+    def _load_raw_config(self) -> tuple[dict[str, Any], str]:
+        """Load config.yaml and return parsed and raw config."""
+        with open(CONFIG_PATH, encoding="utf-8") as config_file:
+            raw_config = config_file.read()
+        config = self._yaml().load(raw_config) or {}
+        return config, raw_config
+
+    def _save_config(self, config: dict[str, Any]) -> None:
+        """Save config.yaml."""
+        with open(CONFIG_PATH, "w", encoding="utf-8") as config_file:
+            self._yaml().dump(config, config_file)
+
+    @staticmethod
+    def _camera_config_from_body(body: dict[str, Any]) -> dict[str, Any]:
+        """Build ffmpeg camera config from request body."""
+        camera_config: dict[str, Any] = {
+            "name": body["name"].strip(),
+            "host": body["host"].strip(),
+            "port": body["port"],
+            "path": body["path"].strip(),
+            "stream_format": body["stream_format"],
+        }
+
+        if username := _optional_trimmed_string(body["username"]):
+            camera_config["username"] = username
+        if password := _optional_trimmed_string(body["password"]):
+            camera_config["password"] = password
+
+        if substream_path := _optional_trimmed_string(body["substream_path"]):
+            camera_config["substream"] = {
+                "path": substream_path,
+                "port": body["substream_port"],
+                "stream_format": body["substream_stream_format"],
+            }
+
+        if body["enable_recorder"]:
+            camera_config["recorder"] = {"idle_timeout": body["idle_timeout"]}
+
+        return camera_config
+
+    def _add_camera_to_config(self, config: dict[str, Any]) -> None:
+        """Add camera to config."""
+        identifier = self.json_body["identifier"].strip()
+        config.setdefault("ffmpeg", {})
+        config["ffmpeg"].setdefault("camera", {})
+
+        if identifier in config["ffmpeg"]["camera"]:
+            raise ValueError(f"Camera '{identifier}' already exists")
+
+        config["ffmpeg"]["camera"][identifier] = self._camera_config_from_body(
+            self.json_body
+        )
+
+        if self.json_body["enable_nvr"]:
+            config.setdefault("nvr", {})
+            config["nvr"][identifier] = {}
+
+    def _restore_config(self, raw_config: str) -> None:
+        """Restore original config."""
+        with open(CONFIG_PATH, "w", encoding="utf-8") as config_file:
+            config_file.write(raw_config)
+
+    async def post_camera_config(self) -> None:
+        """Add a camera to config.yaml."""
+
+        def _update_config() -> dict[str, Any]:
+            config, raw_config = self._load_raw_config()
+            self._add_camera_to_config(config)
+            self._save_config(config)
+
+            if not self.json_body["reload"]:
+                return {"message": "Camera configuration saved", "reloaded": False}
+
+            result = reload_config(self._vis)
+            if result.success:
+                return {
+                    "message": "Camera configuration saved and reloaded",
+                    "reloaded": True,
+                    "restart_required": result.restart_required,
+                }
+
+            self._restore_config(raw_config)
+            reload_config(self._vis)
+            errors = [error.message for error in result.errors]
+            return {
+                "message": "Camera configuration failed validation",
+                "reloaded": False,
+                "restored": True,
+                "errors": errors,
+            }
+
+        try:
+            result = await self.run_in_executor(_update_config)
+        except ValueError as error:
+            self.response_error(HTTPStatus.CONFLICT, reason=str(error))
+            return
+        except (OSError, YAMLError) as error:
+            LOGGER.error("Failed to add camera configuration: %s", error, exc_info=True)
+            self.response_error(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                reason=f"Failed to update configuration: {error}",
+            )
+            return
+
+        if result.get("errors"):
+            self.response_error(
+                HTTPStatus.BAD_REQUEST,
+                reason="; ".join(result["errors"]),
+            )
+            return
+
+        await self.response_success(response=result)
 
     async def get_cameras_endpoint(self) -> None:
         """Return cameras."""


### PR DESCRIPTION
## Summary
- Adds a guided camera setup flow for creating FFmpeg camera entries from the UI.
- Adds a camera settings page with edit/delete support for existing camera configs.
- Includes a generic Mobotix HTTP preset, with no deployment-specific hostnames, credentials, or networks.

## Why
This makes basic camera management possible without editing YAML by hand, while preserving existing config values such as saved passwords when the user leaves them blank.

## Validation
- Cherry-picked onto current upstream `dev`.
- Ran `git diff --check` for this branch.