### PR TITLE
fix: save also token_hash when saving PATs

### DIFF
--- a/viseron/components/webserver/auth.py
+++ b/viseron/components/webserver/auth.py
@@ -159,6 +159,7 @@ class AccessToken:
             "id": self.id,
             "name": self.name,
             "user_id": self.user_id,
+            "token_hash": self.token_hash,
             "created_at": self.created_at,
             "expires_at": self.expires_at,
             "last_used_at": self.last_used_at,


### PR DESCRIPTION
Another crash on load due to this missing field; maybe there should be a test, but couldn't figure out how to wire it.