### PR TITLE
Fix browser auth for stream fallback

### DIFF
--- a/viseron/components/webserver/api/handlers.py
+++ b/viseron/components/webserver/api/handlers.py
@@ -265,6 +265,8 @@ class BaseAPIHandler(ViseronRequestHandler):
             auth_header = self.request.headers.get("Authorization", None)
 
         if auth_header is None:
+            if self.browser_request and self.validate_cookie_session():
+                return True
             LOGGER.debug("Auth header is missing")
             return False
 
@@ -278,9 +280,14 @@ class BaseAPIHandler(ViseronRequestHandler):
             LOGGER.debug(f"Auth type not Bearer: {auth_type}")
             return False
 
-        return self.validate_access_token(
+        if self.validate_access_token(
             auth_val, check_refresh_token=self.browser_request
-        )
+        ):
+            return True
+
+        if self.browser_request and self.validate_cookie_session():
+            return True
+        return False
 
     def _allow_token_parameter(self, schema: Schema, route: Route) -> Schema:
         """Allow token parameter in schema."""

--- a/viseron/components/webserver/request_handler.py
+++ b/viseron/components/webserver/request_handler.py
@@ -263,6 +263,48 @@ class ViseronRequestHandler(tornado.web.RequestHandler):
 
         return True
 
+    def validate_cookie_session(self) -> bool:
+        """Validate the browser cookie session.
+
+        Browser API requests normally authenticate with the JWT header/payload from
+        localStorage plus the signature cookie. If localStorage is stale or missing
+        while the httpOnly session cookies are still valid, fall back to the cookie
+        session instead of leaving the UI in an unauthenticated limbo.
+        """
+        if not self._webserver.auth:
+            raise RuntimeError("Auth is not set up, cannot validate cookie session.")
+
+        refresh_token_cookie = self.get_secure_cookie("refresh_token")
+        static_asset_key = self.get_secure_cookie("static_asset_key")
+        if refresh_token_cookie is None or static_asset_key is None:
+            LOGGER.debug("Cookie session is missing refresh token or static asset key")
+            return False
+
+        refresh_token = self._webserver.auth.get_refresh_token_from_token(
+            refresh_token_cookie.decode()
+        )
+        if refresh_token is None:
+            LOGGER.debug("Refresh token cookie is not valid")
+            return False
+
+        if not hmac.compare_digest(
+            refresh_token.static_asset_key, static_asset_key.decode()
+        ):
+            LOGGER.debug("Static asset key does not belong to the refresh token")
+            return False
+
+        user = self._webserver.auth.get_user(refresh_token.user_id)
+        if user is None or not user.enabled:
+            LOGGER.debug("Cookie session user not found or disabled")
+            return False
+
+        if self.current_user is not None and self.current_user != user:
+            LOGGER.debug("Cookie session user mismatch")
+            return False
+
+        self.current_user = user
+        return True
+
     def _get_cameras(self) -> None | dict[str, AbstractCamera]:
         """Get all registered camera instances."""
         try:

--- a/viseron/components/webserver/stream_handler.py
+++ b/viseron/components/webserver/stream_handler.py
@@ -9,6 +9,7 @@ from http import HTTPStatus
 from typing import TYPE_CHECKING, ClassVar
 
 import cv2
+import httpx
 import imutils
 import tornado.ioloop
 import tornado.web
@@ -17,6 +18,15 @@ from tornado.queues import Queue
 from viseron.components.nvr.const import EVENT_PROCESSED_FRAME_TOPIC
 from viseron.const import TOPIC_STATIC_MJPEG_STREAMS
 from viseron.domains.camera.config import MJPEG_STREAM_SCHEMA
+from viseron.domains.camera.const import (
+    AUTHENTICATION_BASIC,
+    AUTHENTICATION_DIGEST,
+    CONFIG_AUTHENTICATION,
+    CONFIG_PASSWORD,
+    CONFIG_REFRESH_INTERVAL,
+    CONFIG_URL,
+    CONFIG_USERNAME,
+)
 from viseron.domains.motion_detector import AbstractMotionDetectorScanner
 from viseron.events import EventData
 from viseron.exceptions import DomainNotRegisteredError
@@ -90,13 +100,50 @@ class StreamHandler(ViseronRequestHandler):
         )
         self.set_header("Pragma", "no-cache")
 
-    async def write_jpg(self, jpg: np.ndarray) -> None:
+    async def write_jpg(self, jpg: np.ndarray | bytes) -> None:
         """Set the headers and write the jpg data."""
+        jpg_bytes = jpg if isinstance(jpg, bytes) else jpg.tobytes()
         self.write(f"{BOUNDARY}\r\n")
         self.write("Content-type: image/jpeg\r\n")
-        self.write(f"Content-length: {len(jpg)}\r\n\r\n")
-        self.write(jpg.tobytes())
+        self.write(f"Content-length: {len(jpg_bytes)}\r\n\r\n")
+        self.write(jpg_bytes)
         await self.flush()
+
+    @staticmethod
+    def _get_still_image_auth(camera):
+        """Return auth for a configured still image."""
+        if (
+            camera.still_image
+            and camera.still_image[CONFIG_USERNAME]
+            and camera.still_image[CONFIG_PASSWORD]
+        ):
+            if camera.still_image[CONFIG_AUTHENTICATION] == AUTHENTICATION_DIGEST:
+                return httpx.DigestAuth(
+                    camera.still_image[CONFIG_USERNAME],
+                    camera.still_image[CONFIG_PASSWORD],
+                )
+            if camera.still_image[CONFIG_AUTHENTICATION] == AUTHENTICATION_BASIC:
+                return httpx.BasicAuth(
+                    camera.still_image[CONFIG_USERNAME],
+                    camera.still_image[CONFIG_PASSWORD],
+                )
+        return None
+
+    def still_image_jpg(self, camera) -> bytes | None:
+        """Fetch a configured still image and return JPEG bytes."""
+        response = httpx.get(
+            camera.still_image[CONFIG_URL],
+            auth=self._get_still_image_auth(camera),
+            timeout=10,
+        )
+        if response.status_code != HTTPStatus.OK.value:
+            LOGGER.warning(
+                "Failed to fetch still image for MJPEG stream %s: %s",
+                camera.identifier,
+                response.status_code,
+            )
+            return None
+        return response.content
 
     @staticmethod
     def process_frame(
@@ -200,14 +247,26 @@ class DynamicStreamHandler(StreamHandler):
 
         self._set_stream_headers()
 
+        wait_timeout = 1 if nvr.camera.still_image_configured else None
+
         while True:
             try:
-                processed_frame = await frame_queue.get()
+                processed_frame = (
+                    await asyncio.wait_for(frame_queue.get(), timeout=wait_timeout)
+                    if wait_timeout
+                    else await frame_queue.get()
+                )
                 ret, jpg = await self.run_in_executor(
                     self.process_frame, nvr, processed_frame.data, mjpeg_stream_config
                 )
 
                 if ret:
+                    await self.write_jpg(jpg)
+            except asyncio.TimeoutError:
+                if not nvr.camera.still_image_configured:
+                    continue
+                jpg = await self.run_in_executor(self.still_image_jpg, nvr.camera)
+                if jpg:
                     await self.write_jpg(jpg)
             except (
                 tornado.iostream.StreamClosedError,


### PR DESCRIPTION
This is the browser/webserver stream-auth portion split out from #1373 after maintainer feedback that the original PR mixed unrelated changes.

What changed:
- Improves browser API auth handling for stream fallback flows.
- Lets stream handlers use browser session authentication consistently where appropriate.
- Keeps this separate from FFmpeg camera retry/backoff behavior.

