### PR TITLE
fix(webserver): remove wildcard CORS from HLS playlists

### DIFF
--- a/viseron/components/webserver/api/v1/hls.py
+++ b/viseron/components/webserver/api/v1/hls.py
@@ -146,7 +146,6 @@ class HlsAPIHandler(BaseAPIHandler):
 
         self.set_header("Content-Type", "application/x-mpegURL")
         self.set_header("Cache-Control", "no-cache")
-        self.set_header("Access-Control-Allow-Origin", "*")
         await self.response_success(response=playlist)
 
     async def get_hls_playlist_time_period(
@@ -184,7 +183,6 @@ class HlsAPIHandler(BaseAPIHandler):
 
         self.set_header("Content-Type", "application/x-mpegURL")
         self.set_header("Cache-control", "no-cache, must-revalidate, max-age=0")
-        self.set_header("Access-Control-Allow-Origin", "*")
         await self.response_success(response=playlist)
 
     async def get_available_timespans(


### PR DESCRIPTION
Drop Access-Control-Allow-Origin: * on the HLS playlist responses; the frontend is served same-origin and segments were never CORS-enabled.

Not sure why it is there, reading these directly from another player is not supported right?
Even if it were, `*` would allow reading tokens from URL querystring from anywhere.