### PR TITLE
fix(webserver): prevent RCE via render_template

### DIFF
--- a/viseron/__init__.py
+++ b/viseron/__init__.py
@@ -19,7 +19,8 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 import voluptuous as vol
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.schedulers.base import Job, SchedulerNotRunningError
-from jinja2 import BaseLoader, Environment, StrictUndefined
+from jinja2 import BaseLoader, StrictUndefined
+from jinja2.sandbox import SandboxedEnvironment
 from sqlalchemy import insert
 
 from viseron.components import (
@@ -285,7 +286,7 @@ class Viseron:
             self._process_watchdog = ProcessWatchDog(self.background_scheduler)
 
         self.storage: Storage | None = None
-        self.jinja_env = Environment(
+        self.jinja_env = SandboxedEnvironment(
             loader=BaseLoader(), undefined=StrictUndefined, autoescape=True
         )
 

--- a/viseron/components/webserver/websocket_api/commands.py
+++ b/viseron/components/webserver/websocket_api/commands.py
@@ -724,6 +724,7 @@ async def export_timespan(connection: WebSocketHandler, message) -> None:
     )
 
 
+@require_admin
 @websocket_command(
     {
         vol.Required("type"): "render_template",


### PR DESCRIPTION
Use a SandboxedEnvironment for user-supplied Jinja templates and gate the render_template websocket command behind `@require_admin`.

Another issue found while I was looking for something else.