### PR TITLE
fix(storage): warn at init when last tier has no retention configured

### DIFF
--- a/viseron/components/storage/tier_handler.py
+++ b/viseron/components/storage/tier_handler.py
@@ -224,6 +224,17 @@ class TierHandler(FileSystemEventHandler):
         self._max_age = calculate_age(self._tier[CONFIG_MAX_AGE])
         self._min_age = calculate_age(self._tier[CONFIG_MIN_AGE])
 
+        if (
+            self._next_tier is None
+            and not self._max_age
+            and not self._max_bytes
+        ):
+            self._logger.warning(
+                "Last tier '%s' has no max_age or max_size configured; "
+                "files on this tier will accumulate indefinitely.",
+                self._tier[CONFIG_PATH],
+            )
+
     def _create_dataitem(
         self,
     ) -> DataItem:
@@ -537,6 +548,18 @@ class SegmentsTierHandler(TierHandler):
             any(self._continuous_params)
             and self._camera.config[CONFIG_RECORDER][CONFIG_CONTINUOUS_RECORDING]
         )
+
+        if (
+            self._next_tier is None
+            and not any(self._events_params)
+            and not any(self._continuous_params)
+        ):
+            self._logger.warning(
+                "Last recorder tier '%s' has no retention (max_age/max_size) "
+                "configured for events or continuous; files on this tier will "
+                "accumulate indefinitely.",
+                self._path,
+            )
 
         self.add_file_handler(self._path, rf"{self._path}/(.*.m4s$)")
         self.add_file_handler(self._path, rf"{self._path}/(.*.mp4$)")


### PR DESCRIPTION
A tier with no next tier and no `max_age`/`max_size` retains files forever — the tier mover has nothing to act on, so the final tier grows without bound until the disk fills. This is an easy misconfiguration to make and currently fails **silently**.

### Fix
Log a warning during tier initialization when the final tier has no retention configured. Covers both:
- the generic `TierHandler`, and
- the recorder `SegmentsTierHandler` (checking events and continuous retention separately).

No behavioural change beyond the log line; `tier_handler.py` only (+23).

### Context
Part of a small series of storage-reliability fixes alongside #1364 (bound the `check_tier` queue/callbacks) and #1399 (drop stuck tier rows). This one is purely a misconfiguration guard so operators notice before the disk fills rather than after.