### PR TITLE
Revert "fix: save user_token when saving PATs"

### DIFF
--- a/viseron/components/webserver/auth.py
+++ b/viseron/components/webserver/auth.py
@@ -158,7 +158,6 @@ class AccessToken:
         return {
             "id": self.id,
             "name": self.name,
-            "user_id": self.user_id,
             "created_at": self.created_at,
             "expires_at": self.expires_at,
             "last_used_at": self.last_used_at,


### PR DESCRIPTION
This reverts commit 96cd0604b900a11a998c29c57ef289594a72847e.

It is not necessary, the `user_id` field is already saved correctly.