### PR TITLE
feat: add confirmation dialog when deleting

### DIFF
--- a/frontend/src/components/dialog/ConfirmDeleteDialog.tsx
+++ b/frontend/src/components/dialog/ConfirmDeleteDialog.tsx
@@ -1,0 +1,46 @@
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogTitle from "@mui/material/DialogTitle";
+
+interface ConfirmDeleteDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  isPending: boolean;
+  title: string;
+  description: string;
+}
+
+export default function ConfirmDeleteDialog({
+  open,
+  onClose,
+  onConfirm,
+  isPending,
+  title,
+  description,
+}: ConfirmDeleteDialogProps) {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        <DialogContentText>{description}</DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={isPending}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          color="error"
+          loading={isPending}
+          onClick={onConfirm}
+        >
+          Delete
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/recording/RecordingCard.tsx
+++ b/frontend/src/components/recording/RecordingCard.tsx
@@ -12,9 +12,11 @@ import Stack from "@mui/material/Stack";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { useTheme } from "@mui/material/styles";
+import { useState } from "react";
 import LazyLoad from "react-lazyload";
 
 import MutationIconButton from "components/buttons/MutationIconButton";
+import ConfirmDeleteDialog from "components/dialog/ConfirmDeleteDialog";
 import LicensePlateRecognitionIcon from "components/icons/LicensePlateRecognition";
 import { getVideoElement } from "components/player/utils";
 import VideoPlayerPlaceholder from "components/player/videoplayer/VideoPlayerPlaceholder";
@@ -38,6 +40,7 @@ export default function RecordingCard({
   const theme = useTheme();
   const { user } = useAuthContext();
   const deleteRecording = useDeleteRecording();
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   return (
     <Card
@@ -105,18 +108,29 @@ export default function RecordingCard({
               <MutationIconButton
                 mutation={deleteRecording}
                 color="error"
-                onClick={() => {
-                  deleteRecording.mutate({
-                    identifier: camera.identifier,
-                    recording_id: recording.id,
-                    failed: camera.failed,
-                  });
-                }}
+                onClick={() => setConfirmOpen(true)}
               >
                 <TrashCan size={20} />
               </MutationIconButton>
             </Tooltip>
           </Stack>
+          <ConfirmDeleteDialog
+            open={confirmOpen}
+            onClose={() => setConfirmOpen(false)}
+            onConfirm={() => {
+              deleteRecording.mutate(
+                {
+                  identifier: camera.identifier,
+                  recording_id: recording.id,
+                  failed: camera.failed,
+                },
+                { onSuccess: () => setConfirmOpen(false) },
+              );
+            }}
+            isPending={deleteRecording.isPending}
+            title="Delete recording"
+            description="Delete this recording? This action cannot be undone."
+          />
         </CardActions>
       ) : null}
     </Card>

--- a/frontend/src/components/recording/RecordingCardDaily.tsx
+++ b/frontend/src/components/recording/RecordingCardDaily.tsx
@@ -13,10 +13,12 @@ import Stack from "@mui/material/Stack";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { useTheme } from "@mui/material/styles";
+import { useState } from "react";
 import LazyLoad from "react-lazyload";
 import { Link } from "react-router-dom";
 
 import MutationIconButton from "components/buttons/MutationIconButton";
+import ConfirmDeleteDialog from "components/dialog/ConfirmDeleteDialog";
 import { getVideoElement } from "components/player/utils";
 import VideoPlayerPlaceholder from "components/player/videoplayer/VideoPlayerPlaceholder";
 import { useAuthContext } from "context/AuthContext";
@@ -44,6 +46,7 @@ export default function RecordingCardDaily({
   const theme = useTheme();
   const { user } = useAuthContext();
   const deleteRecording = useDeleteRecording();
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   return (
     <Card
@@ -132,23 +135,36 @@ export default function RecordingCardDaily({
               </span>
             </Tooltip>
             {!user || user.role === "admin" || user.role === "write" ? (
-              <Tooltip title="Delete All Videos">
-                <span>
-                  <MutationIconButton
-                    mutation={deleteRecording}
-                    color="error"
-                    onClick={() => {
-                      deleteRecording.mutate({
+              <>
+                <Tooltip title="Delete All Videos">
+                  <span>
+                    <MutationIconButton
+                      mutation={deleteRecording}
+                      color="error"
+                      onClick={() => setConfirmOpen(true)}
+                    >
+                      <TrashCan size={20} />
+                    </MutationIconButton>
+                  </span>
+                </Tooltip>
+                <ConfirmDeleteDialog
+                  open={confirmOpen}
+                  onClose={() => setConfirmOpen(false)}
+                  onConfirm={() => {
+                    deleteRecording.mutate(
+                      {
                         identifier: camera.identifier,
                         date,
                         failed: camera.failed,
-                      });
-                    }}
-                  >
-                    <TrashCan size={20} />
-                  </MutationIconButton>
-                </span>
-              </Tooltip>
+                      },
+                      { onSuccess: () => setConfirmOpen(false) },
+                    );
+                  }}
+                  isPending={deleteRecording.isPending}
+                  title="Delete all videos"
+                  description={`Delete all recordings for ${getDisplayDateStringFromDayjs(getDayjsFromDateString(date))}? This action cannot be undone.`}
+                />
+              </>
             ) : null}
           </Stack>
         </Stack>

--- a/frontend/src/components/recording/RecordingCardLatest.tsx
+++ b/frontend/src/components/recording/RecordingCardLatest.tsx
@@ -10,10 +10,12 @@ import Stack from "@mui/material/Stack";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { useTheme } from "@mui/material/styles";
+import { useState } from "react";
 import LazyLoad from "react-lazyload";
 import { Link } from "react-router-dom";
 
 import MutationIconButton from "components/buttons/MutationIconButton";
+import ConfirmDeleteDialog from "components/dialog/ConfirmDeleteDialog";
 import { getVideoElement } from "components/player/utils";
 import VideoPlayerPlaceholder from "components/player/videoplayer/VideoPlayerPlaceholder";
 import { useAuthContext } from "context/AuthContext";
@@ -39,6 +41,7 @@ export default function RecordingCardLatest({
   const theme = useTheme();
   const { user } = useAuthContext();
   const deleteRecording = useDeleteRecording();
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   const recordingsQuery = useRecordings({
     camera_identifier,
@@ -195,23 +198,33 @@ export default function RecordingCardLatest({
               </span>
             </Tooltip>
             {!user || user.role === "admin" || user.role === "write" ? (
-              <Tooltip title="Delete Recordings">
-                <span>
-                  <MutationIconButton
-                    mutation={deleteRecording}
-                    disabled={!objHasValues(recording)}
-                    color="error"
-                    onClick={() => {
-                      deleteRecording.mutate({
-                        identifier: camera_identifier,
-                        failed,
-                      });
-                    }}
-                  >
-                    <TrashCan size={20} />
-                  </MutationIconButton>
-                </span>
-              </Tooltip>
+              <>
+                <Tooltip title="Delete Recordings">
+                  <span>
+                    <MutationIconButton
+                      mutation={deleteRecording}
+                      disabled={!objHasValues(recording)}
+                      color="error"
+                      onClick={() => setConfirmOpen(true)}
+                    >
+                      <TrashCan size={20} />
+                    </MutationIconButton>
+                  </span>
+                </Tooltip>
+                <ConfirmDeleteDialog
+                  open={confirmOpen}
+                  onClose={() => setConfirmOpen(false)}
+                  onConfirm={() => {
+                    deleteRecording.mutate(
+                      { identifier: camera_identifier, failed },
+                      { onSuccess: () => setConfirmOpen(false) },
+                    );
+                  }}
+                  isPending={deleteRecording.isPending}
+                  title="Delete all recordings"
+                  description={`Delete all recordings for ${cameraQuery.data?.name ?? camera_identifier}? This action cannot be undone.`}
+                />
+              </>
             ) : null}
           </Stack>
         </Stack>


### PR DESCRIPTION
I think it's too dangerous to allow deleting all recordings on a single tap; I am adding here a confirmation dialog for both individual and all recordings.

Let me know if you prefer to have this differently.