### PR TITLE
fix(storage): drop stuck DB row when move target equals source

### DIFF
--- a/viseron/components/storage/tier_handler.py
+++ b/viseron/components/storage/tier_handler.py
@@ -999,6 +999,7 @@ def handle_file(
         logger.debug("File %s is recently requested, skipping", path)
         return
 
+    stuck_row = False
     if force_delete or next_tier is None:
         delete_file(
             storage,
@@ -1013,6 +1014,7 @@ def handle_file(
                 "changed the tier paths or a previous move failed.",
                 path,
             )
+            stuck_row = True
         else:
             move_file(
                 vis,
@@ -1027,17 +1029,24 @@ def handle_file(
                 logger,
             )
 
-    # Delete the file from the database if tier_path is not the same as
-    # curr_tier[CONFIG_PATH]. This is an indication that the tier configuration
-    # has changed and since the old path is not monitored, the delete signal
-    # will not be received by Viseron
-    if tier_path != curr_tier[CONFIG_PATH]:
+    # Delete the file from the database if:
+    # - tier_path is not the same as curr_tier[CONFIG_PATH]. This is an
+    #   indication that the tier configuration has changed and since the old
+    #   path is not monitored, the delete signal will not be received by
+    #   Viseron.
+    # - the move target equals the source (stuck_row). The row points at a
+    #   path this handler can never move or delete, so each tier-check pass
+    #   would re-process it and slowly leak SQLAlchemy connection objects in
+    #   the storage subprocess. Drop the row; OrphanedFilesCleanup will sweep
+    #   the on-disk file if it still exists.
+    if stuck_row or tier_path != curr_tier[CONFIG_PATH]:
         logger.debug(
             "Deleting file %s from database since tier paths are different. "
-            "file tier_path: %s, current tier_path: %s",
+            "file tier_path: %s, current tier_path: %s, stuck_row: %s",
             path,
             tier_path,
             curr_tier[CONFIG_PATH],
+            stuck_row,
         )
         with get_session() as session:
             stmt = delete(Files).where(Files.path == path)


### PR DESCRIPTION
When `handle_file()` computes `new_path = path.replace(tier_path, next_tier[CONFIG_PATH], 1)` and the result is unchanged, the file’s recorded `tier_path` already coincides with this handler’s next-tier path. The current behaviour logs a warning and leaves the row in place, so the same row is re-loaded by `load_tier` on **every** `check_tier` pass.

With hundreds of such stuck rows per camera this produces a steady stream of warnings (~1.5/sec observed) and slowly leaks SQLAlchemy connection objects in the storage subprocess — in production I saw the storage-subprocess RSS climb to several GiB, with `tracemalloc` attributing ~1.16 GiB cumulative to `connection.py`.

### Fix
Treat the no-op move the same way as a stale `tier_path`: delete the DB row so the loop terminates. The on-disk file, if any, is swept by `OrphanedFilesCleanup`; if the file legitimately belongs to the next tier, its watcher will already have inserted a row with the correct `tier_id`.

Confined to `tier_handler.py` (+15/−6), no behavioural change for the normal move/delete paths.

### Relation to #1364
Sibling to #1364 (bounding the `check_tier` queue/callbacks): both target unbounded growth in the storage subprocess. This one removes a distinct source — rows that can never make progress and get re-processed forever. They are independent and can merge in any order.