### PR TITLE
fix: apply restrictions per recording/camera and user/camera

### DIFF
--- a/viseron/components/webserver/api/v1/hls.py
+++ b/viseron/components/webserver/api/v1/hls.py
@@ -328,7 +328,11 @@ def _generate_playlist(
     now = utcnow()
 
     with get_session() as session:
-        stmt = select(Recordings).where(Recordings.id == recording_id)
+        stmt = (
+            select(Recordings)
+            .where(Recordings.id == recording_id)
+            .where(Recordings.camera_identifier == camera.identifier)
+        )
         recording = session.execute(stmt).scalar()
         if recording is None:
             return None

--- a/viseron/components/webserver/request_handler.py
+++ b/viseron/components/webserver/request_handler.py
@@ -444,6 +444,21 @@ class ViseronRequestHandler(tornado.web.RequestHandler):
             if refresh_token and hmac.compare_digest(
                 refresh_token.static_asset_key, static_asset_key.decode()
             ):
+                user = self._webserver.auth.get_user(refresh_token.user_id)
+                if user is None or not user.enabled:
+                    LOGGER.debug("Cookie session user not found or disabled")
+                    return False
+                if (
+                    user.role != Role.ADMIN
+                    and user.assigned_cameras is not None
+                    and camera.identifier not in user.assigned_cameras
+                ):
+                    LOGGER.debug(
+                        "Cookie session user %s not permitted to access camera %s",
+                        user.id,
+                        camera.identifier,
+                    )
+                    return False
                 return True
         return False
 


### PR DESCRIPTION
This PR closes two holes:

* cookie sessions let any logged-in user use any camera
* allow only a specific recording ID for a specific camera
