### PR TITLE
fix: do not attempt ps if viseron already exited

### DIFF
--- a/rootfs/etc/cont-finish.d/10-postgres
+++ b/rootfs/etc/cont-finish.d/10-postgres
@@ -10,7 +10,7 @@ fi
 
 log_info "Wait for Viseron to stop..."
 PID=$(pgrep -f ^viseron)
-while ps -p $PID > /dev/null; do
+while [ -n "$PID" ] && ps -p $PID > /dev/null; do
   sleep 1
 done
 log_info "Viseron has stopped!"


### PR DESCRIPTION
Avoid errors like this:

> [viseron-finish] Viseron exit code 256
> [viseron-finish] Shutdown completed at Sat Jun 20 18:53:38 CEST 2026
>
> [viseron-finish] Viseron received signal 9
> [cont-finish.d] executing container finish scripts...
> [cont-finish.d] 10-postgres: executing...
> Wait for Viseron to stop...
> error: list of process IDs must follow -p
>
> Usage:
>  ps [options]
>
>  Try 'ps --help <simple|list|output|threads|misc|all>'
>   or 'ps --help <s|l|o|t|m|a>'
>  for additional help text.
>
> For more details see ps(1).
> Viseron has stopped!
>