### PR TITLE
feat(ci): add container smoke tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,10 +59,12 @@
 !/tests/*
 !/tests/components
 !/tests/components/**
+!/tests/container
+!/tests/container/**
 !/tests/domains
 !/tests/domains/**
 !/tests/helpers
-!/tests/helpers/*
+!/tests/helpers/**
 
 # Source
 !/viseron
@@ -76,6 +78,7 @@
 !/viseron/watchdog
 !/viseron/watchdog/*
 !/requirements_ci.txt
+!/requirements_container_test.txt
 !/requirements_test.txt
 !/requirements.txt
 !/requirements-3.9.txt

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,5 +1,7 @@
 [mypy]
 python_version = 3.10
+exclude = ^docker/
+namespace_packages = false
 show_error_codes = true
 follow_imports = silent
 local_partial_types = true
@@ -35,6 +37,9 @@ ignore_missing_imports = true
 ignore_missing_imports = true
 
 [mypy-deepstack.*]
+ignore_missing_imports = true
+
+[mypy-docker.*]
 ignore_missing_imports = true
 
 [mypy-face_recognition.*]
@@ -86,6 +91,9 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [mypy-telegram-ext.*]
+ignore_missing_imports = True
+
+[mypy-testinfra.*]
 ignore_missing_imports = True
 
 [mypy-ultralytics.*]

--- a/.pylintrc
+++ b/.pylintrc
@@ -462,7 +462,7 @@ int-import-graph=
 known-standard-library=
 
 # Force import order to recognize a module as part of a third party library.
-known-third-party=enchant
+known-third-party=enchant,docker
 
 
 [DESIGN]

--- a/azure-pipelines/azure-pipelines-viseron.yml
+++ b/azure-pipelines/azure-pipelines-viseron.yml
@@ -3,6 +3,10 @@ parameters:
     displayName: "Build without cache"
     type: boolean
     default: false
+  - name: skipSmokeTests
+    displayName: "Skip container smoke tests"
+    type: boolean
+    default: false
 
 trigger:
   branches:
@@ -61,7 +65,19 @@ stages:
           release: false
           noCache: ${{ parameters.noCache }}
 
-  - stage: "Publish"
+  - stage: Test
+    dependsOn: Build
+    condition: and(succeeded('Build'), eq('${{ parameters.skipSmokeTests }}', false))
+    jobs:
+      - template: templates/smoke_test_stage.yaml
+        parameters:
+          image: viseron
+
+  - stage: Publish
+    dependsOn:
+      - Build
+      - Test
+    condition: and(succeeded('Build'), in(dependencies.Test.result, 'Succeeded', 'Skipped'))
     jobs:
       - job: "ReleaseViseron"
         pool:

--- a/azure-pipelines/templates/smoke_test.yaml
+++ b/azure-pipelines/templates/smoke_test.yaml
@@ -1,0 +1,73 @@
+parameters:
+  - name: image
+    type: string
+    # The base image name without arch prefix, e.g. "viseron".
+  - name: architecture
+    type: string
+    # One of: amd64, amd64-cuda, aarch64, rpi3
+  - name: namespace
+    type: string
+    default: roflcoopter
+  - name: imageTag
+    type: string
+    default: dev
+  - name: pythonVersion
+    type: string
+    default: "3.12"
+  - name: timeoutMinutes
+    type: number
+    default: 10
+  - name: pytestTimeout
+    type: number
+    default: 300
+
+steps:
+  - script: docker run --rm --privileged tonistiigi/binfmt --install all
+    displayName: "Smoke: register QEMU emulators"
+    condition: succeeded()
+
+  - script: |
+      set -euo pipefail
+      python3 -m venv "$AGENT_TEMPDIRECTORY/smoke-venv"
+      "$AGENT_TEMPDIRECTORY/smoke-venv/bin/pip" install --upgrade pip
+      "$AGENT_TEMPDIRECTORY/smoke-venv/bin/pip" install \
+        -r requirements_container_test.txt
+    displayName: "Smoke: install test harness requirements"
+    condition: succeeded()
+
+  - script: |
+      set -euxo pipefail
+      mkdir -p "$BUILD_ARTIFACTSTAGINGDIRECTORY/smoke-${{ parameters.architecture }}"
+      export VISERON_SMOKE_ARTIFACT_DIR="$BUILD_ARTIFACTSTAGINGDIRECTORY/smoke-${{ parameters.architecture }}"
+      "$AGENT_TEMPDIRECTORY/smoke-venv/bin/pytest" \
+        -rs \
+        tests/container/ \
+        --confcutdir=tests/container \
+        --image=${{ parameters.namespace }}/${{ parameters.architecture }}-${{ parameters.image }}:${{ parameters.imageTag }} \
+        --arch=${{ parameters.architecture }} \
+        --boot-timeout=$((${{ parameters.pytestTimeout }} - 60)) \
+        --timeout=${{ parameters.pytestTimeout }} \
+        --junitxml=$(Common.TestResultsDirectory)/smoke-${{ parameters.architecture }}.xml \
+        -v
+    displayName: "Smoke: run pytest"
+    timeoutInMinutes: ${{ parameters.timeoutMinutes }}
+    condition: succeeded()
+    continueOnError: true
+
+  - task: PublishTestResults@2
+    displayName: "Smoke: publish JUnit results"
+    condition: always()
+    inputs:
+      testResultsFormat: "JUnit"
+      testResultsFiles: "$(Common.TestResultsDirectory)/smoke-${{ parameters.architecture }}.xml"
+      testRunTitle: "Smoke ${{ parameters.architecture }}-${{ parameters.image }}"
+      mergeTestResults: false
+      failTaskOnFailedTests: false
+
+  - task: PublishBuildArtifacts@1
+    displayName: "Smoke: publish container artifacts"
+    condition: always()
+    inputs:
+      pathToPublish: "$(Build.ArtifactStagingDirectory)/smoke-${{ parameters.architecture }}"
+      artifactName: "smoke-artifacts-${{ parameters.architecture }}-${{ parameters.image }}"
+      publishLocation: "Container"

--- a/azure-pipelines/templates/smoke_test_stage.yaml
+++ b/azure-pipelines/templates/smoke_test_stage.yaml
@@ -1,0 +1,57 @@
+parameters:
+  - name: architectures
+    type: object
+    default:
+      - aarch64
+      - amd64
+      - amd64-cuda
+      - rpi3
+  - name: namespace
+    type: string
+    default: roflcoopter
+  - name: image
+    type: string
+  - name: imageTag
+    type: string
+    default: dev
+
+jobs:
+  - ${{ each architecture in parameters.architectures }}:
+      - job: smoke_${{ replace(architecture, '-', '_') }}
+        displayName: "Smoke test ${{ architecture }}"
+        pool:
+          ${{ if eq(architecture, 'aarch64') }}:
+            name: rpi5
+          ${{ else }}:
+            name: amd64
+        steps:
+          - task: Docker@2
+            displayName: Login to Docker Hub
+            inputs:
+              command: login
+              containerRegistry: "Docker Hub"
+
+          - script: |
+              docker pull ${{ parameters.namespace }}/${{ architecture }}-${{ parameters.image }}:${{ parameters.imageTag }}
+            displayName: "Smoke: pull ${{ architecture }}-${{ parameters.image }}:${{ parameters.imageTag }}"
+            condition: succeeded()
+
+          - template: smoke_test.yaml
+            parameters:
+              image: ${{ parameters.image }}
+              architecture: ${{ architecture }}
+              namespace: ${{ parameters.namespace }}
+              imageTag: ${{ parameters.imageTag }}
+              ${{ if eq(architecture, 'rpi3') }}:
+                timeoutMinutes: 10
+                pytestTimeout: 360
+              ${{ else }}:
+                timeoutMinutes: 10
+                pytestTimeout: 300
+
+          - task: Docker@2
+            displayName: Logoff Docker Hub
+            condition: always()
+            inputs:
+              command: logout
+              containerRegistry: "Docker Hub"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -97,6 +97,9 @@ RUN \
   # OpenCV and FFmpeg Dependencies
   libgomp1 \
   libwebpdemux2 \
+  # Qt XCB platform plugin dependencies (bundled with opencv-python)
+  libsm6 \
+  libice6 \
   # dlib Dependencies
   # OpenBLAS provided via build-arg since Jetson Nano runs on older Ubuntu version
   "${OPENBLAS_APT_PACKAGE}" \
@@ -125,6 +128,12 @@ RUN \
   && rm -rf /var/lib/apt/lists/* \
   \
   && python3 -m pip install --ignore-installed /wheels/*.whl \
+  # Register PyTorch runtime libs (installed via ultralytics) with the system
+  # linker so that ldd and ld.so can resolve libtorch.so / libc10.so etc.
+  && python3 -c \
+  "import torch, os; open('/etc/ld.so.conf.d/torch.conf','w').write(os.path.join(os.path.dirname(torch.__file__),'lib')+'\n')" \
+  2>/dev/null || true \
+  && ldconfig \
   && rm -r /wheels \
   \
   # Install Python 3.9 if it doesn't exist
@@ -145,6 +154,21 @@ RUN \
   libedgetpu1-max \
   && python3.9 -m pip install --ignore-installed /wheels-3.9/*.whl \
   && rm -r /wheels-3.9 \
+  \
+  # Python 3.9 wheels (e.g. Pillow for armhf) may have been compiled against
+  # Ubuntu 22.04 which shipped libtiff.so.5 and libwebp.so.6.  Ubuntu 24.04
+  # ships libtiff.so.6 and libwebp.so.7 instead.  Create compatibility
+  # symlinks so that those wheels can load on 24.04.  The loop is a no-op on
+  # architectures where the old SONAME is already present.
+  && ldconfig \
+  && for pair in "libtiff.so.5 libtiff.so.6" "libwebp.so.6 libwebp.so.7"; do \
+       old="${pair%% *}"; new="${pair##* }"; \
+       if ! ldconfig -p | grep -qF " $old "; then \
+         src=$(find /usr/lib -name "$new" -not -name "$new.*" 2>/dev/null | head -1); \
+         [ -n "$src" ] && ln -sf "$new" "$(dirname "$src")/$old" || true; \
+       fi; \
+     done \
+  && ldconfig \
   \
   && chmod +x /tmp/s6-overlay-installer && /tmp/s6-overlay-installer / \
   && apt-get autoremove -y \

--- a/docker/aarch64/Dockerfile.base
+++ b/docker/aarch64/Dockerfile.base
@@ -24,7 +24,9 @@ RUN \
   liblapacke \
   libopenexr-3-1-30 \
   libpng16-16t64 \
-  libatomic1 && \
+  libatomic1 \
+  ocl-icd-libopencl1 \
+  clinfo && \
   ln -s /detectors/models/darknet/yolov7-tiny.weights /detectors/models/darknet/default.weights && \
   ln -s /detectors/models/darknet/yolov7-tiny.cfg /detectors/models/darknet/default.cfg
 

--- a/docker/aarch64/Dockerfile.ffmpeg
+++ b/docker/aarch64/Dockerfile.ffmpeg
@@ -753,5 +753,6 @@ RUN \
   cp -r ${PREFIX}/share/ffmpeg /usr/local/share/
 
 FROM scratch
+COPY --from=ffmpeg /opt/ffmpeg /opt/ffmpeg/
 COPY --from=ffmpeg /usr/local/bin /usr/local/bin/
 COPY --from=ffmpeg /usr/local/share /usr/local/share/

--- a/docker/rpi3/Dockerfile.base
+++ b/docker/rpi3/Dockerfile.base
@@ -27,7 +27,8 @@ RUN \
   libopenexr-3-1-30 \
   libpng16-16t64 \
   ## FFmpeg
-  libx265-199 && \
+  libx265-199 \
+  clinfo && \
   echo "/opt/vc/lib" > /etc/ld.so.conf.d/00-vmcs.conf && \
   ldconfig  && \
   ln -s /detectors/models/darknet/yolov7-tiny.weights /detectors/models/darknet/default.weights && \

--- a/requirements_container_test.txt
+++ b/requirements_container_test.txt
@@ -1,0 +1,5 @@
+pytest==9.0.2
+pytest-sugar==1.1.1
+pytest-timeout==2.4.0
+pytest-testinfra==10.1.1
+docker==7.1.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,6 +13,8 @@ pytest-postgresql==8.0.0
 pytest-sugar==1.1.1
 pytest-timeout==2.4.0
 pytest-xdist==3.8.0
+pytest-testinfra==10.1.1
+docker==7.1.0
 vulture==2.14
 
 # The following libraries has to be kept in sync with .pre-commit-config.yaml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
 """Viseron fixtures."""
+
 from __future__ import annotations
 
-from collections.abc import Generator, Iterator
-from typing import Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -20,6 +21,11 @@ from viseron.components.webserver import COMPONENT as WEBSERVER, Webserver
 from viseron.const import FAILED, LOADED, LOADING
 
 from tests.common import MockCamera
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterator
+
+    from pytest_postgresql.executor import PostgreSQLExecutor
 
 test_db = factories.postgresql_proc(port=None, dbname="test_db")
 
@@ -60,7 +66,9 @@ def vis() -> MockViseron:
     viseron = MockViseron()
     viseron.data[DATA_STREAM] = MagicMock(spec=DataStream)
     viseron.data[STORAGE] = MagicMock(spec=Storage)
-    viseron.data[STORAGE].file_batch_size = DEFAULT_TIER_CHECK_BATCH_SIZE
+    viseron.data[STORAGE].file_batch_size = (  # type: ignore[misc]
+        DEFAULT_TIER_CHECK_BATCH_SIZE
+    )
     viseron.data[WEBSERVER] = MagicMock(spec=Webserver)
     viseron.data[LOADED] = {}
     viseron.data[LOADING] = {}
@@ -89,7 +97,7 @@ def patch_enable_logging() -> Iterator[None]:
         yield
 
 
-def _make_db_session(database) -> Generator[Session, Any, None]:
+def _make_db_session(database: PostgreSQLExecutor) -> Generator[Session, Any, None]:
     """Create a DB session."""
     with DatabaseJanitor(
         user=database.user,
@@ -111,7 +119,9 @@ def _make_db_session(database) -> Generator[Session, Any, None]:
         Base.metadata.drop_all(engine)
 
 
-def _get_db_session(database) -> Generator[sessionmaker[Session], Any, None]:
+def _get_db_session(
+    database: PostgreSQLExecutor,
+) -> Generator[sessionmaker[Session], Any, None]:
     """Create a DB session."""
     with DatabaseJanitor(
         user=database.user,
@@ -131,26 +141,26 @@ def _get_db_session(database) -> Generator[sessionmaker[Session], Any, None]:
         Base.metadata.drop_all(engine)
 
 
-@pytest.fixture(scope="function")
-def db_session(test_db):
+@pytest.fixture
+def db_session(test_db: PostgreSQLExecutor):
     """Session for SQLAlchemy."""
     yield from _make_db_session(test_db)
 
 
 @pytest.fixture(scope="class")
-def db_session_class(test_db):
+def db_session_class(test_db: PostgreSQLExecutor):
     """Session for SQLAlchemy."""
     yield from _make_db_session(test_db)
 
 
-@pytest.fixture(scope="function")
-def get_db_session(test_db):
+@pytest.fixture
+def get_db_session(test_db: PostgreSQLExecutor):
     """Session for SQLAlchemy with function scope."""
     yield from _get_db_session(test_db)
 
 
 @pytest.fixture(scope="class")
-def get_db_session_class(test_db):
+def get_db_session_class(test_db: PostgreSQLExecutor):
     """Session for SQLAlchemy with class scope."""
     yield from _get_db_session(test_db)
 
@@ -165,7 +175,7 @@ def alembic_config() -> dict[str, str]:
 
 
 @pytest.fixture
-def alembic_engine(test_db):
+def alembic_engine(test_db: PostgreSQLExecutor):
     """Return engine for pytest-alembic."""
     with DatabaseJanitor(
         user=test_db.user,
@@ -180,3 +190,44 @@ def alembic_engine(test_db):
             f"{test_db.user}:@{test_db.host}:{test_db.port}/{test_db.dbname}"
         )
         yield create_engine(connection_str)
+
+
+CONTAINER_TESTS_DIR = Path(__file__).parent / "container"
+
+
+def _is_inside_container_tests(path: Path) -> bool:
+    """Return True if path is the container smoke test dir or below it."""
+    try:
+        path.resolve().relative_to(CONTAINER_TESTS_DIR.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def _container_tests_requested(config: pytest.Config) -> bool:
+    """Return True if the user explicitly requested tests/container."""
+    rootpath = Path(config.rootpath)
+
+    for arg in config.args:
+        path_arg = arg.split("::", 1)[0]
+        candidate = Path(path_arg)
+        if not candidate.is_absolute():
+            candidate = rootpath / candidate
+
+        if _is_inside_container_tests(candidate):
+            return True
+
+    return False
+
+
+def pytest_ignore_collect(
+    collection_path: Path,
+    config: pytest.Config,
+) -> bool | None:
+    """Skip container smoke tests unless explicitly requested."""
+    if _is_inside_container_tests(collection_path) and not _container_tests_requested(
+        config
+    ):
+        return True
+
+    return None

--- a/tests/container/__init__.py
+++ b/tests/container/__init__.py
@@ -1,0 +1,1 @@
+"""Docker container smoke tests."""

--- a/tests/container/_helpers.py
+++ b/tests/container/_helpers.py
@@ -1,0 +1,225 @@
+"""Helpers shared across container smoke tests."""
+
+from __future__ import annotations
+
+import io
+import os
+import re
+import tarfile
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENV_FILE = REPO_ROOT / "azure-pipelines" / ".env"
+
+
+def parse_env_file(path: Path = ENV_FILE) -> dict[str, str]:
+    """Parse the azure-pipelines/.env file into a flat dict.
+
+    The file uses ``KEY=value`` and ``KEY="value"`` syntax.
+    """
+    values: dict[str, str] = {}
+    if not path.exists():
+        return values
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line_stripped = line.strip()
+        if not line_stripped or line_stripped.startswith("#"):
+            continue
+        match = re.match(r'^([A-Z0-9_]+)\s*=\s*"?(.*?)"?\s*$', line_stripped)
+        if not match:
+            continue
+        values[match.group(1)] = match.group(2)
+    return values
+
+
+EXPECTED = parse_env_file()
+
+
+def wait_for_log(
+    container: Any,
+    pattern: str,
+    timeout: float = 180.0,
+    interval: float = 1.0,
+) -> str:
+    """Poll the container's logs until ``pattern`` matches, then return the logs.
+
+    Raises ``TimeoutError`` on timeout.
+    """
+    compiled = re.compile(pattern)
+    deadline = time.monotonic() + timeout
+    last_logs = ""
+    while time.monotonic() < deadline:
+        last_logs = container.logs().decode("utf-8", errors="replace")
+        if compiled.search(last_logs):
+            return last_logs
+        time.sleep(interval)
+    raise TimeoutError(
+        f"Pattern {pattern!r} not seen within {timeout}s. Last logs:\n{last_logs}"
+    )
+
+
+def wait_for_http(
+    url: str,
+    timeout: float = 60.0,
+    interval: float = 1.0,
+    accept_status: tuple[int, ...] = (200, 301, 302, 401, 403),
+) -> requests.Response:
+    """Poll ``url`` until it returns one of ``accept_status`` codes."""
+    deadline = time.monotonic() + timeout
+    last_exc: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(url, timeout=5, allow_redirects=True)
+            if response.status_code in accept_status:
+                return response
+            last_exc = RuntimeError(f"Got status {response.status_code} from {url}")
+        except requests.RequestException as exc:
+            last_exc = exc
+        time.sleep(interval)
+    raise TimeoutError(f"Timed out waiting for {url}: {last_exc}")
+
+
+# Probe script lives next to this file and is shipped into the container with
+# ``install_http_probe`` (via the Docker SDK's ``put_archive``).  We can't
+# rely on bind-mounting because in the dev-container environment the test
+# process and the Docker daemon are on different filesystems.
+HTTP_PROBE_SOURCE = Path(__file__).parent / "scripts" / "http_probe.py"
+HTTP_PROBE_CONTAINER_PATH = "/tmp/viseron_http_probe.py"  # noqa: S108
+
+
+def _make_tar(items: dict[str, bytes]) -> bytes:
+    """Return an in-memory tar archive containing ``items``.
+
+    ``items`` maps archive-relative paths (relative to the extraction root) to
+    file contents.  Parent directory entries are emitted automatically so
+    ``put_archive`` can create them even when they don't already exist in the
+    container image.
+    """
+    buf = io.BytesIO()
+    dirs_added: set[str] = set()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        for name, data in items.items():
+            # Emit a directory entry for every ancestor that hasn't been added.
+            parts = name.split("/")
+            for depth in range(1, len(parts)):
+                dir_path = "/".join(parts[:depth])
+                if dir_path not in dirs_added:
+                    dir_info = tarfile.TarInfo(name=dir_path)
+                    dir_info.type = tarfile.DIRTYPE
+                    dir_info.mode = 0o755
+                    tar.addfile(dir_info)
+                    dirs_added.add(dir_path)
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            info.mode = 0o644
+            tar.addfile(info, io.BytesIO(data))
+    buf.seek(0)
+    return buf.getvalue()
+
+
+def put_abs(container: Any, container_path: str, data: bytes) -> None:
+    """Stream ``data`` to an absolute path inside ``container``.
+
+    Works regardless of whether intermediate directories exist in the
+    container image: the tar archive includes directory entries for all
+    parents, and Docker's extraction creates them on the fly.  This is
+    necessary for paths like ``/config/config.yaml`` where ``/config`` is
+    created by the S6 init scripts at *runtime*, not baked into the image.
+    """
+    rel = container_path.lstrip("/")  # e.g. "config/config.yaml"
+    container.put_archive("/", _make_tar({rel: data}))
+
+
+def create_directories(container: Any, *container_paths: str) -> None:
+    """Create empty directories at the given absolute paths inside ``container``.
+
+    Uses ``put_archive`` so it works regardless of filesystem visibility
+    between the test process and the Docker daemon.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        for path in container_paths:
+            rel = path.lstrip("/")
+            info = tarfile.TarInfo(name=rel)
+            info.type = tarfile.DIRTYPE
+            info.mode = 0o755
+            tar.addfile(info)
+    buf.seek(0)
+    container.put_archive("/", buf.getvalue())
+
+
+def put_file(container: Any, dest_dir: str, name: str, data: bytes) -> None:
+    """Stream a single file into ``container`` at ``dest_dir/name``.
+
+    ``dest_dir`` must already exist.  For paths whose parents may not yet
+    exist in the image, use :func:`put_abs` instead.
+    """
+    container.put_archive(dest_dir, _make_tar({name: data}))
+
+
+def put_directory(container: Any, src: Path, dest_dir: str) -> None:
+    """Recursively stream all files under ``src`` into ``container:dest_dir``."""
+    items: dict[str, bytes] = {}
+    for path in src.rglob("*"):
+        if path.is_file():
+            items[str(path.relative_to(src))] = path.read_bytes()
+    dest_prefix = dest_dir.lstrip("/")
+    if items:
+        abs_items = {
+            f"{dest_prefix}/{rel_path}": data for rel_path, data in items.items()
+        }
+        container.put_archive("/", _make_tar(abs_items))
+
+
+def install_http_probe(container: Any) -> str:
+    """Stream ``http_probe.py`` into ``container`` and return its path.
+
+    Uses `put_abs` so it works regardless of whether the test process
+    and the Docker daemon share a filesystem and regardless of whether the
+    target directory exists in the image.
+    """
+    put_abs(container, HTTP_PROBE_CONTAINER_PATH, HTTP_PROBE_SOURCE.read_bytes())
+    return HTTP_PROBE_CONTAINER_PATH
+
+
+def wait_for_http_in_container(
+    host: Any,
+    url: str,
+    timeout: float = 60.0,
+    interval: float = 1.0,
+    accept_status: tuple[int, ...] = (200, 301, 302, 401, 403),
+    probe_path: str = HTTP_PROBE_CONTAINER_PATH,
+) -> int:
+    """Poll ``url`` from *inside* the container until a known status code.
+
+    Runs ``python3 <probe_path> <url>`` via testinfra's ``host.run`` so the
+    probe executes in the container's own network namespace.
+
+    Returns the HTTP status code that was accepted.  Raises ``TimeoutError``
+    if no accepted status was observed before ``timeout`` elapses.
+    """
+    deadline = time.monotonic() + timeout
+    last_output = ""
+    while time.monotonic() < deadline:
+        cmd = host.run(f"python3 {probe_path} {url}")
+        last_output = (cmd.stdout + cmd.stderr).strip()
+        if cmd.rc == 0:
+            try:
+                status = int(last_output.splitlines()[-1].strip())
+            except (ValueError, IndexError):
+                status = -1
+            if status in accept_status:
+                return status
+        time.sleep(interval)
+    raise TimeoutError(
+        f"In-container probe of {url} timed out after {timeout}s. "
+        f"Last output:\n{last_output}"
+    )
+
+
+def is_qemu(arch: str) -> bool:
+    """Return True if the configured arch is being executed under qemu."""
+    return os.environ.get("VISERON_SMOKE_QEMU") == "1" or arch == "rpi3"

--- a/tests/container/binary_expectations.py
+++ b/tests/container/binary_expectations.py
@@ -1,0 +1,61 @@
+"""Architecture-specific binary expectations for container smoke tests."""
+
+from __future__ import annotations
+
+GO2RTC_BINARY = "/usr/local/bin/go2rtc"
+VAINFO_BINARY = "/usr/bin/vainfo"
+
+COMMON_CRITICAL_BINARIES = (
+    "/ffmpeg/bin/ffmpeg",
+    "/ffmpeg/bin/ffprobe",
+    "/ffmpeg/bin/zmqsend",
+    "/ffmpeg/bin/qt-faststart",
+    GO2RTC_BINARY,
+    "/usr/sbin/nginx",
+    "/usr/bin/MP4Box",
+    "/usr/bin/clinfo",
+)
+
+ARCH_CRITICAL_BINARIES = {
+    "amd64": (VAINFO_BINARY,),
+    "amd64-cuda": (VAINFO_BINARY,),
+    "aarch64": (),
+    "rpi3": (),
+}
+
+# Shared-library names (as regex fragments) that are known to require specific
+# hardware and therefore will legitimately be absent on a stock CI agent
+ARCH_OPTIONAL_SO_PATTERNS: dict[str, tuple[str, ...]] = {
+    "amd64-cuda": (
+        r"libcuda\.so\.",  # CUDA driver,requires NVIDIA GPU + driver
+        r"libcudart\.so\.",  # CUDA runtime (system copy)
+        r"libmlx5\.so\.",  # Mellanox ConnectX InfiniBand
+        r"librdmacm\.so\.",  # RDMA connection manager
+        r"libibverbs\.so\.",  # InfiniBand verbs
+        r"libfabric\.so\.",  # OpenFabrics libfabric (HPC interconnect)
+        r"libmpi\.so\.",  # MPI (e.g. OpenMPI)
+        r"libpmix\.so\.",  # PMIx process management
+        r"liboshmem\.so\.",  # OpenSHMEM
+        r"libucs\.so\.",  # UCX common services
+        r"libucp\.so\.",  # UCX protocols
+    ),
+}
+
+
+def expected_critical_binaries(arch: str) -> tuple[str, ...]:
+    """Return binaries that must exist in an image for ``arch``."""
+    if arch not in ARCH_CRITICAL_BINARIES:
+        raise ValueError(
+            f"No critical binary expectations declared for architecture {arch!r}"
+        )
+    return (*COMMON_CRITICAL_BINARIES, *ARCH_CRITICAL_BINARIES[arch])
+
+
+def binary_expected_for_arch(binary: str, arch: str) -> bool:
+    """Return True if ``binary`` is required for ``arch``."""
+    return binary in expected_critical_binaries(arch)
+
+
+def binary_test_id(binary: str) -> str:
+    """Return a readable pytest ID for a binary path."""
+    return binary.removeprefix("/").replace("/", "-")

--- a/tests/container/configs/minimal.yaml
+++ b/tests/container/configs/minimal.yaml
@@ -1,0 +1,7 @@
+# Minimal Viseron config used by the container smoke tests.
+#
+# Viseron always loads its core/default components (logger, data_stream,
+# webserver, storage). Specifying logger here forces a non-empty config so the
+# default-config heuristic in viseron/config.py does not kick in.
+logger:
+  default_level: info

--- a/tests/container/conftest.py
+++ b/tests/container/conftest.py
@@ -1,0 +1,332 @@
+"""Shared fixtures for container smoke tests.
+
+Boot the Viseron image once per test session, expose a ``testinfra`` host that
+runs commands inside the container, and tear the container down even if a
+test fails.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import docker
+import pytest
+import testinfra
+
+from . import _helpers as helpers
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+# Default ports
+NGINX_PORT = 8888
+WEBSERVER_PORT = 9999
+
+# Pattern logged by viseron once it has finished booting all components.
+READY_LOG_PATTERN = r"Viseron initialized in [\d.]+ seconds"
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register CLI options used by the container smoke tests."""
+    parser.addoption(
+        "--image",
+        action="store",
+        default=os.environ.get("VISERON_SMOKE_IMAGE", ""),
+        help="Full image reference under test, e.g. roflcoopter/amd64-viseron:dev",
+    )
+    parser.addoption(
+        "--arch",
+        action="store",
+        default=os.environ.get("VISERON_SMOKE_ARCH", "amd64"),
+        choices=["amd64", "amd64-cuda", "aarch64", "rpi3"],
+        help="Architecture being tested",
+    )
+    parser.addoption(
+        "--docker-platform",
+        action="store",
+        default=os.environ.get("VISERON_SMOKE_PLATFORM", ""),
+        help="Optional --platform value passed to docker run (e.g. linux/arm/v7)",
+    )
+    parser.addoption(
+        "--boot-timeout",
+        action="store",
+        type=float,
+        default=float(os.environ.get("VISERON_SMOKE_BOOT_TIMEOUT", "300")),
+        help="Seconds to wait for Viseron to log readiness",
+    )
+    parser.addoption(
+        "--keep-container",
+        action="store_true",
+        default=False,
+        help="Do not stop/remove the container on teardown (debug aid)",
+    )
+
+
+@pytest.fixture(scope="session")
+def image(request: pytest.FixtureRequest) -> str:
+    """Return the image reference under test."""
+    value = request.config.getoption("--image")
+    if not value:
+        pytest.fail(
+            "--image is required (e.g. roflcoopter/amd64-viseron:dev) or set "
+            "VISERON_SMOKE_IMAGE env var"
+        )
+    return value
+
+
+@pytest.fixture(scope="session")
+def arch(request: pytest.FixtureRequest) -> str:
+    """Return the architecture under test."""
+    return request.config.getoption("--arch")
+
+
+@pytest.fixture(scope="session")
+def docker_platform(request: pytest.FixtureRequest, arch: str) -> str:
+    """Return the docker --platform value to use."""
+    explicit = request.config.getoption("--docker-platform")
+    if explicit:
+        return explicit
+    return {
+        "amd64": "linux/amd64",
+        "amd64-cuda": "linux/amd64",
+        "aarch64": "linux/arm64",
+        "rpi3": "linux/arm/v7",
+    }.get(arch, "")
+
+
+@pytest.fixture(scope="session")
+def boot_timeout(request: pytest.FixtureRequest, arch: str) -> float:
+    """Return the boot timeout, with a longer default for QEMU runs."""
+    explicit = request.config.getoption("--boot-timeout")
+    # Bump default for QEMU so emulated startup is not flaky.
+    if helpers.is_qemu(arch) and explicit <= 30:
+        return 60.0
+    return explicit
+
+
+@pytest.fixture(scope="session")
+def docker_client() -> docker.DockerClient:
+    """Return a docker client wired to the local daemon."""
+    return docker.from_env()
+
+
+# Source config used when seeding the container's /config directory.
+_MINIMAL_CONFIG = Path(__file__).parent / "configs" / "minimal.yaml"
+
+# Container paths that Viseron expects to exist and be writable at startup.
+REQUIRED_STORAGE_DIRS = (
+    "/recordings",
+    "/segments",
+    "/snapshots",
+    "/thumbnails",
+    "/event_clips",
+)
+
+
+def _free_port() -> int:
+    """Return an unused TCP port on the host."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("", 0))
+        return sock.getsockname()[1]
+
+
+def _default_gateway() -> str | None:
+    """Return the default IPv4 gateway for the current network namespace."""
+    route_path = Path("/proc/net/route")
+    if not route_path.exists():
+        return None
+
+    for line in route_path.read_text(encoding="utf-8").splitlines()[1:]:
+        fields = line.split()
+        if len(fields) > 2 and fields[1] == "00000000":
+            gateway_hex = fields[2]
+            octets = [
+                str(int(gateway_hex[index : index + 2], 16)) for index in range(0, 8, 2)
+            ]
+            return ".".join(reversed(octets))
+    return None
+
+
+def _can_connect(host: str, port: int) -> bool:
+    """Return True if ``host:port`` accepts a TCP connection."""
+    try:
+        with socket.create_connection((host, port), timeout=0.25):
+            return True
+    except OSError:
+        return False
+
+
+def _published_port_host(port: int) -> str:
+    """Return the address pytest should use for a Docker-published port."""
+    if smoke_host := os.environ.get("VISERON_SMOKE_HOST"):
+        return smoke_host
+
+    if _can_connect("127.0.0.1", port):
+        return "127.0.0.1"
+
+    if Path("/.dockerenv").exists() and (gateway := _default_gateway()):
+        return gateway
+
+    return "127.0.0.1"
+
+
+@pytest.fixture(scope="session")
+def host_nginx_port() -> int:
+    """Pick a random free host port to map to the container's nginx port."""
+    return _free_port()
+
+
+@pytest.fixture(scope="session")
+def artifact_dir(request: pytest.FixtureRequest) -> Path:
+    """Return (and create) the directory where smoke-test artifacts are written.
+
+    Resolving this in its own fixture guarantees the directory exists even when
+    ``viseron_container`` fails before its own body runs (e.g. a fixture
+    dependency error), which would otherwise leave the directory empty.
+    """
+    path = Path(
+        os.environ.get(
+            "VISERON_SMOKE_ARTIFACT_DIR",
+            str(Path(request.config.rootpath) / "smoke-artifacts"),
+        )
+    )
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+@pytest.fixture(scope="session")
+def viseron_container(
+    docker_client: docker.DockerClient,
+    image: str,
+    docker_platform: str,
+    host_nginx_port: int,
+    boot_timeout: float,
+    artifact_dir: Path,
+    request: pytest.FixtureRequest,
+) -> Iterator[Any]:
+    """Start the Viseron container and yield it once it has booted.
+
+    Configuration and helper scripts are pushed into the container via
+    ``put_archive`` rather than bind-mounts. This works in every supported
+    environment including VS Code dev containers, where the test process and
+    the Docker daemon sit on different filesystems so volume paths in the test
+    process are not visible to the daemon.
+    """
+    container_name = f"viseron-smoke-{int(time.time())}"
+
+    run_kwargs: dict[str, Any] = {
+        "image": image,
+        "name": container_name,
+        "environment": {
+            "PUID": str(os.getuid()),
+            "PGID": str(os.getgid()),
+            "TZ": "UTC",
+        },
+        "ports": {f"{NGINX_PORT}/tcp": host_nginx_port},
+    }
+    if Path("/dev/dri").exists():
+        run_kwargs["devices"] = ["/dev/dri:/dev/dri"]
+    if docker_platform:
+        run_kwargs["platform"] = docker_platform
+
+    print(  # noqa: T201
+        f"\n[smoke] starting container {container_name} from {image} "
+        f"(platform={docker_platform or 'default'})"
+    )
+    try:
+        container = docker_client.containers.create(**run_kwargs)
+    except Exception as exc:
+        (artifact_dir / f"{container_name}-startup-error.txt").write_text(
+            f"Container failed to create:\n{exc}\n", encoding="utf-8"
+        )
+        raise
+
+    # Seed /config and required storage directories via the Docker socket
+    # before starting so Viseron reads the correct config from boot.
+    # Using put_abs/create_directories (not bind-mounts) so this works
+    # regardless of filesystem visibility, and regardless of whether the paths
+    # exist in the image at create-time (they may be created by S6 init scripts).
+    helpers.put_abs(container, "/config/config.yaml", _MINIMAL_CONFIG.read_bytes())
+    helpers.create_directories(container, *REQUIRED_STORAGE_DIRS)
+    helpers.install_http_probe(container)
+
+    try:
+        container.start()
+    except Exception as exc:
+        (artifact_dir / f"{container_name}-startup-error.txt").write_text(
+            f"Container failed to start:\n{exc}\n", encoding="utf-8"
+        )
+        container.remove(force=True)
+        raise
+
+    def _dump_artifacts() -> None:
+        """Dump container logs and inspect data on failure."""
+        try:
+            (artifact_dir / f"{container_name}.log").write_bytes(
+                container.logs(stdout=True, stderr=True)
+            )
+        except Exception as exc:  # pylint: disable=broad-except # noqa: BLE001
+            print(f"[smoke] could not capture logs: {exc}")  # noqa: T201
+        print(f"[smoke] artifacts saved to {artifact_dir}")  # noqa: T201
+
+    try:
+        helpers.wait_for_log(container, READY_LOG_PATTERN, timeout=boot_timeout)
+    except BaseException:
+        _dump_artifacts()
+        try:
+            container.stop(timeout=10)
+        finally:
+            container.remove(force=True)
+        raise
+
+    yield container
+
+    if request.session.testsfailed:
+        _dump_artifacts()
+
+    if request.config.getoption("--keep-container"):
+        print(  # noqa: T201
+            f"[smoke] --keep-container set; leaving {container_name} running"
+        )
+        return
+
+    try:
+        container.stop(timeout=15)
+    finally:
+        container.remove(force=True)
+
+
+@pytest.fixture(scope="session")
+def host(viseron_container: Any) -> testinfra.host.Host:
+    """Return a testinfra host bound to the running container."""
+    return testinfra.get_host(f"docker://{viseron_container.name}")
+
+
+@pytest.fixture(scope="session")
+def webserver_url(viseron_container: Any) -> str:
+    """Return the URL used to probe the nginx-fronted webserver.
+
+    The URL is intentionally the *internal* container address (loopback +
+    container-side nginx port).  Tests probe this URL from inside the
+    container via ``host.run`` so the test runner does not need network
+    reachability to the container's published port.
+    """
+    _ = viseron_container
+    return f"http://127.0.0.1:{NGINX_PORT}"
+
+
+@pytest.fixture(scope="session")
+def expected_versions() -> dict[str, str]:
+    """Return version constants sourced from azure-pipelines/.env."""
+    return helpers.EXPECTED
+
+
+@pytest.fixture(scope="session")
+def boot_logs(viseron_container: Any) -> str:
+    """Return the captured logs from the boot."""
+    return viseron_container.logs().decode("utf-8", errors="replace")

--- a/tests/container/scripts/__init__.py
+++ b/tests/container/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Helper scripts for container tests."""

--- a/tests/container/scripts/http_probe.py
+++ b/tests/container/scripts/http_probe.py
@@ -1,0 +1,42 @@
+"""Tiny HTTP probe used by the container smoke tests.
+
+This script runs *inside* the container (copied in via ``docker cp``) so the
+test does not need to reach the container's published port from the host.
+
+Usage:
+    python3 /tmp/http_probe.py <url>
+
+On success, prints the HTTP status code to stdout and exits 0.
+On failure, prints ``ERR <type> <message>`` to stdout and exits 1.
+"""
+
+from __future__ import annotations
+
+import sys
+import urllib.error
+import urllib.request
+
+
+def main() -> int:
+    """Probe ``sys.argv[1]`` with a 5s timeout and print the status code."""
+    if len(sys.argv) < 2:
+        print("ERR Usage http_probe.py <url>")  # noqa: T201
+        return 1
+    url = sys.argv[1]
+    try:
+        request = urllib.request.Request(url, method="GET")  # noqa: S310
+        response = urllib.request.urlopen(request, timeout=5)  # noqa: S310
+        print(response.status)  # noqa: T201
+    except urllib.error.HTTPError as exc:
+        # HTTP errors still carry a status code we want to consider.
+        print(exc.code)  # noqa: T201
+        return 0
+    except Exception as exc:  # pylint: disable=broad-except # noqa: BLE001
+        print(f"ERR {type(exc).__name__} {exc}")  # noqa: T201
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/container/test_binaries.py
+++ b/tests/container/test_binaries.py
@@ -1,0 +1,153 @@
+"""Verify the binaries built and bundled into the image work as expected."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .binary_expectations import GO2RTC_BINARY, VAINFO_BINARY, binary_expected_for_arch
+
+if TYPE_CHECKING:
+    import testinfra
+
+# Build flags expected on every architecture.
+COMMON_FFMPEG_FLAGS = (
+    "--enable-gpl",
+    "--enable-libaribb24",
+    "--enable-libass",
+    "--enable-libfdk_aac",
+    "--enable-libmp3lame",
+    "--enable-libopus",
+    "--enable-libsrt",
+    "--enable-libvmaf",
+    "--enable-libvorbis",
+    "--enable-libvpx",
+    "--enable-libwebp",
+    "--enable-libx264",
+    "--enable-libx265",
+    "--enable-libzimg",
+    "--enable-libzmq",
+    "--enable-static",
+    "--disable-shared",
+)
+
+# Architecture-specific expectations.
+ARCH_FFMPEG_REQUIRED = {
+    "amd64": ("--enable-libvpl", "--enable-libsvtav1"),
+    "amd64-cuda": (
+        "--enable-libvpl",
+        "--enable-libsvtav1",
+        "--enable-cuda",
+        "--enable-cuvid",
+        "--enable-nvenc",
+    ),
+    "aarch64": ("--enable-neon", "--enable-libsvtav1"),
+    "rpi3": ("--enable-neon",),
+}
+
+
+def test_ffmpeg_version_matches_env(
+    host: testinfra.host.Host, expected_versions: dict[str, str]
+) -> None:
+    """``ffmpeg -version`` should match ``FFMPEG_VERSION`` from .env."""
+    cmd = host.run("/ffmpeg/bin/ffmpeg -version")
+    assert cmd.rc == 0, cmd.stderr
+    expected = expected_versions.get("FFMPEG_VERSION")
+    assert expected, "FFMPEG_VERSION missing from azure-pipelines/.env"
+    first_line = cmd.stdout.splitlines()[0]
+    assert expected in first_line, f"expected ffmpeg {expected!r} in: {first_line!r}"
+
+
+def test_ffmpeg_buildconf_required_flags(host: testinfra.host.Host) -> None:
+    """``ffmpeg -buildconf`` should contain all required flags."""
+    cmd = host.run("/ffmpeg/bin/ffmpeg -hide_banner -buildconf")
+    assert cmd.rc == 0, cmd.stderr
+    missing = [flag for flag in COMMON_FFMPEG_FLAGS if flag not in cmd.stdout]
+    assert not missing, (
+        f"missing ffmpeg buildconf flags: {missing}\n\nbuildconf:\n{cmd.stdout}"
+    )
+
+
+def test_ffmpeg_buildconf_arch_specific_flags(
+    host: testinfra.host.Host, arch: str
+) -> None:
+    """Architecture-conditional flags should appear in the buildconf."""
+    required = ARCH_FFMPEG_REQUIRED.get(arch, ())
+    if not required:
+        pytest.skip(f"no arch-specific flags for {arch}")
+    cmd = host.run("/ffmpeg/bin/ffmpeg -hide_banner -buildconf")
+    assert cmd.rc == 0, cmd.stderr
+    missing = [flag for flag in required if flag not in cmd.stdout]
+    assert not missing, f"missing arch-specific flags for {arch}: {missing}"
+
+
+def test_ffmpeg_smoke_encode(host: testinfra.host.Host) -> None:
+    """A trivial lavfi → null encode must succeed."""
+    cmd = host.run(
+        "/ffmpeg/bin/ffmpeg -hide_banner -nostats "
+        "-f lavfi -i testsrc=duration=1:size=160x120:rate=10 "
+        "-f null -"
+    )
+    assert cmd.rc == 0, (
+        f"ffmpeg smoke encode failed: rc={cmd.rc}\n"
+        f"stdout=\n{cmd.stdout}\nstderr=\n{cmd.stderr}"
+    )
+
+
+def test_ffprobe_version(host: testinfra.host.Host) -> None:
+    """``ffprobe -version`` should run."""
+    cmd = host.run("/ffmpeg/bin/ffprobe -version")
+    assert cmd.rc == 0, cmd.stderr
+
+
+def test_mp4box_version(host: testinfra.host.Host) -> None:
+    """``MP4Box -version`` should run."""
+    cmd = host.run("MP4Box -version")
+    # MP4Box returns rc=0 with version on stderr/stdout depending on build.
+    assert (cmd.rc == 0) or ("MP4Box" in cmd.stdout + cmd.stderr), (
+        f"MP4Box version check failed: rc={cmd.rc}\n"
+        f"stdout=\n{cmd.stdout}\nstderr=\n{cmd.stderr}"
+    )
+
+
+def test_go2rtc_help(host: testinfra.host.Host) -> None:
+    """``go2rtc --help`` should exit cleanly."""
+    cmd = host.run(f"{GO2RTC_BINARY} --help")
+    # go2rtc --help exits non-zero on some versions; just assert binary works.
+    assert "go2rtc" in (cmd.stdout + cmd.stderr).lower(), (
+        f"go2rtc smoke failed: rc={cmd.rc}\n"
+        f"stdout=\n{cmd.stdout}\nstderr=\n{cmd.stderr}"
+    )
+
+
+def test_nginx_version(host: testinfra.host.Host) -> None:
+    """``nginx -v`` should print a version string."""
+    cmd = host.run("nginx -v")
+    output = cmd.stdout + cmd.stderr
+    assert "nginx version" in output, output
+
+
+def test_vainfo_runs(host: testinfra.host.Host, arch: str) -> None:
+    """``vainfo`` may report no device, but the binary itself must run.
+
+    We only assert that the binary did not segfault. Exit code is permissive
+    because there is no GPU device on the CI agent.
+    """
+    if not binary_expected_for_arch(VAINFO_BINARY, arch):
+        pytest.skip(f"{VAINFO_BINARY} is not expected in {arch} image")
+
+    executable = host.run(f"test -x {VAINFO_BINARY}")
+    assert executable.rc == 0, f"{VAINFO_BINARY} is expected in {arch} image"
+
+    cmd = host.run(f"{VAINFO_BINARY} --display drm --device /dev/dri/renderD128")
+    output = (cmd.stdout + cmd.stderr).lower()
+    assert cmd.rc != 127, (
+        f"vainfo command was not found: rc={cmd.rc}\n"
+        f"stdout=\n{cmd.stdout}\nstderr=\n{cmd.stderr}"
+    )
+    assert "segmentation fault" not in output, output
+    assert "vainfo" in output or "libva" in output, (
+        f"vainfo did not produce expected output:\nstdout=\n{cmd.stdout}\n"
+        f"stderr=\n{cmd.stderr}"
+    )

--- a/tests/container/test_init_scripts.py
+++ b/tests/container/test_init_scripts.py
@@ -1,0 +1,108 @@
+"""Verify the rootfs s6-overlay cont-init.d scripts populated container state."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    import testinfra
+
+ENV_FILES = (
+    "VISERON_CONFIG_DIR",
+    "VISERON_OPENCL_SUPPORTED",
+    "VISERON_VAAPI_SUPPORTED",
+    "VISERON_CUDA_SUPPORTED",
+    "XDG_RUNTIME_DIR",
+    "XDG_CURRENT_DESKTOP",
+)
+
+
+@pytest.mark.parametrize("env_var", ENV_FILES)
+def test_environment_files_populated(host: testinfra.host.Host, env_var: str) -> None:
+    """``/var/run/environment/<var>`` should exist and be non-empty."""
+    path = f"/var/run/environment/{env_var}"
+    file_ = host.file(path)
+    assert file_.exists, f"{path} was not created by cont-init.d"
+    content = file_.content_string.strip()
+    assert content, f"{path} is empty"
+
+
+def test_viseron_config_dir_value(host: testinfra.host.Host) -> None:
+    """``VISERON_CONFIG_DIR`` should be ``/config`` for the smoke run."""
+    file_ = host.file("/var/run/environment/VISERON_CONFIG_DIR")
+    assert file_.exists
+    assert file_.content_string.strip() == "/config"
+
+
+@pytest.mark.parametrize(
+    "env_var",
+    [
+        "VISERON_OPENCL_SUPPORTED",
+        "VISERON_VAAPI_SUPPORTED",
+        "VISERON_CUDA_SUPPORTED",
+    ],
+)
+def test_capability_env_files_are_boolean(
+    host: testinfra.host.Host, env_var: str
+) -> None:
+    """Capability detection scripts must write ``true`` or ``false``."""
+    file_ = host.file(f"/var/run/environment/{env_var}")
+    assert file_.exists
+    value = file_.content_string.strip()
+    assert value in {"true", "false"}, f"{env_var}={value!r} is not a boolean string"
+
+
+def test_user_abc_present(host: testinfra.host.Host) -> None:
+    """The ``abc`` user must exist with the correct uid.
+
+    The ``video`` group is added dynamically by the container init scripts only
+    if a render device is present, so we only check for membership in that group
+    when /dev/dri exists.
+    """
+    user = host.user("abc")
+    assert user.exists, "user 'abc' does not exist"
+    assert user.uid == os.getuid(), (
+        f"user 'abc' has uid {user.uid}, expected {os.getuid()}"
+    )
+    # Only assert the 'video' group when a render device was actually mounted
+    # into the container
+    if host.file("/dev/dri").exists:
+        assert "video" in user.groups, f"abc not in 'video' group, got {user.groups}"
+
+
+def test_postgres_ready(host: testinfra.host.Host) -> None:
+    """``pg_isready`` should report the local postgres as accepting."""
+    cmd = host.run("pg_isready -h /var/run/postgresql")
+    assert cmd.rc == 0, (
+        f"pg_isready failed: rc={cmd.rc}\nstdout=\n{cmd.stdout}\nstderr=\n{cmd.stderr}"
+    )
+
+
+def test_viseron_database_exists(host: testinfra.host.Host) -> None:
+    """The ``viseron`` database should have been created by 80-postgres."""
+    cmd = host.run(
+        'su - postgres -c "psql -tAc \\"SELECT 1 FROM pg_database '
+        "WHERE datname='viseron'\\\"\""
+    )
+    assert cmd.rc == 0, cmd.stderr
+    assert cmd.stdout.strip() == "1", (
+        f"viseron db not present:\nstdout=\n{cmd.stdout}\nstderr=\n{cmd.stderr}"
+    )
+
+
+def test_ffmpeg_wrapper_resolves(host: testinfra.host.Host) -> None:
+    """``which ffmpeg`` (as the abc user) should resolve to the wrapper."""
+    cmd = host.run("su - abc -c 'which ffmpeg'")
+    assert cmd.rc == 0, cmd.stderr
+    assert cmd.stdout.strip() == "/home/abc/bin/ffmpeg"
+
+
+def test_gstreamer_inspect_runs(host: testinfra.host.Host) -> None:
+    """``gst-inspect-1.0 --version`` should run and print a version."""
+    cmd = host.run("gst-inspect-1.0 --version")
+    output = cmd.stdout + cmd.stderr
+    assert cmd.rc == 0, output
+    assert "gst-inspect" in output.lower() or "gstreamer" in output.lower()

--- a/tests/container/test_libraries.py
+++ b/tests/container/test_libraries.py
@@ -1,0 +1,169 @@
+"""Verify library resolution for binaries and shared objects.
+
+Runs ``ldd`` against critical binaries and the core shared libraries shipped
+in the image to ensure the 24.04 upgrade did not leave any
+``=> not found`` entries. Statically linked binaries are accepted when ``ldd``
+reports them as static, but still have to be executable ELF files.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+
+from .binary_expectations import (
+    ARCH_OPTIONAL_SO_PATTERNS,
+    binary_test_id,
+    expected_critical_binaries,
+)
+
+ELF_MAGIC = ("7f", "45", "4c", "46")
+STATIC_LDD_MARKERS = (
+    "not a dynamic executable",
+    "statically linked",
+)
+
+# Library directories to recursively walk and ldd-check.
+LIB_DIRS = ("/usr/local/lib",)
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    """Generate architecture-specific binary library checks."""
+    if "binary" not in metafunc.fixturenames:
+        return
+
+    arch = metafunc.config.getoption("--arch")
+    try:
+        binaries = expected_critical_binaries(arch)
+    except ValueError as error:
+        raise pytest.UsageError(str(error)) from error
+    metafunc.parametrize("binary", binaries, ids=binary_test_id)
+
+
+def _ldd_reports_static(output: str) -> bool:
+    """Return True if ``ldd`` reports that the target is statically linked."""
+    output = output.lower()
+    return any(marker in output for marker in STATIC_LDD_MARKERS)
+
+
+def _static_binary_check(host: Any, path: str, ldd_output: str) -> None:
+    """Assert that ``path`` is an executable ELF binary with no dynamic deps."""
+    assert _ldd_reports_static(ldd_output), f"ldd did not report {path} as static"
+
+    executable = host.run(f"test -x {path}")
+    assert executable.rc == 0, f"{path} is not executable"
+
+    magic = host.run(f"od -An -tx1 -N4 {path}")
+    assert magic.rc == 0, (
+        f"failed to read ELF magic for {path}: rc={magic.rc}\n"
+        f"stdout=\n{magic.stdout}\n"
+        f"stderr=\n{magic.stderr}"
+    )
+    assert tuple(magic.stdout.split()) == ELF_MAGIC, f"{path} is not an ELF binary"
+
+    readelf = host.run("command -v readelf")
+    if readelf.rc != 0:
+        return
+
+    program_headers = host.run(f"readelf -lW {path}")
+    assert program_headers.rc == 0, (
+        f"failed to read program headers for {path}: rc={program_headers.rc}\n"
+        f"stdout=\n{program_headers.stdout}\n"
+        f"stderr=\n{program_headers.stderr}"
+    )
+    assert "Requesting program interpreter" not in program_headers.stdout, (
+        f"{path} unexpectedly has a dynamic interpreter\n{program_headers.stdout}"
+    )
+
+    dynamic_section = host.run(f"readelf -dW {path} 2>&1")
+    dynamic_output = dynamic_section.stdout + dynamic_section.stderr
+    assert dynamic_section.rc == 0 or "There is no dynamic section" in dynamic_output, (
+        f"failed to read dynamic section for {path}: rc={dynamic_section.rc}\n"
+        f"stdout=\n{dynamic_section.stdout}\n"
+        f"stderr=\n{dynamic_section.stderr}"
+    )
+    assert "(NEEDED)" not in dynamic_output, (
+        f"{path} unexpectedly has dynamic dependencies\n{dynamic_output}"
+    )
+
+
+# Output fragments produced by ldd when QEMU emulation crashes the target binary.
+# This is a QEMU limitation, not a missing-dependency failure.
+_QEMU_CRASH_MARKERS = (
+    "qemu: uncaught target signal",
+    "segmentation fault",
+    "core dumped",
+)
+
+
+def _ldd_check(host: Any, path: str) -> None:
+    """Run ``ldd`` against ``path`` and assert no missing libraries."""
+    cmd = host.run(f"ldd {path} 2>&1")
+    output = cmd.stdout + cmd.stderr
+    if _ldd_reports_static(output):
+        _static_binary_check(host, path, output)
+        return
+
+    # Under QEMU emulation ldd itself can crash with a segfault.  This is a
+    # known QEMU limitation and does not indicate missing dependencies.
+    if any(marker in output.lower() for marker in _QEMU_CRASH_MARKERS):
+        pytest.skip(
+            f"ldd crashed under QEMU for {path}, skipping library resolution check"
+        )
+
+    assert cmd.rc == 0, (
+        f"ldd failed for {path}: rc={cmd.rc}\n"
+        f"stdout=\n{cmd.stdout}\n"
+        f"stderr=\n{cmd.stderr}"
+    )
+    missing = [line.strip() for line in output.splitlines() if "not found" in line]
+    assert not missing, f"Missing libraries for {path}:\n  " + "\n  ".join(missing)
+
+
+def test_binary_libraries_resolve(host: Any, arch: str, binary: str) -> None:
+    """Each critical binary must have all of its dependencies resolvable."""
+    assert host.file(binary).exists, f"{binary} is expected in {arch} image"
+    _ldd_check(host, binary)
+
+
+@pytest.mark.parametrize("lib_dir", LIB_DIRS)
+def test_shared_objects_resolve(host: Any, arch: str, lib_dir: str) -> None:
+    """All ``*.so*`` files under each library directory must resolve.
+
+    Missing libraries that match ``ARCH_OPTIONAL_SO_PATTERNS`` for the current
+    architecture are silently ignored because they require hardware that is not
+    present on a stock CI agent (e.g. CUDA driver).
+    """
+    if not host.file(lib_dir).exists:
+        pytest.skip(f"{lib_dir} not present in image")
+    find = host.run(f"find {lib_dir} -type f \\( -name '*.so' -o -name '*.so.*' \\)")
+    assert find.rc == 0, find.stderr
+    libs = [line for line in find.stdout.splitlines() if line]
+    assert libs, f"no shared objects found under {lib_dir}"
+
+    optional_patterns = [re.compile(p) for p in ARCH_OPTIONAL_SO_PATTERNS.get(arch, ())]
+
+    failures: list[str] = []
+    for lib in libs:
+        # Prepend the lib's own directory to LD_LIBRARY_PATH so that ldd can
+        # resolve sibling libraries inside manylinux/auditwheel *.libs/ bundles.
+        lib_dir = lib.rsplit("/", 1)[0]
+        cmd = host.run(
+            f"LD_LIBRARY_PATH={lib_dir}:${{LD_LIBRARY_PATH:-}} "
+            f"ldd {lib} 2>&1 | grep 'not found' || true"
+        )
+        if not cmd.stdout.strip():
+            continue
+        # Filter lines that match a known hardware-optional library.
+        real_missing = [
+            line
+            for line in cmd.stdout.splitlines()
+            if line.strip() and not any(pat.search(line) for pat in optional_patterns)
+        ]
+        if real_missing:
+            failures.append(f"{lib}:\n" + "\n".join(real_missing))
+    assert not failures, "shared objects with unresolved deps:\n\n" + "\n\n".join(
+        failures
+    )

--- a/tests/container/test_python_imports.py
+++ b/tests/container/test_python_imports.py
@@ -1,0 +1,84 @@
+"""Verify the Python environment inside the image."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    import testinfra
+
+PYTHON_IMPORTS = (
+    "cv2",
+    "numpy",
+    "sqlalchemy",
+    "alembic",
+    "viseron",
+    "viseron.components",
+    "viseron.components.webserver",
+    "viseron.components.storage",
+    "tornado",
+    "voluptuous",
+    "ruamel.yaml",
+    "hailo_platform",
+)
+
+# Modules that are not packaged for certain architectures.
+# Tests for these modules are skipped on the listed architectures.
+_ARCH_EXCLUDED_IMPORTS: dict[str, set[str]] = {
+    # hailo_platform is only provided for amd64 and aarch64.
+    "rpi3": {"hailo_platform"},
+}
+
+
+@pytest.mark.parametrize("module", PYTHON_IMPORTS)
+def test_python_module_imports(
+    host: testinfra.host.Host, module: str, arch: str
+) -> None:
+    """Each module must import without raising."""
+    if module in _ARCH_EXCLUDED_IMPORTS.get(arch, set()):
+        pytest.skip(f"{module} is not available on {arch}")
+    cmd = host.run(f"python3 -c 'import {module}'")
+    assert cmd.rc == 0, (
+        f"failed to import {module}:\nstdout=\n{cmd.stdout}\nstderr=\n{cmd.stderr}"
+    )
+
+
+def test_cv2_version_matches_env(host: testinfra.host.Host, expected_versions) -> None:
+    """``cv2.__version__`` should match ``OPENCV_VERSION`` from .env."""
+    expected = expected_versions.get("OPENCV_VERSION")
+    assert expected, "OPENCV_VERSION missing from azure-pipelines/.env"
+    cmd = host.run("python3 -c 'import cv2; print(cv2.__version__)'")
+    assert cmd.rc == 0, cmd.stderr
+    assert cmd.stdout.strip() == expected, (
+        f"cv2.__version__={cmd.stdout.strip()!r} expected {expected!r}"
+    )
+
+
+def test_cv2_built_without_ffmpeg(host: testinfra.host.Host) -> None:
+    """``cv2.getBuildInformation()`` should report FFMPEG: NO."""
+    cmd = host.run("python3 -c 'import cv2; print(cv2.getBuildInformation())'")
+    assert cmd.rc == 0, cmd.stderr
+    assert "FFMPEG" in cmd.stdout
+    ffmpeg_lines = [
+        line for line in cmd.stdout.splitlines() if "FFMPEG" in line and ":" in line
+    ]
+    assert ffmpeg_lines, "FFMPEG section not found in cv2 build info"
+    assert any("NO" in line for line in ffmpeg_lines), (
+        "FFMPEG enabled in cv2 build info:\n" + "\n".join(ffmpeg_lines)
+    )
+
+
+def test_viseron_metadata(host: testinfra.host.Host) -> None:
+    """``viseron`` must expose its version and basic component module."""
+    cmd = host.run(
+        'python3 -c "'
+        "import json, viseron; "
+        "print(json.dumps({'version': getattr(viseron, '__version__', None), "
+        "'has_components': hasattr(viseron, 'components')}))\""
+    )
+    assert cmd.rc == 0, cmd.stderr
+    payload = json.loads(cmd.stdout.strip())
+    assert payload["has_components"] is True

--- a/tests/container/test_viseron_app.py
+++ b/tests/container/test_viseron_app.py
@@ -1,0 +1,43 @@
+"""Verify the Viseron application boots and serves traffic."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from . import _helpers as helpers
+
+if TYPE_CHECKING:
+    import testinfra
+
+# Lines that we treat as fatal in the boot logs.
+FATAL_LOG_PATTERNS = (
+    re.compile(r"^Traceback \(most recent call last\):", re.MULTILINE),
+    re.compile(r"\b(viseron(\.[\w\.]+)?)\b\s+ERROR\b", re.IGNORECASE | re.MULTILINE),
+)
+
+
+def test_viseron_process_running(host: testinfra.host.Host) -> None:
+    """The viseron python process must be running."""
+    cmd = host.run("pgrep -f 'python3 .*-m viseron'")
+    assert cmd.rc == 0, (
+        f"no viseron process found: rc={cmd.rc}\n"
+        f"stdout=\n{cmd.stdout}\nstderr=\n{cmd.stderr}"
+    )
+
+
+def test_webserver_responds(host: testinfra.host.Host, webserver_url: str) -> None:
+    """The nginx-fronted webserver should answer HTTP requests."""
+    status = helpers.wait_for_http_in_container(host, webserver_url, timeout=30.0)
+    assert status in (200, 301, 302, 401, 403), (
+        f"unexpected status {status} from {webserver_url}"
+    )
+
+
+def test_boot_logs_have_no_tracebacks(boot_logs: str) -> None:
+    """Boot logs must not contain a Python traceback."""
+    matches = [match.group(0) for match in FATAL_LOG_PATTERNS[0].finditer(boot_logs)]
+    assert not matches, (
+        f"found {len(matches)} traceback(s) in boot logs. First 2KB of logs:\n"
+        f"{boot_logs[:2048]}"
+    )


### PR DESCRIPTION
Adds a new test harness for running live tests of the built containers, asserting that libraries and binaries exists, and that Viseron starts up properly.

Can be extended in the future to include more testing to avoid regressions