### PR TITLE
storage: percentage / free-space based retention (min_free_space)

### DIFF
--- a/tests/components/storage/test_config.py
+++ b/tests/components/storage/test_config.py
@@ -33,6 +33,15 @@ def create_size_config(gb=None, mb=None):
     }
 
 
+def create_free_space_config(percent=None, gb=None, mb=None):
+    """Create a standardized min_free_space configuration."""
+    return {
+        "percent": percent,
+        "gb": gb,
+        "mb": mb,
+    }
+
+
 def create_check_interval(days=0, hours=0, minutes=1, seconds=0):
     """Create a standardized check interval configuration."""
     return {
@@ -43,7 +52,9 @@ def create_check_interval(days=0, hours=0, minutes=1, seconds=0):
     }
 
 
-def create_retain_config(max_age=None, min_age=None, max_size=None, min_size=None):
+def create_retain_config(
+    max_age=None, min_age=None, max_size=None, min_size=None, min_free_space=None
+):
     """Create a standardized configuration for retention rules."""
     return {
         "max_age": create_time_config(
@@ -54,6 +65,9 @@ def create_retain_config(max_age=None, min_age=None, max_size=None, min_size=Non
         ),
         "max_size": create_size_config(**(max_size or {"gb": None, "mb": None})),
         "min_size": create_size_config(**(min_size or {"gb": None, "mb": None})),
+        "min_free_space": create_free_space_config(
+            **(min_free_space or {"percent": None, "gb": None, "mb": None})
+        ),
     }
 
 
@@ -318,6 +332,66 @@ def test_validate_tiers(config, raises, error_message):
 
     if _config:
         assert _config == config
+
+
+MIN_FREE_SPACE_CASES = [
+    # percent within (0, 100] is accepted
+    ({"percent": 15}, nullcontext()),
+    ({"percent": 100}, nullcontext()),
+    ({"percent": 0.5}, nullcontext()),
+    # absolute gb/mb accepted
+    ({"gb": 40}, nullcontext()),
+    ({"mb": 500, "gb": 1}, nullcontext()),
+    # percent must be > 0 and <= 100
+    ({"percent": 0}, pytest.raises(vol.Invalid)),
+    ({"percent": -5}, pytest.raises(vol.Invalid)),
+    ({"percent": 150}, pytest.raises(vol.Invalid)),
+]
+
+
+@pytest.mark.parametrize("min_free_space, raises", MIN_FREE_SPACE_CASES)
+def test_min_free_space_schema(min_free_space, raises):
+    """min_free_space accepts percent/gb/mb and rejects out-of-range percent."""
+    config = {
+        "storage": {
+            "recorder": {
+                "tiers": [
+                    create_tier(
+                        path="/tier1",
+                        continuous={
+                            "max_age": {"days": 7},
+                            "min_free_space": min_free_space,
+                        },
+                    ),
+                ]
+            }
+        }
+    }
+    with patch("viseron.components.storage.config._check_path_exists"):
+        with raises:
+            CONFIG_SCHEMA(config)
+
+
+def test_min_free_space_defaults_present():
+    """The schema fills min_free_space defaults on continuous, events, snapshots."""
+    config = CONFIG_SCHEMA({"storage": {}})
+    tier = config["storage"]["recorder"]["tiers"][0]
+    assert tier["continuous"]["min_free_space"] == {
+        "percent": None,
+        "gb": None,
+        "mb": None,
+    }
+    assert tier["events"]["min_free_space"] == {
+        "percent": None,
+        "gb": None,
+        "mb": None,
+    }
+    snapshot_tier = config["storage"]["snapshots"]["tiers"][0]
+    assert snapshot_tier["min_free_space"] == {
+        "percent": None,
+        "gb": None,
+        "mb": None,
+    }
 
 
 def test_check_path_exists():

--- a/tests/components/storage/test_free_space.py
+++ b/tests/components/storage/test_free_space.py
@@ -1,0 +1,79 @@
+"""Test the free-space eviction selection helper.
+
+Pure-numpy, no database — exercises get_files_to_delete_for_free_space, which
+decides the oldest set of files to delete to recover a free-space deficit.
+"""
+
+import numpy as np
+
+from viseron.components.storage.check_tier import (
+    FILES_DTYPE,
+    get_files_to_delete_for_free_space,
+)
+
+
+def _make(rows):
+    """Build a FILES_DTYPE array from (id, size, orig_ctime) triples."""
+    return np.array(
+        [(i, s, t, f"/tier/{i}.m4s", "/tier/") for (i, s, t) in rows],
+        dtype=FILES_DTYPE,
+    )
+
+
+# Five files, 100 bytes each, one second apart. ids are intentionally out of
+# chronological order to prove selection is by orig_ctime, not id or row order.
+_DATA = _make(
+    [
+        (10, 100, 1000),  # oldest
+        (40, 100, 1001),
+        (20, 100, 1002),
+        (50, 100, 1003),
+        (30, 100, 1004),  # newest
+    ]
+)
+
+# Everything old enough to be eligible unless a test says otherwise.
+_ALL_ELIGIBLE = 2000.0
+
+
+def test_no_deficit_is_noop() -> None:
+    """A zero or negative deficit selects nothing."""
+    assert get_files_to_delete_for_free_space(_DATA, 0, _ALL_ELIGIBLE).size == 0
+    assert get_files_to_delete_for_free_space(_DATA, -50, _ALL_ELIGIBLE).size == 0
+
+
+def test_empty_data_is_noop() -> None:
+    """No candidate files selects nothing."""
+    empty = np.empty(0, dtype=FILES_DTYPE)
+    assert get_files_to_delete_for_free_space(empty, 100, _ALL_ELIGIBLE).size == 0
+
+
+def test_selects_oldest_first_covering_deficit() -> None:
+    """Smallest oldest-first prefix whose cumulative size covers the deficit."""
+    result = get_files_to_delete_for_free_space(_DATA, 250, _ALL_ELIGIBLE)
+    assert result["id"].tolist() == [10, 40, 20]
+
+
+def test_exact_boundary_includes_covering_file() -> None:
+    """A deficit landing exactly on a cumulative boundary stops there."""
+    result = get_files_to_delete_for_free_space(_DATA, 200, _ALL_ELIGIBLE)
+    assert result["id"].tolist() == [10, 40]
+
+
+def test_deficit_larger_than_all_returns_all_oldest_first() -> None:
+    """A deficit larger than everything selects every file, oldest first."""
+    result = get_files_to_delete_for_free_space(_DATA, 10_000, _ALL_ELIGIBLE)
+    assert result["id"].tolist() == [10, 40, 20, 50, 30]
+
+
+def test_min_age_protects_recent_files() -> None:
+    """Files newer than the cutoff are never eligible for eviction."""
+    # Only files with orig_ctime <= 1001 are eligible (ids 10 and 40).
+    result = get_files_to_delete_for_free_space(_DATA, 500, 1001.0)
+    assert result["id"].tolist() == [10, 40]
+
+
+def test_all_files_too_recent_is_noop() -> None:
+    """When every file is within the protection window, nothing is selected."""
+    result = get_files_to_delete_for_free_space(_DATA, 500, 500.0)
+    assert result.size == 0

--- a/tests/components/storage/test_util.py
+++ b/tests/components/storage/test_util.py
@@ -1,11 +1,20 @@
 """Test the util module."""
 
 from collections import namedtuple
+from unittest.mock import patch
 
-from viseron.components.storage.util import calculate_age, calculate_bytes
+from viseron.components.storage.util import (
+    calculate_age,
+    calculate_bytes,
+    calculate_free_space_floor,
+)
 
 EventsFiles = namedtuple("EventsFiles", "recording_id file_id path")
 ContinuousFiles = namedtuple("ContinuousFiles", "id path")
+
+# 100 GiB total, so 15% == 15 GiB.
+_DiskUsage = namedtuple("_DiskUsage", "total used free")
+_FAKE_USAGE = _DiskUsage(total=100 * 1024**3, used=0, free=100 * 1024**3)
 
 
 def test_calculate_bytes() -> None:
@@ -30,3 +39,81 @@ def test_calculate_age() -> None:
         == 3600
     )
     assert calculate_age({"minutes": 1, "days": 1, "hours": 1}).total_seconds() == 90060
