### PR TITLE
fix: disable Ultralytics telemetry, always enabled by default

### DIFF
--- a/viseron/components/webserver/api/v1/tuning/labels.py
+++ b/viseron/components/webserver/api/v1/tuning/labels.py
@@ -8,8 +8,13 @@ from ultralytics import YOLO
 from viseron.components.darknet.const import DEFAULT_LABEL_PATH as DARKNET_LABEL_PATH
 from viseron.components.edgetpu.const import DEFAULT_CLASSIFIER_LABEL_PATH
 from viseron.components.hailo.const import DEFAULT_LABEL_PATH as HAILO_LABEL_PATH
+from viseron.helpers.ultralytics_telemetry import disable_ultralytics_telemetry
 
 LOGGER = logging.getLogger(__name__)
+
+# Opt out of ultralytics' built-in analytics/crash reporting at import time,
+# before any model is loaded.
+disable_ultralytics_telemetry()
 
 CODEPROJECTAI_MODELS = {
     "ipcam-animal": [

--- a/viseron/components/yolo/object_detector.py
+++ b/viseron/components/yolo/object_detector.py
@@ -12,6 +12,7 @@ from viseron import Viseron
 from viseron.domains.object_detector import AbstractObjectDetector
 from viseron.domains.object_detector.detected_object import DetectedObject
 from viseron.exceptions import DomainNotReady
+from viseron.helpers.ultralytics_telemetry import disable_ultralytics_telemetry
 
 from .const import (
     COMPONENT,
@@ -24,6 +25,10 @@ from .const import (
 )
 
 LOGGER = logging.getLogger(__name__)
+
+# Opt out of ultralytics' built-in analytics/crash reporting at import time,
+# before any model is loaded.
+disable_ultralytics_telemetry()
 
 
 def setup(vis: Viseron, config: dict[str, Any], identifier: str) -> bool:

--- a/viseron/helpers/ultralytics_telemetry.py
+++ b/viseron/helpers/ultralytics_telemetry.py
@@ -1,0 +1,19 @@
+"""Helpers for the third-party ultralytics package."""
+
+from ultralytics import settings
+
+
+def disable_ultralytics_telemetry() -> None:
+    """Disable ultralytics' built-in analytics and crash reporting.
+
+    The upstream ultralytics package ships Google Analytics event collection
+    and Sentry crash reporting, controlled by the persisted ``sync`` setting
+    which defaults to enabled. Per the ultralytics documentation, persisting
+    ``sync = False`` opts out of both.
+
+    The setting is read at ultralytics import time, so this takes full effect
+    from the next process start. On the very first run after a fresh install
+    the in-process telemetry instance may have latched its enabled flag before
+    this call; that single-process window is accepted as negligible.
+    """
+    settings.update({"sync": False})


### PR DESCRIPTION
Ultraylitcs collects telemetry by default; see this: https://docs.ultralytics.com/help/privacy

I found out by accident. I think it should be disabled by default, or configurable by user - your choice.

There is another approach which involves using an env variable and a config file, but I thought it was more fragile/easier to break.

Official docs here: https://docs.ultralytics.com/help/privacy#modifying-settings