### PR TITLE
build: bump urllib3 and requests for CVE fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,13 +24,13 @@ python-slugify==8.0.4
 PyGObject==3.42.2 # Newer versions does not compile for the Jetson Nano
 PyYAML==6.0.1
 ruamel.yaml==0.18.9
-requests==2.32.0
+requests==2.32.4
 scikit-learn==1.2.2
 scipy==1.17.1
 supervision==0.21.0
 tornado==6.4.2
 typing-extensions==4.13.2
-urllib3==1.26.15
+urllib3==1.26.19
 voluptuous==0.14.2
 setproctitle==1.3.3
 sqlalchemy==2.0.30


### PR DESCRIPTION
urllib3 1.26.15 -> 1.26.19 (CVE-2023-43804, CVE-2023-45803); requests 2.32.0 -> 2.32.4 (CVE-2024-47081).

This one would probably be flagged by dependabot already.