### PR TITLE
fix: save user_token when saving PATs

### DIFF
--- a/viseron/components/webserver/auth.py
+++ b/viseron/components/webserver/auth.py
@@ -158,6 +158,7 @@ class AccessToken:
         return {
             "id": self.id,
             "name": self.name,
+            "user_id": self.user_id,
             "created_at": self.created_at,
             "expires_at": self.expires_at,
             "last_used_at": self.last_used_at,


### PR DESCRIPTION
This prevents a crash when restarting Viseron after having created a PAT

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/tornado/web.py", line 1769, in _execute
    result = await result  # type: ignore
             ^^^^^^^^^^^^
  File "/src/viseron/components/webserver/stream_handler.py", line 71, in prepare
    if not await self.run_in_executor(self.validate_camera_token, camera):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/src/viseron/components/webserver/request_handler.py", line 54, in run_in_executor
    return await self.ioloop.run_in_executor(None, func, *args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/src/viseron/components/webserver/request_handler.py", line 422, in validate_camera_token
    if token.startswith("vpat_") and self._validate_camera_pat(token, camera):
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/src/viseron/components/webserver/request_handler.py", line 440, in _validate_camera_pat
    pat = self._webserver.auth.validate_access_token_pat(raw_token)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/src/viseron/components/webserver/auth.py", line 767, in validate_access_token_pat
    tokens_snapshot = list(self.access_tokens.values())
                           ^^^^^^^^^^^^^^^^^^
  File "/src/viseron/components/webserver/auth.py", line 282, in access_tokens
    self._load()
  File "/src/viseron/components/webserver/auth.py", line 566, in _load
    user_id=pat["user_id"],
            ~~~^^^^^^^^^^^
KeyError: 'user_id'
```