### PR TITLE
feat: support custom CA certificate for webhook component TLS verification

### DIFF
--- a/docs/src/pages/components-explorer/components/webhook/config.json
+++ b/docs/src/pages/components-explorer/components/webhook/config.json
@@ -128,6 +128,13 @@
             "description": "Whether to verify SSL certificates for the webhook request.",
             "optional": true,
             "default": true
+          },
+          {
+            "type": "string",
+            "name": "ca_cert",
+            "description": "Path to a custom CA certificate bundle (PEM file or directory) used to verify the webhook server's TLS certificate. When set, it takes precedence over verify_ssl. Useful for servers fronted by a self-hosted Certificate Authority.",
+            "optional": true,
+            "default": null
           }
         ],
         "name": {

--- a/tests/components/webhook/test_webhook.py
+++ b/tests/components/webhook/test_webhook.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from viseron.components.webhook import CONFIG_PAYLOAD, Webhook
+from viseron.components.webhook import CONFIG_PAYLOAD, HOOK_SCHEMA, Webhook
 
 HOOK_CONFIG: dict = {
     "trigger": {"event": "test_event", "condition": None},
@@ -19,6 +19,7 @@ HOOK_CONFIG: dict = {
     "timeout": 10,
     "content_type": "application/json",
     "verify_ssl": True,
+    "ca_cert": None,
 }
 
 VALID_URL = "http://localhost/test"
@@ -126,3 +127,100 @@ class TestPayloadEncoding:
         mock_request.assert_called_once()
         _, kwargs = mock_request.call_args
         assert kwargs["data"] is None
+
+
+CA_CERT_PATH = "/path/to/ca.pem"
+
+
+class TestVerify:
+    """Tests for how the webhook resolves the requests ``verify`` argument."""
+
+    @staticmethod
+    def _run(vis: MagicMock, hook_conf: dict) -> MagicMock:
+        """Drive ``_handle_event`` and return the patched ``requests.request``."""
+        mock_render = MagicMock()
+        mock_render.side_effect = [VALID_URL, ASCII_PAYLOAD]
+
+        with (
+            patch("viseron.components.webhook.requests.request") as mock_request,
+            patch("viseron.components.webhook.render_template", mock_render),
+            patch(
+                "viseron.components.webhook.render_template_condition",
+                return_value=(True, "true"),
+            ),
+        ):
+            webhook = Webhook(vis, {"test_hook": hook_conf})
+            webhook._handle_event(hook_conf, {"name": "john"}, "test_hook")
+        return mock_request
+
+    def test_ca_cert_used_as_verify(self, vis: MagicMock) -> None:
+        """A configured ca_cert path is passed as the verify argument."""
+        hook_conf = dict(HOOK_CONFIG)
+        hook_conf["ca_cert"] = CA_CERT_PATH
+
+        mock_request = self._run(vis, hook_conf)
+
+        mock_request.assert_called_once()
+        _, kwargs = mock_request.call_args
+        assert kwargs["verify"] == CA_CERT_PATH
+
+    def test_verify_ssl_true_when_no_ca_cert(self, vis: MagicMock) -> None:
+        """Without ca_cert the boolean verify_ssl value is used unchanged."""
+        hook_conf = dict(HOOK_CONFIG)
+        hook_conf["ca_cert"] = None
+        hook_conf["verify_ssl"] = True
+
+        mock_request = self._run(vis, hook_conf)
+
+        mock_request.assert_called_once()
+        _, kwargs = mock_request.call_args
+        assert kwargs["verify"] is True
+
+    def test_verify_ssl_false_when_no_ca_cert(self, vis: MagicMock) -> None:
+        """verify_ssl: False is still honored when no ca_cert is set."""
+        hook_conf = dict(HOOK_CONFIG)
+        hook_conf["ca_cert"] = None
+        hook_conf["verify_ssl"] = False
+
+        mock_request = self._run(vis, hook_conf)
+
+        mock_request.assert_called_once()
+        _, kwargs = mock_request.call_args
+        assert kwargs["verify"] is False
+
+    def test_ca_cert_takes_precedence_over_verify_ssl(self, vis: MagicMock) -> None:
+        """ca_cert wins over verify_ssl when both are provided."""
+        hook_conf = dict(HOOK_CONFIG)
+        hook_conf["ca_cert"] = CA_CERT_PATH
+        hook_conf["verify_ssl"] = False
+
+        mock_request = self._run(vis, hook_conf)
+
+        mock_request.assert_called_once()
+        _, kwargs = mock_request.call_args
+        assert kwargs["verify"] == CA_CERT_PATH
+
+
+class TestSchema:
+    """Tests for HOOK_SCHEMA validation of the ca_cert option."""
+
+    def test_ca_cert_accepts_string(self) -> None:
+        """A string ca_cert validates and is preserved."""
+        validated = HOOK_SCHEMA(
+            {
+                "trigger": {"event": "test_event"},
+                "url": VALID_URL,
+                "ca_cert": CA_CERT_PATH,
+            }
+        )
+        assert validated["ca_cert"] == CA_CERT_PATH
+
+    def test_ca_cert_defaults_to_none(self) -> None:
+        """Omitting ca_cert defaults it to None."""
+        validated = HOOK_SCHEMA(
+            {
+                "trigger": {"event": "test_event"},
+                "url": VALID_URL,
+            }
+        )
+        assert validated["ca_cert"] is None

--- a/viseron/components/webhook/__init__.py
+++ b/viseron/components/webhook/__init__.py
@@ -19,6 +19,7 @@ from viseron.helpers.validators import (
 
 from .const import (
     COMPONENT,
+    CONFIG_CA_CERT,
     CONFIG_CONDITION,
     CONFIG_CONTENT_TYPE,
     CONFIG_EVENT,
@@ -31,6 +32,7 @@ from .const import (
     CONFIG_URL,
     CONFIG_USERNAME,
     CONFIG_VERIFY_SSL,
+    DEFAULT_CA_CERT,
     DEFAULT_CONDITION,
     DEFAULT_CONTENT_TYPE,
     DEFAULT_HEADERS,
@@ -40,6 +42,7 @@ from .const import (
     DEFAULT_TIMEOUT,
     DEFAULT_USERNAME,
     DEFAULT_VERIFY_SSL,
+    DESC_CA_CERT,
     DESC_COMPONENT,
     DESC_CONDITION,
     DESC_CONTENT_TYPE,
@@ -132,6 +135,11 @@ HOOK_SCHEMA = vol.Schema(
             default=DEFAULT_VERIFY_SSL,
             description=DESC_VERIFY_SSL,
         ): bool,
+        vol.Optional(
+            CONFIG_CA_CERT,
+            default=DEFAULT_CA_CERT,
+            description=DESC_CA_CERT,
+        ): Maybe(str),
     }
 )
 
@@ -223,6 +231,12 @@ class Webhook:
         if hook_conf[CONFIG_CONTENT_TYPE]:
             headers["Content-Type"] = hook_conf[CONFIG_CONTENT_TYPE]
 
+        # A custom CA certificate path takes precedence over the verify_ssl
+        # boolean so that servers fronted by a self-hosted CA can be verified
+        # without disabling TLS verification entirely.
+        ca_cert = hook_conf[CONFIG_CA_CERT]
+        verify = ca_cert if ca_cert else hook_conf[CONFIG_VERIFY_SSL]
+
         try:
             LOGGER.debug(
                 f"Sending webhook '{hook_name}' "
@@ -237,7 +251,7 @@ class Webhook:
                 data=payload.encode("utf-8") if payload else None,
                 headers=headers,
                 timeout=hook_conf[CONFIG_TIMEOUT],
-                verify=hook_conf[CONFIG_VERIFY_SSL],
+                verify=verify,
                 auth=auth,
             )
             LOGGER.debug(f"Webhook '{hook_name}' status code: {resp.status_code}")

--- a/viseron/components/webhook/const.py
+++ b/viseron/components/webhook/const.py
@@ -23,6 +23,7 @@ CONFIG_PAYLOAD: Final = "payload"
 CONFIG_TIMEOUT: Final = "timeout"
 CONFIG_CONTENT_TYPE: Final = "content_type"
 CONFIG_VERIFY_SSL: Final = "verify_ssl"
+CONFIG_CA_CERT: Final = "ca_cert"
 
 DEFAULT_CONDITION: Final = None
 DEFAULT_HEADERS: Final = None
@@ -33,6 +34,7 @@ DEFAULT_CONTENT_TYPE: Final = "application/json"
 DEFAULT_TIMEOUT: Final = 10
 DEFAULT_METHOD: Final = "get"
 DEFAULT_VERIFY_SSL: Final = True
+DEFAULT_CA_CERT: Final = None
 
 DESC_TRIGGER: Final = "The trigger configuration for the webhook."
 DESC_EVENT: Final = "The event type that triggers the webhook."
@@ -51,6 +53,12 @@ DESC_PAYLOAD: Final = "Payload to send with the webhook request."
 DESC_TIMEOUT: Final = "The timeout for the webhook request in seconds."
 DESC_CONTENT_TYPE: Final = "The content type of the webhook request."
 DESC_VERIFY_SSL: Final = "Whether to verify SSL certificates for the webhook request."
+DESC_CA_CERT: Final = (
+    "Path to a custom CA certificate bundle (PEM file or directory) used to "
+    "verify the webhook server's TLS certificate. When set, it takes precedence "
+    "over verify_ssl. Useful for servers fronted by a self-hosted Certificate "
+    "Authority."
+)
 
 INCLUSION_GROUP_AUTHENTICATION: Final = "authentication"
 


### PR DESCRIPTION
## Summary

Adds an optional per-hook `ca_cert` config key to the `webhook` component so TLS verification can be pointed at a custom CA bundle (a PEM file or a directory of certs) instead of only the system trust store.

When `ca_cert` is set, its path is passed straight to the `requests` library's `verify` argument and takes precedence over the existing `verify_ssl` boolean. When it is unset (the default), behavior is unchanged: `verify_ssl` (default `True`) drives verification exactly as before.

```yaml
webhook:
  my_hook:
    trigger:
      event: some_event
    url: https://signal.internal.example/v2/send
    ca_cert: /config/certs/internal-ca.pem
```

## Why this matters

Today the `webhook` component only exposes a boolean `verify_ssl`, so reaching an HTTPS endpoint fronted by a self-hosted Certificate Authority forces a choice between full verification against the system trust store (which fails) or disabling TLS verification entirely. A `ca_cert` path lets these internal services be verified properly without weakening security. This is the use case raised in #1343 (an internal signal-cli webservice behind a self-hosted CA).

## Testing

- Added unit tests covering the `verify` resolution: `ca_cert` path used as `verify`, `verify_ssl: True`/`False` honored when no `ca_cert` is set, and `ca_cert` taking precedence over `verify_ssl` when both are present.
- Added schema tests confirming `ca_cert` accepts a string and defaults to `None` when omitted.
- Regenerated the webhook component docs config (`config.json`) to include the new option so the generated-docs CI check stays in sync.
- `ruff check` and `ruff format --check` pass on the touched files.

Fixes #1343