+
+
+def test_calculate_free_space_floor_unset() -> None:
+    """Unset (or empty) config disables free-space eviction."""
+    assert calculate_free_space_floor(None, "/") == 0
+    assert calculate_free_space_floor({}, "/") == 0
+    assert (
+        calculate_free_space_floor({"percent": None, "gb": None, "mb": None}, "/")
+        == 0
+    )
+
+
+def test_calculate_free_space_floor_percent() -> None:
+    """Percent is taken of the filesystem total."""
+    with patch(
+        "viseron.components.storage.util.shutil.disk_usage",
+        return_value=_FAKE_USAGE,
+    ):
+        assert (
+            calculate_free_space_floor(
+                {"percent": 15, "gb": None, "mb": None}, "/data"
+            )
+            == 15 * 1024**3
+        )
+
+
+def test_calculate_free_space_floor_absolute() -> None:
+    """Absolute gb/mb do not read the filesystem and are summed."""
+    with patch(
+        "viseron.components.storage.util.shutil.disk_usage"
+    ) as mock_disk_usage:
+        assert (
+            calculate_free_space_floor({"percent": None, "gb": 40, "mb": None}, "/")
+            == 40 * 1024**3
+        )
+        assert (
+            calculate_free_space_floor({"percent": None, "gb": 1, "mb": 512}, "/")
+            == 1024**3 + 512 * 1024**2
+        )
+        mock_disk_usage.assert_not_called()
+
+
+def test_calculate_free_space_floor_max_of_several() -> None:
+    """When several are set the largest (most conservative) floor wins."""
+    with patch(
+        "viseron.components.storage.util.shutil.disk_usage",
+        return_value=_FAKE_USAGE,
+    ):
+        # percent -> 15 GiB, absolute -> 40 GiB => 40 GiB.
+        assert (
+            calculate_free_space_floor({"percent": 15, "gb": 40, "mb": None}, "/data")
+            == 40 * 1024**3
+        )
+        # percent -> 15 GiB, absolute -> 5 GiB => 15 GiB.
+        assert (
+            calculate_free_space_floor({"percent": 15, "gb": 5, "mb": None}, "/data")
+            == 15 * 1024**3
+        )
+
+
+def test_calculate_free_space_floor_stat_failure() -> None:
+    """A failing stat drops the percent term but keeps the absolute floor."""
+    with patch(
+        "viseron.components.storage.util.shutil.disk_usage",
+        side_effect=OSError("no such path"),
+    ):
+        assert (
+            calculate_free_space_floor(
+                {"percent": 15, "gb": 10, "mb": None}, "/missing"
+            )
+            == 10 * 1024**3
+        )
+        assert (
+            calculate_free_space_floor(
+                {"percent": 15, "gb": None, "mb": None}, "/missing"
+            )
+            == 0
+        )

