### PR TITLE
fix: path traversal in publicimage token lookup; missing return after finish()

### DIFF
--- a/viseron/components/webserver/api/v1/publicimage.py
+++ b/viseron/components/webserver/api/v1/publicimage.py
@@ -54,7 +54,13 @@ class PublicimageAPIHandler(BaseAPIHandler):
             # Try all allowed extensions to find the file
             file_path = None
             for ext in ALLOWED_EXTENSIONS:
-                candidate = os.path.join(PUBLIC_IMAGES_PATH, f"{token}{ext}")
+                candidate = os.path.realpath(
+                    os.path.join(PUBLIC_IMAGES_PATH, f"{token}{ext}")
+                )
+                base = os.path.realpath(PUBLIC_IMAGES_PATH) + os.sep
+                if not candidate.startswith(base):
+                    self.response_error(HTTPStatus.BAD_REQUEST, reason="Invalid token")
+                    return
                 if await self.run_in_executor(os.path.exists, candidate):
                     file_path = candidate
                     break

--- a/viseron/components/webserver/static_file_handler.py
+++ b/viseron/components/webserver/static_file_handler.py
@@ -41,6 +41,7 @@ class AccessTokenStaticFileHandler(
                     reason="Missing camera identifier in request",
                 )
                 self.finish()
+                return
 
             camera = self._get_camera(self._camera_identifier, failed=self._failed)
             if not camera:


### PR DESCRIPTION
Sanitize publicimage token against directory escape via `os.path.realpath`.
Add missing return after `finish()` in static file handler `prepare()`.