--- a/viseron/components/storage/check_tier.py
+++ b/viseron/components/storage/check_tier.py
@@ -75,6 +75,13 @@ class Worker:
         self._last_call: dict[str, float] = {}
         self._check_locks: dict[str, threading.Lock] = {}
         self._checks_in_progress: dict[str, bool] = {}
+        # Free-space eviction is a filesystem-global (all-cameras) pass, but it
+        # is triggered off each camera's per-tier check_tier. These serialize
+        # and throttle it so concurrent camera checks don't each run the whole
+        # eviction on the same filesystem. Keyed by tier_fs_path.
+        self._free_space_locks: dict[str, threading.Lock] = {}
+        self._free_space_locks_meta = threading.Lock()
+        self._free_space_last_run: dict[str, float] = {}
 
     def _should_check_tier_files(self, item: DataItem) -> bool:
         """Quick aggregate check if tier actually needs processing.
@@ -236,6 +243,10 @@ class Worker:
         try:
             if item.cmd == "check_tier":
                 self.check_tier(item)
+                # Filesystem-global free-space eviction, piggybacked on the
+                # per-camera check. Self-throttled and self-guarding; never
+                # raises, so it cannot fail the camera's normal tier check.
+                self.free_space_evict(item)
             if item.cmd == "move_file":
                 self.move_file(item)
             if item.cmd == "delete_file":
@@ -402,6 +413,119 @@ class Worker:
 
         return rows_to_move
 
+    def _get_free_space_lock(self, fs_path: str) -> threading.Lock:
+        with self._free_space_locks_meta:
+            return self._free_space_locks.setdefault(fs_path, threading.Lock())
+
+    def free_space_evict(self, item: DataItem) -> None:
+        """Delete the oldest files on a tier until the free-space floor is met.
+
+        Runs off each camera's check_tier but operates across all cameras on
+        the tier's filesystem. Serialized + throttled per filesystem so N
+        cameras checking at once cause one eviction pass, not N. A no-op when
+        ``min_free_bytes`` is 0 (feature disabled) or free space is already at
+        or above the floor. Never raises — a failure here must not fail the
+        camera's normal tier check.
+        """
+        fs_path = item.tier_fs_path
+        floor = item.min_free_bytes
+        if not fs_path or floor <= 0:
+            return
+
+        lock = self._get_free_space_lock(fs_path)
+        # Non-blocking: if another camera's check already holds it, that pass
+        # will satisfy the floor for this filesystem — no need to queue behind.
+        if not lock.acquire(blocking=False):
+            return
+        try:
+            now = utcnow().timestamp()
+            throttle = item.throttle_period.total_seconds()
+            last = self._free_space_last_run.get(fs_path, 0.0)
+            if throttle > 0 and (now - last) < throttle:
+                return
+            self._free_space_last_run[fs_path] = now
+
+            try:
+                usage = shutil.disk_usage(fs_path)
+            except OSError as error:
+                LOGGER.warning("free-space check: cannot stat %s: %s", fs_path, error)
+                return
+            if usage.free >= floor:
+                return
+
+            deficit = floor - usage.free
+            subcategory = item.subcategories[0]
+            data = load_free_space_candidates(
+                self._get_session,
+                item.category,
+                subcategory,
+                item.tier_id,
+                fs_path,
+            )
+            if data.size == 0:
+                LOGGER.warning(
+                    "free-space: %s is below the %.2f GiB floor (%.2f GiB free) "
+                    "but has no evictable %s files on this tier",
+                    fs_path,
+                    floor / (1024**3),
+                    usage.free / (1024**3),
+                    subcategory,
+                )
+                return
+
+            # Protect files younger than 5x the segment duration — they may
+            # still be referenced by an active HLS playlist.
+            max_ctime_ts = (
+                utcnow() - datetime.timedelta(seconds=CAMERA_SEGMENT_DURATION * 5)
+            ).timestamp()
+            selected = get_files_to_delete_for_free_space(
+                data, deficit, max_ctime_ts
+            )
+            if selected.size == 0:
+                LOGGER.warning(
+                    "free-space: %s is below the %.2f GiB floor (%.2f GiB free) "
+                    "but all %s files are within the write-protection window; "
+                    "nothing evicted this pass",
+                    fs_path,
+                    floor / (1024**3),
+                    usage.free / (1024**3),
+                    subcategory,
+                )
+                return
+
+            deleted = 0
+            freed = 0
+            for row in selected:
+                path = str(row["path"])
+                try:
+                    delete_file(self._get_session, path, LOGGER)
+                except FileNotFoundError:
+                    # File already gone; delete_file still removed the DB row.
+                    pass
+                except OSError as error:
+                    LOGGER.warning(
+                        "free-space: stopping eviction on %s after delete error: %s",
+                        fs_path,
+                        error,
+                    )
+                    break
+                deleted += 1
+                freed += int(row["size"])
+            LOGGER.warning(
+                "free-space: %s had %.2f GiB free (< %.2f GiB floor); evicted "
+                "%d oldest %s file(s), ~%.2f GiB",
+                fs_path,
+                usage.free / (1024**3),
+                floor / (1024**3),
+                deleted,
+                subcategory,
+                freed / (1024**3),
+            )
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("free-space eviction failed for %s", fs_path)
+        finally:
+            lock.release()
+
 
 def load_tier(
     get_session: Callable[..., Session],
@@ -435,6 +559,45 @@ def load_tier(
             data,
             dtype=FILES_DTYPE,
         )
+
+
+def load_free_space_candidates(
+    get_session: Callable[..., Session],
+    category: str,
+    subcategory: str,
+    tier_id: int,
+    tier_path: str,
+):
+    """Load a tier's files across ALL cameras for free-space eviction.
+
+    Unlike :func:`load_tier` this is deliberately not filtered by
+    ``camera_identifier``: free space is a filesystem-global property, so the
+    oldest files across every camera on ``tier_path`` are the eviction
+    candidates. Restricted to a single ``subcategory`` (segments for the
+    recorder, the snapshot domain for snapshots) so thumbnails / event clips —
+    which are managed alongside their recording — are never free-space evicted.
+    """
+    with get_session() as session:
+        stmt = select(
+            Files.id, Files.size, Files.orig_ctime, Files.path, Files.tier_path
+        ).where(
+            Files.tier_id == tier_id,
+            Files.category == category,
+            Files.subcategory == subcategory,
+            Files.tier_path == tier_path,
+        )
+        result = session.execute(stmt).yield_per(1000)
+        data = [
+            (
+                row.id,
+                row.size,
+                int(row.orig_ctime.timestamp()),
+                row.path,
+                row.tier_path,
+            )
+            for row in result
+        ]
+    return np.array(data, dtype=FILES_DTYPE)
 
 
 def load_recordings(
@@ -521,6 +684,47 @@ def get_files_to_move(
 
     stripped_rows = rows_to_move[["id", "path", "tier_path"]]
     return stripped_rows[::-1]
+
+
+def get_files_to_delete_for_free_space(
+    data: np.ndarray,
+    deficit_bytes: int,
+    max_ctime_timestamp: float,
+):
+    """Return the oldest files to delete to recover ``deficit_bytes``.
+
+    ``data`` is a tier's files (``FILES_DTYPE``) for *all* cameras on one
+    filesystem. Rows are sorted oldest-first; the smallest oldest-first prefix
+    whose cumulative size covers ``deficit_bytes`` is returned (full rows, so
+    the caller has ``path``/``size``).
+
+    Only files with ``orig_ctime <= max_ctime_timestamp`` are eligible — this
+    protects freshly written segments that may still be referenced by an active
+    HLS playlist, mirroring the ``file_min_age`` guard used by the recordings
+    path.
+
+    Deletion is chosen (never a move) because free space is only returned to a
+    disk by deletion; on a shared/terminal tier that is the only lever. The
+    selection is a single size-summed batch (no re-poll of ``disk_usage`` per
+    row) so a filesystem whose accounting lags behind unlinks (e.g. btrfs,
+    which only updates on transaction commit) is not over-evicted.
+    """
+    if deficit_bytes <= 0 or data.size == 0:
+        return np.empty(0, dtype=data.dtype)
+
+    order = np.argsort(data["orig_ctime"], kind="stable")
+    ordered = data[order]
+
+    eligible = ordered[ordered["orig_ctime"] <= max_ctime_timestamp]
+    if eligible.size == 0:
+        return np.empty(0, dtype=data.dtype)
+
+    cumulative_size = np.cumsum(eligible["size"])
+    # First index whose running total reaches the deficit; include it so the
+    # cumulative sum is >= the deficit.
+    idx = int(np.searchsorted(cumulative_size, deficit_bytes, side="left"))
+    count = min(idx + 1, eligible.size)
+    return eligible[:count]
 
 
 def get_recordings_to_move(

--- a/viseron/components/storage/config.py
+++ b/viseron/components/storage/config.py
@@ -22,12 +22,14 @@ from viseron.components.storage.const import (
     CONFIG_MAX_SIZE,
     CONFIG_MB,
     CONFIG_MIN_AGE,
+    CONFIG_MIN_FREE_SPACE,
     CONFIG_MIN_SIZE,
     CONFIG_MINUTES,
     CONFIG_MOTION_DETECTOR,
     CONFIG_MOVE_ON_SHUTDOWN,
     CONFIG_OBJECT_DETECTOR,
     CONFIG_PATH,
+    CONFIG_PERCENT,
     CONFIG_POLL,
     CONFIG_RECORDER,
     CONFIG_SECONDS,
@@ -56,11 +58,13 @@ from viseron.components.storage.const import (
     DEFAULT_MAX_SIZE,
     DEFAULT_MB,
     DEFAULT_MIN_AGE,
+    DEFAULT_MIN_FREE_SPACE,
     DEFAULT_MIN_SIZE,
     DEFAULT_MINUTES,
     DEFAULT_MOTION_DETECTOR,
     DEFAULT_MOVE_ON_SHUTDOWN,
     DEFAULT_OBJECT_DETECTOR,
+    DEFAULT_PERCENT,
     DEFAULT_POLL,
     DEFAULT_RECORDER,
     DEFAULT_RECORDER_TIERS,
@@ -82,6 +86,9 @@ from viseron.components.storage.const import (
     DESC_DRAIN,
     DESC_EVENTS,
     DESC_FACE_RECOGNITION,
+    DESC_FREE_SPACE_GB,
+    DESC_FREE_SPACE_MB,
+    DESC_FREE_SPACE_PERCENT,
     DESC_INTERVAL,
     DESC_LICENSE_PLATE_RECOGNITION,
     DESC_MAX_AGE,
@@ -93,6 +100,7 @@ from viseron.components.storage.const import (
     DESC_MAX_SIZE,
     DESC_MIN_AGE,
     DESC_MIN_DAYS,
+    DESC_MIN_FREE_SPACE,
     DESC_MIN_GB,
     DESC_MIN_HOURS,
     DESC_MIN_MB,
@@ -168,6 +176,32 @@ def get_size_schema(
     }
 
 
+def get_free_space_schema() -> dict[vol.Optional, Maybe]:
+    """Get the min_free_space schema (percent and/or absolute gb/mb)."""
+    return {
+        vol.Optional(
+            CONFIG_PERCENT,
+            default=DEFAULT_PERCENT,
+            description=DESC_FREE_SPACE_PERCENT,
+        ): Maybe(
+            vol.All(
+                vol.Coerce(float),
+                vol.Range(min=0, max=100, min_included=False),
+            )
+        ),
+        vol.Optional(
+            CONFIG_GB,
+            default=DEFAULT_GB,
+            description=DESC_FREE_SPACE_GB,
+        ): Maybe(vol.Coerce(float)),
+        vol.Optional(
+            CONFIG_MB,
+            default=DEFAULT_MB,
+            description=DESC_FREE_SPACE_MB,
+        ): Maybe(vol.Coerce(float)),
+    }
+
+
 def get_age_schema(
     age_type: Literal["min"] | Literal["max"],
 ) -> dict[vol.Optional, Maybe]:
@@ -203,6 +237,11 @@ TIER_SCHEMA_BASE = vol.Schema(
             default=DEFAULT_MAX_SIZE,
             description=DESC_MAX_SIZE,
         ): get_size_schema("max"),
+        vol.Optional(
+            CONFIG_MIN_FREE_SPACE,
+            default=DEFAULT_MIN_FREE_SPACE,
+            description=DESC_MIN_FREE_SPACE,
+        ): get_free_space_schema(),
         vol.Optional(
             CONFIG_MAX_AGE,
             default=DEFAULT_MAX_AGE,

--- a/viseron/components/storage/const.py
+++ b/viseron/components/storage/const.py
@@ -71,10 +71,12 @@ CONFIG_DRAIN: Final = "drain"
 CONFIG_CHECK_INTERVAL: Final = "check_interval"
 CONFIG_MIN_SIZE: Final = "min_size"
 CONFIG_MAX_SIZE: Final = "max_size"
+CONFIG_MIN_FREE_SPACE: Final = "min_free_space"
 CONFIG_MAX_AGE: Final = "max_age"
 CONFIG_MIN_AGE: Final = "min_age"
 CONFIG_GB: Final = "gb"
 CONFIG_MB: Final = "mb"
+CONFIG_PERCENT: Final = "percent"
 CONFIG_DAYS: Final = "days"
 CONFIG_HOURS: Final = "hours"
 CONFIG_MINUTES: Final = "minutes"
@@ -140,6 +142,8 @@ DEFAULT_MINUTES: Final = None
 DEFAULT_SECONDS: Final = None
 DEFAULT_MIN_SIZE: dict[str, Any] = {}
 DEFAULT_MAX_SIZE: dict[str, Any] = {}
+DEFAULT_MIN_FREE_SPACE: dict[str, Any] = {}
+DEFAULT_PERCENT: Final = None
 DEFAULT_MIN_AGE: dict[str, Any] = {}
 DEFAULT_MAX_AGE: dict[str, Any] = {}
 DEFAULT_CONTINUOUS: Final = None
@@ -250,6 +254,28 @@ DESC_CHECK_INTERVAL_MINUTES = "Minutes between checks for files to move/delete."
 DESC_CHECK_INTERVAL_SECONDS = "Seconds between checks for files to move/delete."
 DESC_MIN_SIZE = "Minimum size of files to keep in this tier."
 DESC_MAX_SIZE = "Maximum size of files to keep in this tier."
+DESC_MIN_FREE_SPACE = (
+    "Keep at least this much of the <b>filesystem</b> holding this tier free by "
+    "evicting the oldest files on the tier (across all cameras) when free space "
+    "drops below the floor. This layers on top of <code>max_age</code> and "
+    "<code>max_size</code> — a file is removed when <em>any</em> configured "
+    "rule triggers. Because only deletion (not moving) returns space to a disk, "
+    "this is meant for the <b>last</b> tier on a filesystem. Unset by default, "
+    "which disables it and preserves the previous size/age-only behaviour."
+)
+DESC_FREE_SPACE_PERCENT = (
+    "Percentage (0-100, exclusive of 0) of the filesystem's total size to keep "
+    "free. Evaluated live against the filesystem's total capacity."
+)
+DESC_FREE_SPACE_GB = (
+    "Absolute amount of free space to maintain in GB. Added together with "
+    "<code>mb</code>. If <code>percent</code> is also set, the larger (more "
+    "conservative) floor wins."
+)
+DESC_FREE_SPACE_MB = (
+    "Absolute amount of free space to maintain in MB. Added together with "
+    "<code>gb</code>."
+)
 DESC_MIN_AGE = "Minimum age of files to keep in this tier."
 DESC_MAX_AGE = "Maximum age of files to keep in this tier."
 DESC_CONTINUOUS = "Retention rules for continuous recordings."

--- a/viseron/components/storage/storage_subprocess.py
+++ b/viseron/components/storage/storage_subprocess.py
@@ -63,6 +63,15 @@ class DataItem:
     events_min_age: datetime.timedelta | None = None
     events_max_age: datetime.timedelta | None = None
     events_min_bytes: int | None = None
+    # Free-space retention: keep at least this many bytes free on the
+    # filesystem holding ``tier_fs_path``, evicting the oldest files on this
+    # tier (across ALL cameras) when live free space drops below the floor.
+    # 0 disables it. ``tier_fs_path`` is the tier's configured path (matches
+    # the Files.tier_path column and is what shutil.disk_usage is called on).
+    # Orthogonal to the per-camera move/delete driven by max_bytes/max_age
+    # above — it only ever deletes, never moves.
+    min_free_bytes: int = 0
+    tier_fs_path: str | None = None
     callback_id: str | None = None
     data: np.ndarray | None = None
     error: str | None = None

--- a/viseron/components/storage/tier_handler.py
+++ b/viseron/components/storage/tier_handler.py
@@ -39,6 +39,7 @@ from viseron.components.storage.const import (
     CONFIG_MAX_AGE,
     CONFIG_MAX_SIZE,
     CONFIG_MIN_AGE,
+    CONFIG_MIN_FREE_SPACE,
     CONFIG_MIN_SIZE,
     CONFIG_MINUTES,
     CONFIG_MOVE_ON_SHUTDOWN,
@@ -77,6 +78,7 @@ from viseron.components.storage.util import (
     EventFileDeleted,
     calculate_age,
     calculate_bytes,
+    calculate_free_space_floor,
     get_event_clips_path,
     get_segments_path,
     get_thumbnails_path,
@@ -223,6 +225,9 @@ class TierHandler(FileSystemEventHandler):
         self._min_bytes = calculate_bytes(self._tier[CONFIG_MIN_SIZE])
         self._max_age = calculate_age(self._tier[CONFIG_MAX_AGE])
         self._min_age = calculate_age(self._tier[CONFIG_MIN_AGE])
+        self._min_free_bytes = calculate_free_space_floor(
+            self._tier.get(CONFIG_MIN_FREE_SPACE), self._tier[CONFIG_PATH]
+        )
 
         if (
             self._next_tier is None
@@ -251,6 +256,8 @@ class TierHandler(FileSystemEventHandler):
             max_age=self._max_age,
             min_bytes=self._min_bytes,
             drain=self._tier[CONFIG_DRAIN],
+            min_free_bytes=self._min_free_bytes,
+            tier_fs_path=self._tier[CONFIG_PATH],
         )
 
     def _check_tier_event_handler(self, _event: Event) -> None:
@@ -543,6 +550,20 @@ class SegmentsTierHandler(TierHandler):
             self._events_min_age,
         ]
 
+        # Free space is a property of the filesystem, not of continuous vs
+        # events, so take the most conservative (largest) floor configured
+        # under either block for this tier's path.
+        self._min_free_bytes = max(
+            calculate_free_space_floor(
+                self._tier[CONFIG_CONTINUOUS].get(CONFIG_MIN_FREE_SPACE),
+                self._tier[CONFIG_PATH],
+            ),
+            calculate_free_space_floor(
+                self._tier[CONFIG_EVENTS].get(CONFIG_MIN_FREE_SPACE),
+                self._tier[CONFIG_PATH],
+            ),
+        )
+
         self._events_enabled = any(self._events_params)
         self._continuous_enabled = (
             any(self._continuous_params)
@@ -591,6 +612,8 @@ class SegmentsTierHandler(TierHandler):
             events_min_age=self._events_min_age,
             events_max_age=self._events_max_age,
             events_min_bytes=self._events_min_bytes,
+            min_free_bytes=self._min_free_bytes,
+            tier_fs_path=self._tier[CONFIG_PATH],
         )
 
     @property

--- a/viseron/components/storage/util.py
+++ b/viseron/components/storage/util.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import threading
 from dataclasses import dataclass
 from datetime import timedelta
@@ -15,6 +16,7 @@ from viseron.components.storage.const import (
     CONFIG_MB,
     CONFIG_MINUTES,
     CONFIG_PATH,
+    CONFIG_PERCENT,
     CONFIG_SECONDS,
     TIER_CATEGORY_SNAPSHOTS,
     TIER_SUBCATEGORY_EVENT_CLIPS,
@@ -62,6 +64,41 @@ def convert_mb_to_bytes(mb: int) -> int:
 def convert_gb_to_bytes(gb: int) -> int:
     """Convert gb to bytes."""
     return gb * 1024 * 1024 * 1024
+
+
+def calculate_free_space_floor(free_space: dict[str, Any] | None, path: str) -> int:
+    """Bytes of free space to maintain on the filesystem holding ``path``.
+
+    ``percent`` is taken of ``shutil.disk_usage(path).total``; ``gb``/``mb`` are
+    absolute and reuse :func:`calculate_bytes`. When several are set the largest
+    (most conservative) floor is used. Returns ``0`` when nothing is configured,
+    which callers treat as "free-space eviction disabled".
+
+    The filesystem total is read once here (it does not change over the life of
+    a mount); the live ``free`` figure is polled at eviction time.
+    """
+    if not free_space:
+        return 0
+
+    floor = 0
+    percent = free_space.get(CONFIG_PERCENT)
+    if percent:
+        try:
+            total = shutil.disk_usage(path).total
+        except OSError:
+            total = 0
+        floor = max(floor, int(total * percent / 100))
+
+    floor = max(
+        floor,
+        calculate_bytes(
+            {
+                CONFIG_GB: free_space.get(CONFIG_GB),
+                CONFIG_MB: free_space.get(CONFIG_MB),
+            }
+        ),
+    )
+    return floor
 
 
 def get_segments_path(


### PR DESCRIPTION
## Summary

Adds an optional `min_free_space` retention rule to the `storage` component so a tier can be told to *"keep at least X% (or X GB) of the filesystem free"*, evaluated live, instead of (or in addition to) the existing absolute per-camera `max_size` byte cap.

### Motivation

Today a tier's size limit is only expressible as absolute bytes, enforced **per camera per tier** (`max_size: { gb, mb }`). That has two sharp edges on real deployments:

1. **It doesn't compose with the number of cameras.** Operators reason about `max_size` as a total, but the true worst case is `per-camera cap × number of cameras`. On a shared disk it's easy to under-provision and fill the volume.
2. **It's blind to the rest of the disk.** When the tier's path shares a filesystem with other data, a byte cap can't express "always leave headroom on the volume" — which is usually what you actually want on a shared disk.

### What this does

```yaml
storage:
  recorder:
    tiers:
      - path: /recordings
        continuous:
          max_age: { days: 7 }
          min_free_space: { percent: 15 }   # or { gb: 40 }
```

When set, the **oldest files on that tier across all cameras** on the filesystem are evicted whenever live free space (`shutil.disk_usage`) drops below the floor. It layers on top of `max_age`/`max_size` — a file is removed when **any** configured rule fires. Accepted on the recorder `continuous`/`events` blocks and on snapshot/timelapse tiers.

**Fully backward compatible:** unset ⇒ floor `0` ⇒ the previous size/age-only behaviour, exactly. No DB/schema migration.

### Implementation

Free space is a **filesystem-global** property while the existing tier check is **per-camera**, so this is a dedicated all-cameras eviction pass rather than a change to the per-camera path:

- `util.calculate_free_space_floor` — resolves percent-of-total + absolute gb/mb to a byte floor (the largest wins); total read once via `disk_usage`.
- `check_tier.get_files_to_delete_for_free_space` — pure-numpy oldest-first selection covering the deficit, with a write-protection window guarding freshly written segments (active HLS).
- `check_tier.load_free_space_candidates` — loads a tier's files across all cameras for one subcategory.
- `check_tier.Worker.free_space_evict` — piggybacked on each camera's `check_tier`, but **serialized + throttled per filesystem** so N concurrent camera checks cause **one** eviction pass, not N. Reuses the existing `delete_file` path.
- `DataItem` carries `min_free_bytes` + `tier_fs_path` (defaults keep it inert); tier handlers resolve the floor once at init and plumb it through.

### Design notes

- **Deletion, never move** — only deletion returns space to a disk, so this is meant for the **terminal** tier of a filesystem.
- **btrfs-safe** — selection is a single size-summed batch (no per-row `disk_usage` re-poll), so a filesystem whose accounting lags behind unlinks isn't over-evicted.
- **Known limitation** — under genuine disk pressure this can evict old continuous segments that belong to an event recording (that recording's playback then 404s). It's a last-resort backstop; happy to add orphan-only (recording-aware) protection if you'd prefer that as the default.

### Tests

- `test_free_space.py` — compute selection (oldest-first, exact boundaries, min-age protection, empty/no-deficit).
- `test_util.py` — `calculate_free_space_floor` (percent / absolute / max-of-several / stat-failure / unset).
- `test_config.py` — schema accept/reject for `min_free_space` (percent `(0,100]`) + defaults presence on continuous/events/snapshots.
