### PR TITLE
feat(nvr): add recording schedule

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -364,10 +364,6 @@ jobs:
         id: python
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          install: true
       - name: Build wheels Docker image
         run: |
           docker compose ${{ env.DOCKER_COMPOSE_CI_FILES }} build amd64-wheels

--- a/docs/docs/documentation/configuration/recordings.mdx
+++ b/docs/docs/documentation/configuration/recordings.mdx
@@ -382,6 +382,56 @@ ffmpeg: # or any other camera component
 </TabItem>
 </Tabs>
 
+## Recording schedule
+
+By default, event and continuous recordings are allowed at any time. You can restrict either (or both) to specific times of day by adding a `schedule` key to a cameras `recorder` configuration.
+
+The schedule is configured independently for `events` and `continuous` recordings, each as a list of entries with a `start` and `end` [cron expression](https://en.wikipedia.org/wiki/Cron).
+
+A recording type is active when the most recently passed `start` time is more recent than the most recently passed `end` time,
+so a window that spans midnight (one that starts at `22:00` and ends at `06:00` for example) works without any extra configuration.
+Multiple entries can be listed and the schedule is then active if **any** entry matches.
+
+:::info
+
+If either `events` or `continuous` is omitted, the recordings will be active 24/7 for that type of recording.
+
+:::
+
+:::info
+
+Manual recordings are not affected by the schedule and can always be started on-demand.
+
+:::
+
+The cron expressions are evaluated using a `timezone` key, which defaults to the server's own timezone.
+If your cameras should follow a different timezone than the server, override it with any [IANA timezone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+
+Example configuration to only record events on weekdays between 08:00 and 18:00, and only keep continuous recordings between 22:00 and 06:00 every day:
+
+```yaml title="/config/config.yaml"
+ffmpeg: # or any other camera component
+  camera:
+    camera_one:
+      name: Camera 1
+      host: !secret camera_one_host
+      path: /Streaming/Channels/101/
+      username: !secret camera_one_username
+      password: !secret camera_one_password
+      recorder:
+        continuous_recording: true
+        // highlight-start
+        schedule:
+          timezone: Europe/Stockholm
+          events:
+            - start: "0 8 * * mon-fri" # 08:00 Mon-Fri
+              end: "0 18 * * mon-fri" # 18:00 Mon-Fri
+          continuous:
+            - start: "0 22 * * *" # 22:00 every day
+              end: "0 6 * * *" # 06:00 every day
+        // highlight-end
+```
+
 ## File format
 
 The recordings are saved in short `.m4s` (aka `fMP4` or `fragmented MP4`) segments.

--- a/docs/src/pages/components-explorer/components/ffmpeg/config.json
+++ b/docs/src/pages/components-explorer/components/ffmpeg/config.json
@@ -2366,6 +2366,72 @@
                     "default": true
                   },
                   {
+                    "type": "map",
+                    "value": [
+                      {
+                        "type": "list",
+                        "values": [
+                          [
+                            {
+                              "type": "string",
+                              "name": "start",
+                              "description": "A <a href=https://en.wikipedia.org/wiki/Cron>cron expression</a> for when this schedule entry starts, e.g. <code>0 8 * * mon-fri</code> for 08:00 on weekdays.",
+                              "required": true,
+                              "default": null
+                            },
+                            {
+                              "type": "string",
+                              "name": "end",
+                              "description": "A <a href=https://en.wikipedia.org/wiki/Cron>cron expression</a> for when this schedule entry ends. Can occur 'before' <code>start</code> in the day to span midnight, e.g. <code>start: 0 22 * * *</code>, <code>end: 0 6 * * *</code>.",
+                              "required": true,
+                              "default": null
+                            }
+                          ]
+                        ],
+                        "name": "events",
+                        "description": "Schedule for event recordings. If omitted, event recording is allowed at any time.",
+                        "optional": true,
+                        "default": null
+                      },
+                      {
+                        "type": "list",
+                        "values": [
+                          [
+                            {
+                              "type": "string",
+                              "name": "start",
+                              "description": "A <a href=https://en.wikipedia.org/wiki/Cron>cron expression</a> for when this schedule entry starts, e.g. <code>0 8 * * mon-fri</code> for 08:00 on weekdays.",
+                              "required": true,
+                              "default": null
+                            },
+                            {
+                              "type": "string",
+                              "name": "end",
+                              "description": "A <a href=https://en.wikipedia.org/wiki/Cron>cron expression</a> for when this schedule entry ends. Can occur 'before' <code>start</code> in the day to span midnight, e.g. <code>start: 0 22 * * *</code>, <code>end: 0 6 * * *</code>.",
+                              "required": true,
+                              "default": null
+                            }
+                          ]
+                        ],
+                        "name": "continuous",
+                        "description": "Schedule for continuous recording. If omitted, continuous recording (when <code>continuous_recording</code> is enabled) is allowed at any time.",
+                        "optional": true,
+                        "default": null
+                      },
+                      {
+                        "type": "string",
+                        "name": "timezone",
+                        "description": "An <a href=https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>IANA timezone</a> (e.g. <code>Europe/Stockholm</code>) used to evaluate the schedule's cron expressions. Defaults to the server's own timezone.",
+                        "optional": true,
+                        "default": null
+                      }
+                    ],
+                    "name": "schedule",
+                    "description": "Restrict event and/or continuous recording to specific times of day. If omitted, recording is not restricted by a schedule.",
+                    "optional": true,
+                    "default": null
+                  },
+                  {
                     "type": "list",
                     "values": [
                       {

--- a/docs/src/pages/components-explorer/components/gstreamer/config.json
+++ b/docs/src/pages/components-explorer/components/gstreamer/config.json
@@ -2105,6 +2105,72 @@
                     "default": true
                   },
                   {
+                    "type": "map",
+                    "value": [
+                      {
+                        "type": "list",
+                        "values": [
+                          [
+                            {
+                              "type": "string",
+                              "name": "start",
+                              "description": "A <a href=https://en.wikipedia.org/wiki/Cron>cron expression</a> for when this schedule entry starts, e.g. <code>0 8 * * mon-fri</code> for 08:00 on weekdays.",
+                              "required": true,
+                              "default": null
+                            },
+                            {
+                              "type": "string",
+                              "name": "end",
+                              "description": "A <a href=https://en.wikipedia.org/wiki/Cron>cron expression</a> for when this schedule entry ends. Can occur 'before' <code>start</code> in the day to span midnight, e.g. <code>start: 0 22 * * *</code>, <code>end: 0 6 * * *</code>.",
+                              "required": true,
+                              "default": null
+                            }
+                          ]
+                        ],
+                        "name": "events",
+                        "description": "Schedule for event recordings. If omitted, event recording is allowed at any time.",
+                        "optional": true,
+                        "default": null
+                      },
+                      {
+                        "type": "list",
+                        "values": [
+                          [
+                            {
+                              "type": "string",
+                              "name": "start",
+                              "description": "A <a href=https://en.wikipedia.org/wiki/Cron>cron expression</a> for when this schedule entry starts, e.g. <code>0 8 * * mon-fri</code> for 08:00 on weekdays.",
+                              "required": true,
+                              "default": null
+                            },
+                            {
+                              "type": "string",
+                              "name": "end",
+                              "description": "A <a href=https://en.wikipedia.org/wiki/Cron>cron expression</a> for when this schedule entry ends. Can occur 'before' <code>start</code> in the day to span midnight, e.g. <code>start: 0 22 * * *</code>, <code>end: 0 6 * * *</code>.",
+                              "required": true,
+                              "default": null
+                            }
+                          ]
+                        ],
+                        "name": "continuous",
+                        "description": "Schedule for continuous recording. If omitted, continuous recording (when <code>continuous_recording</code> is enabled) is allowed at any time.",
+                        "optional": true,
+                        "default": null
+                      },
+                      {
+                        "type": "string",
+                        "name": "timezone",
+                        "description": "An <a href=https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>IANA timezone</a> (e.g. <code>Europe/Stockholm</code>) used to evaluate the schedule's cron expressions. Defaults to the server's own timezone.",
+                        "optional": true,
+                        "default": null
+                      }
+                    ],
+                    "name": "schedule",
+                    "description": "Restrict event and/or continuous recording to specific times of day. If omitted, recording is not restricted by a schedule.",
+                    "optional": true,
+                    "default": null
+                  },
+                  {
                     "type": "list",
                     "values": [
                       {

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ deepstack-python==0.8
 dlib==20.0.1
 codeproject-ai-api==0.1
 colorlog==6.8.2
+croniter==6.2.4
 face-recognition==1.3.0
 httpx==0.27.0
 python-immutable==1.1.0
@@ -30,6 +31,7 @@ scikit-learn==1.2.2
 scipy==1.17.1
 supervision==0.21.0
 tornado==6.5.7
+tzlocal==5.3.1
 typing-extensions==4.13.2
 urllib3==2.7.0
 voluptuous==0.14.2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -34,6 +34,7 @@ pyupgrade==3.15.2
 
 # types
 types-aiofiles
+types-croniter
 types-requests==2.31.0.6
 types-psutil
 types-psycopg2

--- a/scripts/gen_docs/__main__.py
+++ b/scripts/gen_docs/__main__.py
@@ -20,11 +20,13 @@ from viseron.helpers.validators import (
     UNDEFINED,
     CameraIdentifier,
     CoerceNoneToDict,
+    CronExpression,
     Deprecated,
     Maybe,
     PathExists,
     Slug,
     StringKey,
+    Timezone,
     Url,
     jinja2_template,
 )
@@ -252,6 +254,14 @@ def convert(schema, custom_convert=None):  # noqa: C901
             "name": schema.key,
             "value": schema.message,
         }
+
+    if isinstance(schema, CronExpression):
+        return {
+            "type": "string",
+        }
+
+    if isinstance(schema, Timezone):
+        return {"type": "string"}
 
     if schema == jinja2_template:  # pylint: disable=comparison-with-callable
         return {

--- a/tests/common.py
+++ b/tests/common.py
@@ -14,7 +14,12 @@ from viseron.components import Component
 from viseron.components.storage.models import Files, Recordings
 from viseron.const import LOADED
 from viseron.domain_registry import DomainState
-from viseron.domains.camera.const import DOMAIN as CAMERA_DOMAIN
+from viseron.domains.camera.const import (
+    CONFIG_CONTINUOUS_RECORDING,
+    CONFIG_RECORDER,
+    CONFIG_SCHEDULE,
+    DOMAIN as CAMERA_DOMAIN,
+)
 from viseron.domains.motion_detector import (
     AbstractMotionDetectorExternal,
     AbstractMotionDetectorScanner,
@@ -171,6 +176,15 @@ class MockCamera(MagicMock):
         **kwargs,
     ):
         """Initialize the mock camera."""
+        kwargs.setdefault(
+            "config",
+            {
+                CONFIG_RECORDER: {
+                    CONFIG_CONTINUOUS_RECORDING: True,
+                    CONFIG_SCHEDULE: None,
+                }
+            },
+        )
         super().__init__(
             recorder=MagicMock(lookback=lookback),
             identifier=identifier,

--- a/tests/components/nvr/test_nvr.py
+++ b/tests/components/nvr/test_nvr.py
@@ -17,6 +17,12 @@ from viseron.components.nvr.nvr import EVENT_MOTION_DETECTOR_RESULT, NVR
 from viseron.components.storage.models import TriggerTypes
 from viseron.domain_registry import DomainState
 from viseron.domains.camera import EventFrameBytesData
+from viseron.domains.camera.const import (
+    CONFIG_RECORDER,
+    CONFIG_SCHEDULE_CONTINUOUS,
+    CONFIG_SCHEDULE_EVENTS,
+    CONFIG_SCHEDULE_TIMEZONE,
+)
 from viseron.domains.camera.recorder import ManualRecording
 from viseron.events import Event
 from viseron.helpers import utcnow
@@ -48,6 +54,14 @@ class FakeTime:
 def patch_nvr_utcnow(monkeypatch, fake_time: FakeTime) -> None:
     """Patch utcnow used by the NVR module."""
     monkeypatch.setattr("viseron.components.nvr.nvr.utcnow", lambda: fake_time.now)
+
+
+def patch_schedule_now(monkeypatch, fake_time: FakeTime) -> None:
+    """Patch the clock used by the recording schedule evaluator."""
+    monkeypatch.setattr(
+        "viseron.domains.camera.schedule.utcnow",
+        lambda: fake_time.now,
+    )
 
 
 def configure_camera_for_recording_tests(
@@ -95,7 +109,7 @@ def safe_put(queue, item) -> None:
 
 def feed_frame_to_nvr(nvr) -> None:
     """Queue frame + scanner tokens."""
-    for scanner in nvr._frame_scanners.values():  # pylint: disable=protected-access
+    for scanner in nvr._frame_scanners.values():
         safe_put(scanner.result_queue, object())
     frame = Event(
         "dummy",
@@ -1096,3 +1110,144 @@ class TestNVRRunManualRecording:
         assert "Max recording time exceeded, stopping recorder" in caplog.text
         nvr.stop_recorder.assert_called_once_with(force=True)
         assert not camera.is_recording
+
+
+class TestNVRRecordingSchedule:
+    """Tests for event recording schedule gating."""
+
+    def test_object_event_blocked_outside_schedule(self, vis, monkeypatch):
+        """Object detected outside the configured schedule does not record."""
+        object_detector = MockObjectDetector(fps=5, scan_on_motion_only=False)
+        nvr, camera = make_nvr(
+            vis, camera_output_fps=5, object_detector=object_detector
+        )
+        fake_time = FakeTime()  # 2025-01-01 00:00 UTC
+        patch_nvr_utcnow(monkeypatch, fake_time)
+        patch_schedule_now(monkeypatch, fake_time)
+        configure_camera_for_recording_tests(camera, fake_time, idle_timeout=2)
+        camera.config[CONFIG_RECORDER]["schedule"] = {
+            CONFIG_SCHEDULE_EVENTS: [{"start": "0 8 * * *", "end": "0 18 * * *"}],
+            CONFIG_SCHEDULE_CONTINUOUS: None,
+            CONFIG_SCHEDULE_TIMEZONE: "UTC",
+        }
+
+        object_detector.objects_in_fov = [
+            SimpleNamespace(trigger_event_recording=True, label="person")
+        ]
+        feed_frame_to_nvr(nvr)
+        nvr._run()
+        assert camera.is_recording is False
+        camera.start_recorder.assert_not_called()
+
+    def test_object_event_allowed_inside_schedule(self, vis, monkeypatch):
+        """Object detected inside the configured schedule starts recording."""
+        object_detector = MockObjectDetector(fps=5, scan_on_motion_only=False)
+        nvr, camera = make_nvr(
+            vis, camera_output_fps=5, object_detector=object_detector
+        )
+        fake_time = FakeTime()  # 2025-01-01 00:00 UTC
+        patch_nvr_utcnow(monkeypatch, fake_time)
+        patch_schedule_now(monkeypatch, fake_time)
+        configure_camera_for_recording_tests(camera, fake_time, idle_timeout=2)
+        camera.config[CONFIG_RECORDER]["schedule"] = {
+            CONFIG_SCHEDULE_EVENTS: [{"start": "0 0 * * *", "end": "0 12 * * *"}],
+            CONFIG_SCHEDULE_CONTINUOUS: None,
+            CONFIG_SCHEDULE_TIMEZONE: "UTC",
+        }
+
+        object_detector.objects_in_fov = [
+            SimpleNamespace(trigger_event_recording=True, label="person")
+        ]
+        feed_frame_to_nvr(nvr)
+        nvr._run()
+        assert camera.is_recording is True
+        camera.start_recorder.assert_called_once()
+
+    def test_motion_event_blocked_outside_schedule(self, vis, monkeypatch):
+        """Motion detected outside the configured schedule does not record."""
+        motion_detector = MockMotionDetector(fps=5, trigger_event_recording=True)
+        nvr, camera = make_nvr(
+            vis, camera_output_fps=5, motion_detector=motion_detector
+        )
+        fake_time = FakeTime()  # 2025-01-01 00:00 UTC
+        patch_nvr_utcnow(monkeypatch, fake_time)
+        patch_schedule_now(monkeypatch, fake_time)
+        configure_camera_for_recording_tests(camera, fake_time, idle_timeout=2)
+        camera.config[CONFIG_RECORDER]["schedule"] = {
+            CONFIG_SCHEDULE_EVENTS: [{"start": "0 8 * * *", "end": "0 18 * * *"}],
+            CONFIG_SCHEDULE_CONTINUOUS: None,
+            CONFIG_SCHEDULE_TIMEZONE: "UTC",
+        }
+
+        motion_detector.motion_detected = True
+        feed_frame_to_nvr(nvr)
+        nvr._run()
+        assert camera.is_recording is False
+        camera.start_recorder.assert_not_called()
+
+    def test_manual_recording_bypasses_schedule(self, vis, monkeypatch):
+        """Manual recording starts even when outside the event schedule."""
+        nvr, camera = make_nvr(vis, camera_output_fps=5)
+        fake_time = FakeTime()  # 2025-01-01 00:00 UTC
+        patch_nvr_utcnow(monkeypatch, fake_time)
+        patch_schedule_now(monkeypatch, fake_time)
+        configure_camera_for_recording_tests(camera, fake_time, idle_timeout=2)
+        camera.config[CONFIG_RECORDER]["schedule"] = {
+            CONFIG_SCHEDULE_EVENTS: [{"start": "0 8 * * *", "end": "0 18 * * *"}],
+            CONFIG_SCHEDULE_CONTINUOUS: None,
+            CONFIG_SCHEDULE_TIMEZONE: "UTC",
+        }
+
+        nvr.start_manual_recording(ManualRecording(duration=None))
+        feed_frame_to_nvr(nvr)
+        nvr._run()
+        assert camera.is_recording is True
+
+    def test_event_schedule_uses_configured_timezone(self, vis, monkeypatch):
+        """The configured schedule timezone (not UTC) is used to gate recording.
+
+        07:30 UTC is 08:30 in Europe/Stockholm (UTC+1 in January), so an
+        08:00-18:00 Stockholm-time schedule is already active, even though
+        the same schedule interpreted as plain UTC would not have started yet.
+        """
+        object_detector = MockObjectDetector(fps=5, scan_on_motion_only=False)
+        nvr, camera = make_nvr(
+            vis, camera_output_fps=5, object_detector=object_detector
+        )
+        fake_time = FakeTime(
+            start=datetime.datetime(2025, 1, 1, 7, 30, tzinfo=datetime.timezone.utc)
+        )
+        patch_nvr_utcnow(monkeypatch, fake_time)
+        patch_schedule_now(monkeypatch, fake_time)
+        configure_camera_for_recording_tests(camera, fake_time, idle_timeout=2)
+        camera.config[CONFIG_RECORDER]["schedule"] = {
+            CONFIG_SCHEDULE_EVENTS: [{"start": "0 8 * * *", "end": "0 18 * * *"}],
+            CONFIG_SCHEDULE_CONTINUOUS: None,
+            CONFIG_SCHEDULE_TIMEZONE: "Europe/Stockholm",
+        }
+
+        object_detector.objects_in_fov = [
+            SimpleNamespace(trigger_event_recording=True, label="person")
+        ]
+        feed_frame_to_nvr(nvr)
+        nvr._run()
+        assert camera.is_recording is True
+        camera.start_recorder.assert_called_once()
+
+    def test_no_schedule_configured_allows_recording(self, vis, monkeypatch):
+        """Absent schedule (default) does not restrict event recording."""
+        object_detector = MockObjectDetector(fps=5, scan_on_motion_only=False)
+        nvr, camera = make_nvr(
+            vis, camera_output_fps=5, object_detector=object_detector
+        )
+        fake_time = FakeTime()
+        patch_nvr_utcnow(monkeypatch, fake_time)
+        patch_schedule_now(monkeypatch, fake_time)
+        configure_camera_for_recording_tests(camera, fake_time, idle_timeout=2)
+
+        object_detector.objects_in_fov = [
+            SimpleNamespace(trigger_event_recording=True, label="person")
+        ]
+        feed_frame_to_nvr(nvr)
+        nvr._run()
+        assert camera.is_recording is True

--- a/tests/components/storage/test_check_tier.py
+++ b/tests/components/storage/test_check_tier.py
@@ -4,10 +4,14 @@ import datetime
 from typing import Any
 from unittest.mock import patch
 
+import numpy as np
+from croniter import croniter
 from sqlalchemy import update
 
 from viseron.components.storage.check_tier import (
+    FILES_DTYPE,
     Worker,
+    get_continuous_files_to_move,
     get_files_to_move,
     get_recordings_to_move,
     load_recordings,
@@ -15,8 +19,15 @@ from viseron.components.storage.check_tier import (
 )
 from viseron.components.storage.models import Recordings
 from viseron.components.storage.storage_subprocess import DataItem
+from viseron.const import CAMERA_SEGMENT_DURATION
+from viseron.domains.camera.schedule import schedule_active
 
 from tests.common import BaseTestWithRecordings
+
+# Active for a single minute per year, so effectively never
+NEVER_ACTIVE_SCHEDULE = [{"start": "0 0 1 1 *", "end": "1 0 1 1 *"}]
+# Started every minute and ended once a year, so effectively always
+ALWAYS_ACTIVE_SCHEDULE = [{"start": "* * * * *", "end": "0 0 1 1 *"}]
 
 
 class TestCheckTier(BaseTestWithRecordings):
@@ -37,6 +48,7 @@ class TestCheckTier(BaseTestWithRecordings):
             min_age_timestamp=self._simulated_now.timestamp(),
             min_bytes=0,
             max_age_timestamp=0,
+            file_min_age_timestamp=self._simulated_now.timestamp(),
             drain=False,
         )
 
@@ -63,6 +75,7 @@ class TestCheckTier(BaseTestWithRecordings):
             min_age_timestamp=min_age_timestamp,
             min_bytes=0,
             max_age_timestamp=0,
+            file_min_age_timestamp=self._simulated_now.timestamp(),
             drain=False,
         )
 
@@ -86,6 +99,7 @@ class TestCheckTier(BaseTestWithRecordings):
             min_age_timestamp=self._simulated_now.timestamp(),
             min_bytes=0,
             max_age_timestamp=max_age_timestamp,
+            file_min_age_timestamp=self._simulated_now.timestamp(),
             drain=False,
         )
         assert len(files_to_move) == 6
@@ -115,6 +129,7 @@ class TestCheckTier(BaseTestWithRecordings):
             min_age_timestamp=self._simulated_now.timestamp(),
             min_bytes=110,
             max_age_timestamp=max_age_timestamp,
+            file_min_age_timestamp=self._simulated_now.timestamp(),
             drain=False,
         )
         assert len(files_to_move) == 5
@@ -144,6 +159,7 @@ class TestCheckTier(BaseTestWithRecordings):
             min_age_timestamp=self._simulated_now.timestamp(),
             min_bytes=0,
             max_age_timestamp=max_age_timestamp,
+            file_min_age_timestamp=self._simulated_now.timestamp(),
             drain=False,
         )
 
@@ -168,6 +184,7 @@ class TestCheckTier(BaseTestWithRecordings):
             min_age_timestamp=self._simulated_now.timestamp(),
             min_bytes=0,
             max_age_timestamp=0,
+            file_min_age_timestamp=self._simulated_now.timestamp(),
             drain=True,
         )
 
@@ -188,10 +205,67 @@ class TestCheckTier(BaseTestWithRecordings):
             min_age_timestamp=self._simulated_now.timestamp(),
             min_bytes=0,
             max_age_timestamp=0,
+            file_min_age_timestamp=self._simulated_now.timestamp(),
             drain=True,
         )
 
         assert len(files_to_move) == 0
+
+    def test_get_files_to_move_file_min_age(self) -> None:
+        """Test get_files_to_move using file_min_age_timestamp.
+
+        max_age alone would select 6 files, but file_min_age_timestamp is a hard
+        floor on every selected file, keeping the 3 most recent of them. The age
+        branch has no min-age guard of its own, so this is the only thing
+        protecting files that are still being written to.
+        """
+        max_age_timestamp = (self._now + datetime.timedelta(seconds=26)).timestamp()
+        file_min_age_timestamp = (
+            self._now + datetime.timedelta(seconds=11)
+        ).timestamp()
+        data = load_tier(
+            get_session=self._get_db_session,
+            category="recorder",
+            subcategories=["segments"],
+            tier_id=0,
+            camera_identifier="test",
+        )
+        files_to_move = get_files_to_move(
+            data=data,
+            max_bytes=0,
+            min_age_timestamp=self._simulated_now.timestamp(),
+            min_bytes=0,
+            max_age_timestamp=max_age_timestamp,
+            file_min_age_timestamp=file_min_age_timestamp,
+            drain=False,
+        )
+
+        assert list(files_to_move["id"]) == [1, 3, 5]
+
+    def test_get_files_to_move_drain_ignores_file_min_age(self) -> None:
+        """Test that drain bypasses file_min_age_timestamp.
+
+        Mirrors get_recordings_to_move: a draining tier is being emptied, so the
+        per-file floor does not apply.
+        """
+        data = load_tier(
+            get_session=self._get_db_session,
+            category="recorder",
+            subcategories=["segments"],
+            tier_id=0,
+            camera_identifier="test",
+        )
+        files_to_move = get_files_to_move(
+            data=data,
+            max_bytes=80,
+            min_age_timestamp=self._simulated_now.timestamp(),
+            min_bytes=0,
+            max_age_timestamp=0,
+            file_min_age_timestamp=(self._now - datetime.timedelta(days=1)).timestamp(),
+            drain=True,
+        )
+
+        assert len(files_to_move) == len(data)
 
     def test_recordings_to_move_query_max_bytes(self) -> None:
         """Test recordings_to_move_query using max_bytes."""
@@ -524,6 +598,316 @@ class TestCheckTier(BaseTestWithRecordings):
             assert file["recording_id"] == -1
 
 
+class TestGetContinuousFilesToMove:
+    """Test get_continuous_files_to_move: schedule-aware continuous retention."""
+
+    # 08:00-18:00 daily
+    SCHEDULE = [{"start": "0 8 * * *", "end": "0 18 * * *"}]
+
+    def _files(self, *entries: tuple[int, int, datetime.datetime]) -> np.ndarray:
+        return np.array(
+            [
+                (id_, size, int(ts.timestamp()), f"/test/{id_}.m4s", "/test/")
+                for id_, size, ts in entries
+            ],
+            dtype=FILES_DTYPE,
+        )
+
+    def test_no_schedule_matches_get_files_to_move(self) -> None:
+        """With schedule_entries=None, behaves exactly like get_files_to_move."""
+        now = datetime.datetime(2024, 1, 2, 20, 0, tzinfo=datetime.timezone.utc)
+        data = self._files(
+            (1, 10, now - datetime.timedelta(days=40)),
+            (2, 10, now - datetime.timedelta(seconds=5)),
+        )
+        max_age_timestamp = (now - datetime.timedelta(days=30)).timestamp()
+
+        result = get_continuous_files_to_move(
+            data=data.copy(),
+            max_bytes=0,
+            min_age_timestamp=now.timestamp(),
+            min_bytes=0,
+            max_age_timestamp=max_age_timestamp,
+            file_min_age_timestamp=now.timestamp(),
+            drain=False,
+            now=now,
+            schedule_entries=None,
+            timezone="UTC",
+            lookback_seconds=30,
+        )
+        expected = get_files_to_move(
+            data=data.copy(),
+            max_bytes=0,
+            min_age_timestamp=now.timestamp(),
+            min_bytes=0,
+            max_age_timestamp=max_age_timestamp,
+            file_min_age_timestamp=now.timestamp(),
+            drain=False,
+        )
+        assert list(result["id"]) == list(expected["id"])
+
+    def test_file_recorded_during_active_window_keeps_full_retention(self) -> None:
+        """A file recorded while the schedule was active is not evicted early.
+
+        Case:
+        - Recorded at 10:00 (inside 08:00-18:00 schedule)
+        - Now is 20:00 the same day, ten hours after recording
+        - Max age is 30 days
+
+        Result: file is not evicted, because it was recorded during an active window
+        and is nowhere near the max age.
+        """
+        now = datetime.datetime(2024, 1, 2, 20, 0, tzinfo=datetime.timezone.utc)
+        recorded_at = datetime.datetime(2024, 1, 2, 10, 0, tzinfo=datetime.timezone.utc)
+        data = self._files((1, 10, recorded_at))
+
+        result = get_continuous_files_to_move(
+            data=data,
+            max_bytes=0,
+            min_age_timestamp=now.timestamp(),
+            min_bytes=0,
+            max_age_timestamp=(now - datetime.timedelta(days=30)).timestamp(),
+            file_min_age_timestamp=now.timestamp(),
+            drain=False,
+            now=now,
+            schedule_entries=self.SCHEDULE,
+            timezone="UTC",
+            lookback_seconds=30,
+        )
+        assert len(result) == 0
+
+    def test_file_recorded_during_inactive_window_evicted_past_lookback(
+        self,
+    ) -> None:
+        """A file recorded while the schedule was inactive is capped to lookback.
+
+        Case:
+        - Schedule is 08:00-18:00 daily
+        - Recorded at 19:00 (after the 18:00 end)
+        - Now is 20:00, one hour later - well past the 30s lookback
+        - Max age is 30 days
+
+        Result: file is evicted, because it was recorded during an inactive window
+        and is now past the lookback threshold.
+        """
+        now = datetime.datetime(2024, 1, 2, 20, 0, tzinfo=datetime.timezone.utc)
+        recorded_at = datetime.datetime(2024, 1, 2, 19, 0, tzinfo=datetime.timezone.utc)
+        data = self._files((1, 10, recorded_at))
+
+        result = get_continuous_files_to_move(
+            data=data,
+            max_bytes=0,
+            min_age_timestamp=now.timestamp(),
+            min_bytes=0,
+            max_age_timestamp=(now - datetime.timedelta(days=30)).timestamp(),
+            file_min_age_timestamp=now.timestamp(),
+            drain=False,
+            now=now,
+            schedule_entries=self.SCHEDULE,
+            timezone="UTC",
+            lookback_seconds=30,
+        )
+        assert list(result["id"]) == [1]
+
+    def test_file_recorded_during_inactive_window_within_lookback_is_kept(
+        self,
+    ) -> None:
+        """A file inside the lookback buffer is never evicted.
+
+        Even though it was recorded while the schedule was inactive, it may
+        still be needed as lookback for the next event.
+        """
+        now = datetime.datetime(2024, 1, 2, 20, 0, tzinfo=datetime.timezone.utc)
+        recorded_at = now - datetime.timedelta(seconds=10)  # 19:59:50, inactive
+        data = self._files((1, 10, recorded_at))
+
+        result = get_continuous_files_to_move(
+            data=data,
+            max_bytes=0,
+            min_age_timestamp=now.timestamp(),
+            min_bytes=0,
+            max_age_timestamp=(now - datetime.timedelta(days=30)).timestamp(),
+            file_min_age_timestamp=now.timestamp(),
+            drain=False,
+            now=now,
+            schedule_entries=self.SCHEDULE,
+            timezone="UTC",
+            lookback_seconds=30,
+        )
+        assert len(result) == 0
+
+    def test_inactive_file_straddling_lookback_boundary_is_kept(self) -> None:
+        """The segment covering the start of the pre-roll window is retained."""
+        now = datetime.datetime(2024, 1, 2, 20, 0, tzinfo=datetime.timezone.utc)
+        # Inactive (20:00 is outside 08:00-18:00), one second older than the
+        # lookback window, so it is the segment straddling its start.
+        recorded_at = now - datetime.timedelta(seconds=31)
+        data = self._files((1, 10, recorded_at))
+
+        result = get_continuous_files_to_move(
+            data=data,
+            max_bytes=0,
+            min_age_timestamp=now.timestamp(),
+            min_bytes=0,
+            max_age_timestamp=(now - datetime.timedelta(days=30)).timestamp(),
+            file_min_age_timestamp=now.timestamp(),
+            drain=False,
+            now=now,
+            schedule_entries=self.SCHEDULE,
+            timezone="UTC",
+            lookback_seconds=30,
+        )
+        assert len(result) == 0
+
+    def test_inactive_files_respect_min_age(self) -> None:
+        """A configured min_age is never overridden by the schedule cutoff.
+
+        The shortened inactive horizon selects the file, but the per-file floor
+        the caller passes still keeps it, exactly as it would for an active file.
+        """
+        now = datetime.datetime(2024, 1, 2, 20, 0, tzinfo=datetime.timezone.utc)
+        recorded_at = now - datetime.timedelta(minutes=10)  # inactive
+        data = self._files((1, 10, recorded_at))
+
+        result = get_continuous_files_to_move(
+            data=data,
+            max_bytes=0,
+            # min_age of one hour, i.e. nothing younger than this may be moved.
+            min_age_timestamp=(now - datetime.timedelta(hours=1)).timestamp(),
+            min_bytes=0,
+            max_age_timestamp=(now - datetime.timedelta(days=30)).timestamp(),
+            file_min_age_timestamp=(now - datetime.timedelta(hours=1)).timestamp(),
+            drain=False,
+            now=now,
+            schedule_entries=self.SCHEDULE,
+            timezone="UTC",
+            lookback_seconds=30,
+        )
+        assert len(result) == 0
+
+    def test_respects_configured_timezone(self) -> None:
+        """The configured timezone (not UTC) decides whether the window was active."""
+        now = datetime.datetime(2024, 1, 2, 20, 0, tzinfo=datetime.timezone.utc)
+        recorded_at = datetime.datetime(2024, 1, 2, 7, 30, tzinfo=datetime.timezone.utc)
+        data = self._files((1, 10, recorded_at))
+        max_age_timestamp = (now - datetime.timedelta(days=30)).timestamp()
+
+        result_utc = get_continuous_files_to_move(
+            data=data.copy(),
+            max_bytes=0,
+            min_age_timestamp=now.timestamp(),
+            min_bytes=0,
+            max_age_timestamp=max_age_timestamp,
+            file_min_age_timestamp=now.timestamp(),
+            drain=False,
+            now=now,
+            schedule_entries=self.SCHEDULE,
+            timezone="UTC",
+            lookback_seconds=30,
+        )
+        assert list(result_utc["id"]) == [1]
+
+        result_stockholm = get_continuous_files_to_move(
+            data=data.copy(),
+            max_bytes=0,
+            min_age_timestamp=now.timestamp(),
+            min_bytes=0,
+            max_age_timestamp=max_age_timestamp,
+            file_min_age_timestamp=now.timestamp(),
+            drain=False,
+            now=now,
+            schedule_entries=self.SCHEDULE,
+            timezone="Europe/Stockholm",
+            lookback_seconds=30,
+        )
+        assert len(result_stockholm) == 0
+
+    def test_mixed_active_and_inactive_files(self) -> None:
+        """Active and inactive files are evaluated independently in one call."""
+        now = datetime.datetime(2024, 1, 2, 20, 0, tzinfo=datetime.timezone.utc)
+        active_recorded = datetime.datetime(
+            2024, 1, 2, 10, 0, tzinfo=datetime.timezone.utc
+        )
+        inactive_recorded = datetime.datetime(
+            2024, 1, 2, 19, 0, tzinfo=datetime.timezone.utc
+        )
+        data = self._files(
+            (1, 10, active_recorded),
+            (2, 10, inactive_recorded),
+        )
+
+        result = get_continuous_files_to_move(
+            data=data,
+            max_bytes=0,
+            min_age_timestamp=now.timestamp(),
+            min_bytes=0,
+            max_age_timestamp=(now - datetime.timedelta(days=30)).timestamp(),
+            file_min_age_timestamp=now.timestamp(),
+            drain=False,
+            now=now,
+            schedule_entries=self.SCHEDULE,
+            timezone="UTC",
+            lookback_seconds=30,
+        )
+        assert list(result["id"]) == [2]
+
+    def test_schedule_evaluation_does_not_scale_with_file_count(self) -> None:
+        """Cron is parsed per schedule transition, not per file.
+
+        A tier holding a couple of days of segments has thousands of rows, and
+        evaluating the schedule for each of them parses two cron expressions per
+        entry. The state only flips where a cron fires, so the whole range is
+        resolved from a handful of evaluations.
+        """
+        now = datetime.datetime(2024, 1, 3, 4, 0, tzinfo=datetime.timezone.utc)
+        oldest = now - datetime.timedelta(days=2)
+        data = self._files(
+            *[
+                (id_, 10, oldest + datetime.timedelta(seconds=120 * id_))
+                for id_ in range(1, 1500)
+            ]
+        )
+        lookback_seconds = 30
+
+        with patch(
+            "viseron.domains.camera.schedule.croniter", wraps=croniter
+        ) as mock_croniter:
+            result = get_continuous_files_to_move(
+                data=data,
+                max_bytes=0,
+                min_age_timestamp=now.timestamp(),
+                min_bytes=0,
+                max_age_timestamp=0,
+                file_min_age_timestamp=now.timestamp(),
+                drain=False,
+                now=now,
+                schedule_entries=self.SCHEDULE,
+                timezone="UTC",
+                lookback_seconds=lookback_seconds,
+            )
+
+        # 6 window edges across the two days, plus the initial state
+        assert mock_croniter.call_count < 50
+
+        cutoff = (
+            now - datetime.timedelta(seconds=lookback_seconds + CAMERA_SEGMENT_DURATION)
+        ).timestamp()
+        expected = {
+            int(row["id"])
+            for row in data
+            if row["orig_ctime"] < cutoff
+            and not schedule_active(
+                self.SCHEDULE,
+                "UTC",
+                datetime.datetime.fromtimestamp(
+                    int(row["orig_ctime"]), tz=datetime.timezone.utc
+                ),
+            )
+        }
+        assert expected
+        assert set(result["id"].tolist()) == expected
+
+
 class TestShouldCheckTierFiles(BaseTestWithRecordings):
     """Test Worker._should_check_tier_files fast-path gate for file checks."""
 
@@ -683,6 +1067,127 @@ class TestShouldCheckTierFiles(BaseTestWithRecordings):
         )
         assert worker._should_check_tier_files(item) is False
 
+    def test_continuous_schedule_inactive_file_past_lookback_returns_true(self) -> None:
+        """A schedule-aware lookback gate fires even when bytes/age gates would not.
+
+        Without the schedule-aware gate, an inactive-window file older than the
+        lookback buffer would never trigger a real check (and would sit forever)
+        since neither max_bytes nor max_age alone would notice it.
+        """
+        worker = self._make_worker()
+        item = self._make_item(
+            max_bytes=0,
+            max_age=datetime.timedelta(days=365),
+            continuous_schedule=NEVER_ACTIVE_SCHEDULE,
+            continuous_schedule_timezone="UTC",
+            continuous_lookback_seconds=1,
+        )
+        future_now = self._now + datetime.timedelta(minutes=10)
+        with patch(
+            "viseron.components.storage.check_tier.utcnow", return_value=future_now
+        ):
+            assert worker._should_check_tier_files(item) is True
+
+    def test_continuous_schedule_oldest_file_within_lookback_returns_false(
+        self,
+    ) -> None:
+        """No gate fires when the oldest file is still within the lookback buffer."""
+        worker = self._make_worker()
+        item = self._make_item(
+            max_bytes=0,
+            max_age=datetime.timedelta(days=365),
+            continuous_schedule=NEVER_ACTIVE_SCHEDULE,
+            continuous_schedule_timezone="UTC",
+            continuous_lookback_seconds=99999,
+        )
+        assert worker._should_check_tier_files(item) is False
+
+    def test_continuous_schedule_only_active_files_returns_false(self) -> None:
+        """Files recorded while the schedule was active do not fire the gate.
+
+        They keep the full configured retention, so the schedule has nothing to
+        contribute and the expensive check is skipped. Without this the gate is
+        defeated for every camera that configures a schedule, since a tier almost
+        always holds files older than the lookback buffer.
+        """
+        worker = self._make_worker()
+        item = self._make_item(
+            max_bytes=0,
+            max_age=datetime.timedelta(days=365),
+            continuous_schedule=ALWAYS_ACTIVE_SCHEDULE,
+            continuous_schedule_timezone="UTC",
+            continuous_lookback_seconds=1,
+        )
+        future_now = self._now + datetime.timedelta(minutes=10)
+        with patch(
+            "viseron.components.storage.check_tier.utcnow", return_value=future_now
+        ):
+            assert worker._should_check_tier_files(item) is False
+
+    def test_continuous_schedule_inactive_file_newer_than_oldest_returns_true(
+        self,
+    ) -> None:
+        """The gate looks at every inactive window, not just the oldest file.
+
+        The oldest file was recorded while the schedule was active, but a later
+        one was not, so there is still something for the schedule to evict.
+        """
+        # Schedule ends on the next whole minute, which the last files fall after
+        ends_at = (self._now + datetime.timedelta(minutes=1)).replace(
+            second=0, microsecond=0
+        )
+        worker = self._make_worker()
+        item = self._make_item(
+            max_bytes=0,
+            max_age=datetime.timedelta(days=365),
+            continuous_schedule=[
+                {
+                    "start": "* * * * *",
+                    "end": f"{ends_at.minute} {ends_at.hour} "
+                    f"{ends_at.day} {ends_at.month} *",
+                }
+            ],
+            continuous_schedule_timezone="UTC",
+            continuous_lookback_seconds=1,
+        )
+        future_now = self._now + datetime.timedelta(minutes=10)
+        with patch(
+            "viseron.components.storage.check_tier.utcnow", return_value=future_now
+        ):
+            assert worker._should_check_tier_files(item) is True
+
+    def test_continuous_schedule_too_many_windows_returns_true(self) -> None:
+        """A schedule with more windows than can be queried defers to the check.
+
+        Every file here was recorded while the schedule was active, so the exact
+        answer is False, but the windows are capped before that can be decided.
+        """
+        # Schedule ends after the last file, so no file is in an inactive window
+        ends_at = (self._now + datetime.timedelta(minutes=3)).replace(
+            second=0, microsecond=0
+        )
+        worker = self._make_worker()
+        item = self._make_item(
+            max_bytes=0,
+            max_age=datetime.timedelta(days=365),
+            continuous_schedule=[
+                {
+                    "start": "* * * * *",
+                    "end": f"{ends_at.minute} {ends_at.hour} "
+                    f"{ends_at.day} {ends_at.month} *",
+                }
+            ],
+            continuous_schedule_timezone="UTC",
+            continuous_lookback_seconds=1,
+        )
+        future_now = self._now + datetime.timedelta(minutes=10)
+        with patch(
+            "viseron.components.storage.check_tier.utcnow", return_value=future_now
+        ):
+            assert worker._should_check_tier_files(item) is False
+            with patch("viseron.components.storage.check_tier.MAX_SCHEDULE_CHANGES", 2):
+                assert worker._should_check_tier_files(item) is True
+
 
 class TestCheckTierIntegration(BaseTestWithRecordings):
     """Integration tests for Worker.check_tier through the full gate + logic pipeline.
@@ -836,6 +1341,7 @@ class TestCheckTierIntegration(BaseTestWithRecordings):
             min_age_timestamp=min_age_timestamp,
             min_bytes=0,
             max_age_timestamp=0,
+            file_min_age_timestamp=min_age_timestamp,
             drain=False,
         )
 
@@ -872,6 +1378,7 @@ class TestCheckTierIntegration(BaseTestWithRecordings):
             min_age_timestamp=min_age_timestamp,
             min_bytes=0,
             max_age_timestamp=0,
+            file_min_age_timestamp=min_age_timestamp,
             drain=True,
         )
 

--- a/tests/components/storage/test_tier_handler.py
+++ b/tests/components/storage/test_tier_handler.py
@@ -28,7 +28,13 @@ from viseron.components.storage.tier_handler import (
     find_next_tier_segments,
     handle_file,
 )
-from viseron.domains.camera.const import CONFIG_CONTINUOUS_RECORDING, CONFIG_LOOKBACK
+from viseron.domains.camera.const import (
+    CONFIG_CONTINUOUS_RECORDING,
+    CONFIG_LOOKBACK,
+    CONFIG_SCHEDULE,
+    CONFIG_SCHEDULE_CONTINUOUS,
+    CONFIG_SCHEDULE_TIMEZONE,
+)
 from viseron.helpers import utcnow
 
 from tests.common import BaseTestWithRecordings
@@ -264,7 +270,11 @@ class TestSegmentsTierHandler(BaseTestWithRecordings):
         mock_camera = Mock()
         mock_camera.identifier = "test"
         mock_camera.config = {
-            CONFIG_RECORDER: {CONFIG_LOOKBACK: 5, CONFIG_CONTINUOUS_RECORDING: True}
+            CONFIG_RECORDER: {
+                CONFIG_LOOKBACK: 5,
+                CONFIG_CONTINUOUS_RECORDING: True,
+                CONFIG_SCHEDULE: None,
+            }
         }
 
         tier_handler = SegmentsTierHandler(
@@ -363,7 +373,11 @@ class TestSegmentsTierHandler(BaseTestWithRecordings):
         mock_camera = Mock()
         mock_camera.identifier = "test"
         mock_camera.config = {
-            CONFIG_RECORDER: {CONFIG_LOOKBACK: 5, CONFIG_CONTINUOUS_RECORDING: True}
+            CONFIG_RECORDER: {
+                CONFIG_LOOKBACK: 5,
+                CONFIG_CONTINUOUS_RECORDING: True,
+                CONFIG_SCHEDULE: None,
+            }
         }
 
         tier_handlers = []
@@ -446,7 +460,11 @@ class TestCheckTierCallbackLifecycle:
         mock_camera.identifier = "test"
         mock_camera.recorder.lookback = 5
         mock_camera.config = {
-            CONFIG_RECORDER: {CONFIG_LOOKBACK: 5, CONFIG_CONTINUOUS_RECORDING: True}
+            CONFIG_RECORDER: {
+                CONFIG_LOOKBACK: 5,
+                CONFIG_CONTINUOUS_RECORDING: True,
+                CONFIG_SCHEDULE: None,
+            }
         }
         # _create_dataitem reads CONFIG_DRAIN, which _get_tier_config omits.
         tier_config = _get_tier_config(events=True, continuous=True)
@@ -566,7 +584,11 @@ def test_find_next_tier_segments(vis: Viseron):
     mock_camera = Mock()
     mock_camera.identifier = "test_camera"
     mock_camera.config = {
-        CONFIG_RECORDER: {CONFIG_LOOKBACK: 5, CONFIG_CONTINUOUS_RECORDING: True}
+        CONFIG_RECORDER: {
+            CONFIG_LOOKBACK: 5,
+            CONFIG_CONTINUOUS_RECORDING: True,
+            CONFIG_SCHEDULE: None,
+        }
     }
 
     tier_handler_0 = SegmentsTierHandler(
@@ -627,3 +649,143 @@ def test_find_next_tier_segments(vis: Viseron):
 
     result = find_next_tier_segments(mock_storage, 2, mock_camera, "events")
     assert result is None
+
+
+def test_continuous_enabled_is_structural_only(vis: MockViseron) -> None:
+    """continuous_enabled reflects config only, never live schedule state.
+
+    The schedule is applied per-file inside the storage subprocess (see
+    get_continuous_files_to_move), not by disabling the whole continuous
+    retention path here.
+    Disabling it here would route orphan continuous
+    files through the events-only force_delete path and destroy already
+    -retained footage the moment the schedule closes.
+    """
+    mock_camera = Mock()
+    mock_camera.identifier = "test"
+    mock_camera.recorder.lookback = 5
+    mock_camera.config = {
+        CONFIG_RECORDER: {
+            CONFIG_LOOKBACK: 5,
+            CONFIG_CONTINUOUS_RECORDING: True,
+            CONFIG_SCHEDULE: {
+                CONFIG_SCHEDULE_CONTINUOUS: [
+                    {"start": "0 22 * * *", "end": "0 6 * * *"}
+                ],
+                CONFIG_SCHEDULE_TIMEZONE: "UTC",
+            },
+        }
+    }
+
+    tier = _get_tier_config(events=True, continuous=True)
+    tier[CONFIG_DRAIN] = False
+    tier_handler = SegmentsTierHandler(
+        vis,
+        mock_camera,
+        0,
+        "recorder",
+        "segments",
+        tier,
+        None,
+    )
+
+    assert tier_handler.continuous_enabled is True
+    assert tier_handler._create_dataitem().files_enabled is True
+
+
+def test_create_dataitem_passes_continuous_schedule_entries(
+    vis: MockViseron,
+) -> None:
+    """_create_dataitem forwards the configured continuous schedule and lookback."""
+    mock_camera = Mock()
+    mock_camera.identifier = "test"
+    mock_camera.recorder.lookback = 7
+    schedule_entries = [{"start": "0 22 * * *", "end": "0 6 * * *"}]
+    mock_camera.config = {
+        CONFIG_RECORDER: {
+            CONFIG_LOOKBACK: 7,
+            CONFIG_CONTINUOUS_RECORDING: True,
+            CONFIG_SCHEDULE: {
+                CONFIG_SCHEDULE_CONTINUOUS: schedule_entries,
+                CONFIG_SCHEDULE_TIMEZONE: "Europe/Stockholm",
+            },
+        }
+    }
+
+    tier = _get_tier_config(events=True, continuous=True)
+    tier[CONFIG_DRAIN] = False
+    tier_handler = SegmentsTierHandler(
+        vis,
+        mock_camera,
+        0,
+        "recorder",
+        "segments",
+        tier,
+        None,
+    )
+
+    item = tier_handler._create_dataitem()
+    assert item.continuous_schedule == schedule_entries
+    assert item.continuous_schedule_timezone == "Europe/Stockholm"
+    assert item.continuous_lookback_seconds == 7
+
+
+def test_create_dataitem_continuous_schedule_none_when_omitted(
+    vis: MockViseron,
+) -> None:
+    """Omitting the schedule preserves the pre-existing always-on behavior."""
+    mock_camera = Mock()
+    mock_camera.identifier = "test"
+    mock_camera.recorder.lookback = 5
+    mock_camera.config = {
+        CONFIG_RECORDER: {
+            CONFIG_LOOKBACK: 5,
+            CONFIG_CONTINUOUS_RECORDING: True,
+            CONFIG_SCHEDULE: None,
+        }
+    }
+
+    tier = _get_tier_config(events=True, continuous=True)
+    tier[CONFIG_DRAIN] = False
+    tier_handler = SegmentsTierHandler(
+        vis,
+        mock_camera,
+        0,
+        "recorder",
+        "segments",
+        tier,
+        None,
+    )
+
+    assert tier_handler.continuous_enabled is True
+    item = tier_handler._create_dataitem()
+    assert item.continuous_schedule is None
+    assert item.continuous_schedule_timezone is None
+    assert item.files_enabled is True
+
+
+def test_continuous_enabled_now_false_when_continuous_recording_disabled(
+    vis: MockViseron,
+) -> None:
+    """continuous_recording: false still disables continuous regardless of schedule."""
+    mock_camera = Mock()
+    mock_camera.identifier = "test"
+    mock_camera.config = {
+        CONFIG_RECORDER: {
+            CONFIG_LOOKBACK: 5,
+            CONFIG_CONTINUOUS_RECORDING: False,
+            CONFIG_SCHEDULE: None,
+        }
+    }
+
+    tier_handler = SegmentsTierHandler(
+        vis,
+        mock_camera,
+        0,
+        "recorder",
+        "segments",
+        _get_tier_config(events=True, continuous=True),
+        None,
+    )
+
+    assert tier_handler.continuous_enabled is False

--- a/tests/domains/camera/test_config.py
+++ b/tests/domains/camera/test_config.py
@@ -1,0 +1,39 @@
+"""Tests for the camera domain recording schedule config schema."""
+
+from __future__ import annotations
+
+import pytest
+import voluptuous as vol
+
+from viseron.domains.camera.config import RECORDING_SCHEDULE_SCHEMA
+from viseron.domains.camera.const import (
+    CONFIG_SCHEDULE_EVENTS,
+    CONFIG_SCHEDULE_TIMEZONE,
+)
+from viseron.helpers.validators import UNDEFINED
+
+
+def test_timezone_defaults_to_undefined():
+    """Omitting timezone leaves it UNDEFINED, to be resolved at runtime."""
+    result = RECORDING_SCHEDULE_SCHEMA({CONFIG_SCHEDULE_EVENTS: None})
+    # voluptuous calls the UNDEFINED class as a default factory, so the stored
+    # value is an instance. UNDEFINED.__eq__ makes == the idiomatic check.
+    assert result[CONFIG_SCHEDULE_TIMEZONE] == UNDEFINED
+
+
+def test_timezone_can_be_overridden():
+    """An explicit timezone is preserved."""
+    result = RECORDING_SCHEDULE_SCHEMA({CONFIG_SCHEDULE_TIMEZONE: "America/New_York"})
+    assert result[CONFIG_SCHEDULE_TIMEZONE] == "America/New_York"
+
+
+def test_timezone_accepts_none():
+    """An explicit null falls back to runtime resolution too."""
+    result = RECORDING_SCHEDULE_SCHEMA({CONFIG_SCHEDULE_TIMEZONE: None})
+    assert result[CONFIG_SCHEDULE_TIMEZONE] is None
+
+
+def test_invalid_timezone_override_rejected():
+    """An invalid timezone override fails schema validation."""
+    with pytest.raises(vol.Invalid):
+        RECORDING_SCHEDULE_SCHEMA({CONFIG_SCHEDULE_TIMEZONE: "Not/AZone"})

--- a/tests/domains/camera/test_recorder.py
+++ b/tests/domains/camera/test_recorder.py
@@ -1,4 +1,5 @@
 """Tests for recorder."""
+
 from __future__ import annotations
 
 import datetime
@@ -95,7 +96,7 @@ def test_get_recordings_utc(get_db_session_recordings: Callable[[], Session]) ->
 
 
 def test_get_recordings_positive_offset(
-    get_db_session_recordings: Callable[[], Session]
+    get_db_session_recordings: Callable[[], Session],
 ) -> None:
     """Test get_recordings in UTC+5:30 (India)."""
     recordings = get_recordings(
@@ -111,7 +112,7 @@ def test_get_recordings_positive_offset(
 
 
 def test_get_recordings_negative_offset(
-    get_db_session_recordings: Callable[[], Session]
+    get_db_session_recordings: Callable[[], Session],
 ) -> None:
     """Test get_recordings in UTC-5 (Eastern)."""
     recordings = get_recordings(
@@ -123,7 +124,7 @@ def test_get_recordings_negative_offset(
 
 
 def test_get_recordings_date_specific_timezone(
-    get_db_session_recordings: Callable[[], Session]
+    get_db_session_recordings: Callable[[], Session],
 ) -> None:
     """Test get_recordings with specific date in different timezone."""
     # Test in UTC+1
@@ -146,7 +147,7 @@ def test_get_recordings_date_specific_timezone(
 
 
 def test_get_recordings_latest_with_timezone(
-    get_db_session_recordings: Callable[[], Session]
+    get_db_session_recordings: Callable[[], Session],
 ) -> None:
     """Test get_recordings latest flag with timezone consideration."""
     # Test in UTC-7 (PDT)
@@ -166,7 +167,7 @@ def test_get_recordings_latest_with_timezone(
 
 
 def test_get_recordings_latest_daily_with_timezone(
-    get_db_session_recordings: Callable[[], Session]
+    get_db_session_recordings: Callable[[], Session],
 ) -> None:
     """Test get_recordings latest daily flag with timezone consideration."""
     # Test in UTC+9 (Japan)
@@ -184,7 +185,7 @@ def test_get_recordings_latest_daily_with_timezone(
 
 
 def test_delete_recordings_with_timezone(
-    get_db_session_recordings: Callable[[], Session]
+    get_db_session_recordings: Callable[[], Session],
 ) -> None:
     """Test delete_recordings with timezone consideration."""
     # Test deleting recordings for a specific date in UTC+1
@@ -276,7 +277,7 @@ class ConcreteTestRecorder(AbstractRecorder):
 
 @pytest.fixture(name="add_recording_to_session")
 def fixture_add_recording_to_session(
-    get_db_session: Callable[[], Session]
+    get_db_session: Callable[[], Session],
 ) -> Callable[
     [int, datetime.datetime, datetime.datetime, datetime.datetime, str, str], None
 ]:
@@ -309,7 +310,7 @@ def fixture_add_recording_to_session(
 
 @pytest.fixture(name="add_segment_to_session")
 def fixture_add_segment_to_session(
-    get_db_session: Callable[[], Session]
+    get_db_session: Callable[[], Session],
 ) -> Callable[[datetime.datetime, float], None]:
     """Fixture to add a segment to the session with an incrementing variable."""
 
@@ -464,10 +465,11 @@ class TestAbstractRecorder:
             segment_start = recording.start_time + datetime.timedelta(seconds=offset)
             add_segment_to_session(segment_start, segment_duration)
 
-        # pylint: disable=protected-access
-        with patch.object(recorder._storage, "get_session") as mock_get_session, patch(
-            "shutil.move"
-        ) as _, patch("viseron.domains.camera.recorder.sleep"):
+        with (
+            patch.object(recorder._storage, "get_session") as mock_get_session,
+            patch("shutil.move") as _,
+            patch("viseron.domains.camera.recorder.sleep"),
+        ):
             mock_get_session.return_value = get_db_session()
 
             result = recorder._concatenate_fragments(recording)

--- a/tests/domains/camera/test_schedule.py
+++ b/tests/domains/camera/test_schedule.py
@@ -1,0 +1,329 @@
+"""Tests for camera recording schedule evaluation."""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from croniter import croniter
+
+from viseron.domains.camera.const import CONFIG_SCHEDULE_TIMEZONE
+from viseron.domains.camera.schedule import (
+    _schedule_active_at_minute,
+    resolve_timezone,
+    schedule_active,
+    schedule_state_changes,
+)
+from viseron.helpers import get_local_timezone
+from viseron.helpers.validators import UNDEFINED
+
+WEEKDAY_EVENING = datetime.datetime(
+    2024, 1, 1, 20, 0, tzinfo=datetime.timezone.utc
+)  # Monday
+WEEKDAY_MORNING = datetime.datetime(
+    2024, 1, 1, 10, 0, tzinfo=datetime.timezone.utc
+)  # Monday
+WEEKEND_MORNING = datetime.datetime(
+    2024, 1, 6, 10, 0, tzinfo=datetime.timezone.utc
+)  # Saturday
+
+WEEKDAY_SCHEDULE = [{"start": "0 8 * * mon-fri", "end": "0 18 * * mon-fri"}]
+OVERNIGHT_SCHEDULE = [{"start": "0 22 * * *", "end": "0 6 * * *"}]
+
+
+@pytest.mark.parametrize("entries", [None, []])
+def test_schedule_active_no_entries(entries: list[dict[str, Any]] | None) -> None:
+    """No entries means recording is never restricted."""
+    assert schedule_active(entries, "UTC", WEEKDAY_EVENING) is True
+
+
+def test_schedule_active_within_window() -> None:
+    """Active during a same-day window on a matching weekday."""
+    assert schedule_active(WEEKDAY_SCHEDULE, "UTC", WEEKDAY_MORNING) is True
+
+
+def test_schedule_active_outside_window() -> None:
+    """Inactive outside the configured hours on a matching weekday."""
+    assert schedule_active(WEEKDAY_SCHEDULE, "UTC", WEEKDAY_EVENING) is False
+
+
+def test_schedule_active_wrong_day() -> None:
+    """Inactive on a day of week not covered by the cron expression."""
+    assert schedule_active(WEEKDAY_SCHEDULE, "UTC", WEEKEND_MORNING) is False
+
+
+def test_schedule_active_overnight_before_midnight() -> None:
+    """Overnight window is active before midnight on the start day."""
+    before_midnight = datetime.datetime(2024, 1, 1, 23, 0, tzinfo=datetime.timezone.utc)
+    assert schedule_active(OVERNIGHT_SCHEDULE, "UTC", before_midnight) is True
+
+
+def test_schedule_active_overnight_after_midnight() -> None:
+    """Overnight window is still active just after midnight on the next day."""
+    after_midnight = datetime.datetime(2024, 1, 2, 3, 0, tzinfo=datetime.timezone.utc)
+    assert schedule_active(OVERNIGHT_SCHEDULE, "UTC", after_midnight) is True
+
+
+def test_schedule_active_overnight_daytime() -> None:
+    """Overnight window is inactive during the following day."""
+    daytime = datetime.datetime(2024, 1, 2, 12, 0, tzinfo=datetime.timezone.utc)
+    assert schedule_active(OVERNIGHT_SCHEDULE, "UTC", daytime) is False
+
+
+def test_schedule_active_multiple_entries_ored() -> None:
+    """Any matching entry makes the schedule active."""
+    entries = [
+        {"start": "0 8 * * mon-fri", "end": "0 18 * * mon-fri"},
+        {"start": "0 0 * * sat,sun", "end": "59 23 * * sat,sun"},
+    ]
+    assert schedule_active(entries, "UTC", WEEKEND_MORNING) is True
+    assert schedule_active(entries, "UTC", WEEKDAY_MORNING) is True
+    assert schedule_active(entries, "UTC", WEEKDAY_EVENING) is False
+
+
+def test_schedule_active_defaults_to_now() -> None:
+    """Now defaults to the current system time when not provided."""
+    assert schedule_active(None, "UTC") is True
+
+
+def test_schedule_active_inclusive_of_start_boundary() -> None:
+    """The window is active at the exact minute the start cron fires."""
+    entries = [{"start": "0 8 * * *", "end": "0 18 * * *"}]
+    at_start = datetime.datetime(2024, 1, 1, 8, 0, tzinfo=datetime.timezone.utc)
+    assert schedule_active(entries, "UTC", at_start) is True
+
+
+def test_schedule_active_exclusive_of_end_boundary() -> None:
+    """The window is no longer active at the exact minute the end cron fires."""
+    entries = [{"start": "0 8 * * *", "end": "0 18 * * *"}]
+    at_end = datetime.datetime(2024, 1, 1, 18, 0, tzinfo=datetime.timezone.utc)
+    assert schedule_active(entries, "UTC", at_end) is False
+
+
+def test_schedule_active_respects_non_utc_timezone() -> None:
+    """A UTC instant is evaluated against the configured zone's wall clock."""
+    entries = [{"start": "0 8 * * *", "end": "0 18 * * *"}]
+    at_07_30_utc = datetime.datetime(2024, 1, 1, 7, 30, tzinfo=datetime.timezone.utc)
+    assert schedule_active(entries, "UTC", at_07_30_utc) is False
+    assert schedule_active(entries, "Europe/Stockholm", at_07_30_utc) is True
+
+
+def test_schedule_active_timezone_across_dst_transition() -> None:
+    """The configured zone's DST offset is respected, not a fixed UTC offset."""
+    entries = [{"start": "0 8 * * *", "end": "0 18 * * *"}]
+
+    winter_06_30_utc = datetime.datetime(
+        2024, 1, 1, 6, 30, tzinfo=datetime.timezone.utc
+    )
+    assert schedule_active(entries, "Europe/Stockholm", winter_06_30_utc) is False
+
+    summer_06_30_utc = datetime.datetime(
+        2024, 7, 1, 6, 30, tzinfo=datetime.timezone.utc
+    )
+    assert schedule_active(entries, "Europe/Stockholm", summer_06_30_utc) is True
+
+
+class TestScheduleActiveCaching:
+    """Tests for the per-minute memoization of schedule_active.
+
+    schedule_active is called for every frame the NVR processes, and cron
+    expressions only change state on minute boundaries, so the answer is cached
+    for the minute it was computed in.
+    """
+
+    SCHEDULE = [{"start": "0 8 * * *", "end": "0 18 * * *"}]
+
+    def setup_method(self) -> None:
+        """Clear the lru_cache before each test."""
+        _schedule_active_at_minute.cache_clear()
+
+    def teardown_method(self) -> None:
+        """Clear the lru_cache after each test."""
+        _schedule_active_at_minute.cache_clear()
+
+    def test_repeated_calls_within_the_same_minute_parse_cron_once(self) -> None:
+        """Cron expressions are parsed once per minute, not once per call."""
+        now = datetime.datetime(2024, 1, 1, 10, 0, tzinfo=datetime.timezone.utc)
+
+        with patch(
+            "viseron.domains.camera.schedule.croniter", wraps=croniter
+        ) as mock_croniter:
+            for second in range(0, 60, 5):
+                assert (
+                    schedule_active(self.SCHEDULE, "UTC", now.replace(second=second))
+                    is True
+                )
+
+        # One croniter per cron expression, for the first call only
+        assert mock_croniter.call_count == 2
+
+    def test_cache_is_keyed_per_minute(self) -> None:
+        """The cached answer expires on the minute the schedule flips."""
+        just_before_end = datetime.datetime(
+            2024, 1, 1, 17, 59, 59, tzinfo=datetime.timezone.utc
+        )
+        at_end = datetime.datetime(2024, 1, 1, 18, 0, tzinfo=datetime.timezone.utc)
+
+        assert schedule_active(self.SCHEDULE, "UTC", just_before_end) is True
+        assert schedule_active(self.SCHEDULE, "UTC", at_end) is False
+
+    def test_cache_is_keyed_on_entries_and_timezone(self) -> None:
+        """Different schedules and timezones must not share a cache entry."""
+        at_07_30_utc = datetime.datetime(
+            2024, 1, 1, 7, 30, tzinfo=datetime.timezone.utc
+        )
+
+        assert schedule_active(self.SCHEDULE, "UTC", at_07_30_utc) is False
+        assert schedule_active(self.SCHEDULE, "Europe/Stockholm", at_07_30_utc) is True
+        assert (
+            schedule_active(
+                [{"start": "0 7 * * *", "end": "0 18 * * *"}], "UTC", at_07_30_utc
+            )
+            is True
+        )
+
+
+class TestScheduleStateChanges:
+    """Tests for schedule_state_changes."""
+
+    SCHEDULE = [{"start": "0 8 * * *", "end": "0 18 * * *"}]
+
+    def test_range_inside_a_window_has_no_changes(self) -> None:
+        """A range that never crosses a cron firing is a single state."""
+        start = datetime.datetime(2024, 1, 1, 9, 0, tzinfo=datetime.timezone.utc)
+        end = datetime.datetime(2024, 1, 1, 10, 0, tzinfo=datetime.timezone.utc)
+
+        assert schedule_state_changes(self.SCHEDULE, "UTC", start, end) == [
+            (start.timestamp(), True)
+        ]
+
+    def test_window_boundaries_are_reported(self) -> None:
+        """Both edges of a window show up as state changes."""
+        start = datetime.datetime(2024, 1, 1, 7, 0, tzinfo=datetime.timezone.utc)
+        end = datetime.datetime(2024, 1, 1, 19, 0, tzinfo=datetime.timezone.utc)
+
+        assert schedule_state_changes(self.SCHEDULE, "UTC", start, end) == [
+            (start.timestamp(), False),
+            (
+                datetime.datetime(
+                    2024, 1, 1, 8, 0, tzinfo=datetime.timezone.utc
+                ).timestamp(),
+                True,
+            ),
+            (
+                datetime.datetime(
+                    2024, 1, 1, 18, 0, tzinfo=datetime.timezone.utc
+                ).timestamp(),
+                False,
+            ),
+        ]
+
+    def test_firings_that_do_not_flip_the_state_are_collapsed(self) -> None:
+        """Overlapping entries only produce a change where the union changes."""
+        entries = [
+            {"start": "0 8 * * *", "end": "0 18 * * *"},
+            {"start": "0 9 * * *", "end": "0 17 * * *"},
+        ]
+        start = datetime.datetime(2024, 1, 1, 7, 0, tzinfo=datetime.timezone.utc)
+        end = datetime.datetime(2024, 1, 1, 19, 0, tzinfo=datetime.timezone.utc)
+
+        changes = schedule_state_changes(entries, "UTC", start, end)
+
+        # 09:00 and 17:00 fire but the union is unchanged there
+        assert [active for _, active in changes] == [False, True, False]
+
+    def test_changes_are_evaluated_in_the_configured_timezone(self) -> None:
+        """Cron fields are matched against the configured zone's wall clock."""
+        start = datetime.datetime(2024, 1, 1, 5, 0, tzinfo=datetime.timezone.utc)
+        end = datetime.datetime(2024, 1, 1, 19, 0, tzinfo=datetime.timezone.utc)
+
+        changes = schedule_state_changes(self.SCHEDULE, "Europe/Stockholm", start, end)
+
+        # Stockholm is UTC+1 in January
+        assert changes == [
+            (start.timestamp(), False),
+            (
+                datetime.datetime(
+                    2024, 1, 1, 7, 0, tzinfo=datetime.timezone.utc
+                ).timestamp(),
+                True,
+            ),
+            (
+                datetime.datetime(
+                    2024, 1, 1, 17, 0, tzinfo=datetime.timezone.utc
+                ).timestamp(),
+                False,
+            ),
+        ]
+
+    def test_max_changes_truncates_a_too_fine_grained_schedule(self) -> None:
+        """The walk stops once max_changes is exceeded.
+
+        A schedule that flips every minute has nothing to collapse, so callers
+        that only need to know it is unenumerable can cap the work.
+        """
+        # Active on even minutes, inactive on odd ones
+        entries = [{"start": "*/2 * * * *", "end": "1-59/2 * * * *"}]
+        start = datetime.datetime(2024, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
+        end = start + datetime.timedelta(hours=1)
+
+        assert len(schedule_state_changes(entries, "UTC", start, end)) == 61
+        assert (
+            len(schedule_state_changes(entries, "UTC", start, end, max_changes=5)) == 6
+        )
+
+    def test_matches_a_per_instant_evaluation(self) -> None:
+        """The bisected result is identical to evaluating every minute."""
+        start = datetime.datetime(2024, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
+        end = start + datetime.timedelta(days=2)
+
+        changes = schedule_state_changes(self.SCHEDULE, "UTC", start, end)
+
+        minute = start
+        while minute <= end:
+            index = max(
+                i for i, (ts, _) in enumerate(changes) if ts <= minute.timestamp()
+            )
+            assert changes[index][1] == schedule_active(self.SCHEDULE, "UTC", minute)
+            minute += datetime.timedelta(minutes=17)
+
+
+class TestResolveTimezone:
+    """Tests for resolve_timezone."""
+
+    def setup_method(self):
+        """Clear the lru_cache before each test."""
+        get_local_timezone.cache_clear()
+
+    def teardown_method(self):
+        """Clear the lru_cache after each test."""
+        get_local_timezone.cache_clear()
+
+    @pytest.mark.parametrize("configured", [UNDEFINED, None])
+    def test_unset_resolves_to_server_timezone(self, configured) -> None:
+        """An unset timezone is resolved to the server's timezone at runtime."""
+        schedule = {CONFIG_SCHEDULE_TIMEZONE: configured}
+        with patch(
+            "viseron.domains.camera.schedule.get_local_timezone",
+            return_value="Europe/Stockholm",
+        ):
+            assert resolve_timezone(schedule) == "Europe/Stockholm"
+
+    def test_missing_key_resolves_to_server_timezone(self) -> None:
+        """A schedule without the key at all still resolves."""
+        with patch(
+            "viseron.domains.camera.schedule.get_local_timezone",
+            return_value="Europe/Stockholm",
+        ):
+            assert resolve_timezone({}) == "Europe/Stockholm"
+
+    def test_explicit_timezone_is_used_verbatim(self) -> None:
+        """An explicitly configured timezone overrides the server default."""
+        schedule = {CONFIG_SCHEDULE_TIMEZONE: "America/New_York"}
+        with patch(
+            "viseron.domains.camera.schedule.get_local_timezone",
+            return_value="Europe/Stockholm",
+        ):
+            assert resolve_timezone(schedule) == "America/New_York"

--- a/tests/helpers/test__init__.py
+++ b/tests/helpers/test__init__.py
@@ -2,6 +2,8 @@
 
 from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock, patch
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import pytest
 
@@ -207,3 +209,61 @@ def test_microsecond_precision():
 
     assert time_from.microsecond == 0
     assert time_to.microsecond == 999999
+
+
+class TestGetLocalTimezone:
+    """Tests for get_local_timezone."""
+
+    def setup_method(self):
+        """Clear the lru_cache before each test."""
+        helpers.get_local_timezone.cache_clear()
+
+    def test_resolves_iana_name_via_tzlocal(self):
+        """Test that the IANA name is taken from tzlocal.get_localzone()."""
+        with patch(
+            "tzlocal.get_localzone",
+            return_value=ZoneInfo("Europe/Stockholm"),
+        ):
+            assert helpers.get_local_timezone() == "Europe/Stockholm"
+
+    def test_falls_back_to_utc_when_tz_env_is_invalid(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        """Test fallback to UTC when tzlocal can't resolve an invalid TZ env var."""
+        with patch(
+            "tzlocal.get_localzone",
+            side_effect=ZoneInfoNotFoundError("bad tz"),
+        ):
+            assert helpers.get_local_timezone() == "UTC"
+        assert "Could not determine the server's timezone" in caplog.text
+
+    def test_falls_back_to_utc_when_localtime_is_a_copied_file(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        """Test fallback to UTC when /etc/localtime is a copy, not a symlink.
+
+        tzlocal represents this case as a ZoneInfo with key "local" - a valid
+        tzinfo for offset/DST purposes, but not a real IANA name we can
+        surface to the user or feed back into the timezone config option.
+        """
+        with patch("tzlocal.get_localzone", return_value=Mock(key="local")):
+            assert helpers.get_local_timezone() == "UTC"
+        assert "Could not determine the server's timezone" in caplog.text
+
+    def test_falls_back_to_utc_when_tzlocal_returns_fixed_offset(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        """Test fallback to UTC when tzlocal's own last resort has no IANA key."""
+        with patch("tzlocal.get_localzone", return_value=timezone.utc):
+            assert helpers.get_local_timezone() == "UTC"
+        assert "Could not determine the server's timezone" in caplog.text
+
+    def test_result_is_cached(self):
+        """Test that tzlocal is only consulted once thanks to lru_cache."""
+        with patch(
+            "tzlocal.get_localzone",
+            return_value=ZoneInfo("Europe/Stockholm"),
+        ) as mock_get_localzone:
+            helpers.get_local_timezone()
+            helpers.get_local_timezone()
+        mock_get_localzone.assert_called_once()

--- a/tests/helpers/test_validators.py
+++ b/tests/helpers/test_validators.py
@@ -4,10 +4,12 @@ import pytest
 import voluptuous as vol
 
 from viseron.helpers.validators import (
+    UNDEFINED,
     CoerceNoneToDict,
     Maybe,
     Slug,
     StringKey,
+    Timezone,
 )
 
 
@@ -96,6 +98,61 @@ class TestSlug:
             validator(123)
         with pytest.raises(vol.Invalid):
             validator(None)
+
+
+class TestTimezone:
+    """Tests for the Timezone validator."""
+
+    def test_returns_value_for_valid_iana_timezone(self):
+        """Test that a valid IANA timezone name is returned unchanged."""
+        validator = Timezone()
+        assert validator("Europe/Stockholm") == "Europe/Stockholm"
+        assert validator("UTC") == "UTC"
+
+    def test_raises_for_unknown_timezone(self):
+        """Test that an unknown timezone name raises vol.Invalid."""
+        validator = Timezone()
+        with pytest.raises(vol.Invalid):
+            validator("Not/AZone")
+
+    def test_raises_for_non_string(self):
+        """Test that a non-string value raises vol.Invalid."""
+        validator = Timezone()
+        with pytest.raises(vol.Invalid):
+            validator(123)
+        with pytest.raises(vol.Invalid):
+            validator(None)
+
+    def test_passes_undefined_through_without_logging(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        """Test that the UNDEFINED sentinel is passed through untouched.
+
+        Maybe(Timezone()) runs the UNDEFINED schema default through this
+        validator before reaching the UNDEFINED branch of vol.Any. Rejecting
+        it would log a bogus error on every config load for anyone who has a
+        schedule but no explicit timezone.
+        """
+        validator = Timezone()
+        assert validator(UNDEFINED) is UNDEFINED
+        instance = UNDEFINED()
+        assert validator(instance) is instance
+        assert "Invalid timezone" not in caplog.text
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "/etc/passwd",
+            "../../etc/passwd",
+            "Europe/../Europe/Berlin",
+        ],
+    )
+    def test_raises_invalid_for_malformed_keys(self, value: str):
+        """Test that malformed zone keys raise vol.Invalid, not ValueError."""
+        validator = Timezone()
+        with pytest.raises(vol.Invalid):
+            validator(value)
 
 
 class TestMaybe:

--- a/viseron/components/nvr/nvr.py
+++ b/viseron/components/nvr/nvr.py
@@ -21,7 +21,13 @@ from viseron.components.nvr.sensor import OperationStateSensor
 from viseron.components.nvr.toggle import ManualRecordingToggle
 from viseron.components.storage.models import TriggerTypes
 from viseron.const import VISERON_SIGNAL_SHUTDOWN
-from viseron.domains.camera.const import DOMAIN as CAMERA_DOMAIN
+from viseron.domains.camera.const import (
+    CONFIG_RECORDER,
+    CONFIG_SCHEDULE,
+    CONFIG_SCHEDULE_EVENTS,
+    DOMAIN as CAMERA_DOMAIN,
+)
+from viseron.domains.camera.schedule import resolve_timezone, schedule_active
 from viseron.domains.motion_detector import AbstractMotionDetectorScanner
 from viseron.domains.motion_detector.const import (
     EVENT_MOTION_DETECTOR_RESULT,
@@ -35,6 +41,7 @@ from viseron.domains.object_detector.const import (
 from viseron.events import EventData
 from viseron.exceptions import DomainNotRegisteredError
 from viseron.helpers import utcnow
+from viseron.helpers.validators import UNDEFINED
 from viseron.viseron_types import Domain
 from viseron.watchdog.thread_watchdog import RestartableThread
 
@@ -490,6 +497,15 @@ class NVR(AbstractNVR):
                         ):
                             frame_scanner.domain_instance.result_failed_callback()
 
+    def _event_recording_scheduled(self) -> bool:
+        """Return if event recording is currently allowed by the schedule."""
+        schedule = self._camera.config[CONFIG_RECORDER][CONFIG_SCHEDULE]
+        if not schedule or schedule == UNDEFINED:
+            return True
+        return schedule_active(
+            schedule[CONFIG_SCHEDULE_EVENTS], resolve_timezone(schedule)
+        )
+
     def start_manual_recording(self, manual_recording: ManualRecording) -> None:
         """Start a manual recording with a set duration."""
         self._logger.debug(
@@ -647,6 +663,10 @@ class NVR(AbstractNVR):
         if self._camera.is_recording:
             return
 
+        # Only process objects if event recording is currently allowed
+        if not self._event_recording_scheduled():
+            return
+
         # Only process objects if we are actively scanning for objects and the last
         # scan did not return an error
         if (
@@ -704,6 +724,7 @@ class NVR(AbstractNVR):
             if (
                 self._motion_detector.trigger_event_recording
                 and not self._camera.is_recording
+                and self._event_recording_scheduled()
             ):
                 self._trigger_type = TriggerTypes.MOTION
                 self._start_recorder = True

--- a/viseron/components/storage/check_tier.py
+++ b/viseron/components/storage/check_tier.py
@@ -7,20 +7,22 @@ import logging
 import os
 import shutil
 import threading
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
-from sqlalchemy import delete, func, select
+from sqlalchemy import and_, delete, func, or_, select
 from sqlalchemy.orm import scoped_session, sessionmaker
 
 from viseron.components.storage.const import ENGINE
 from viseron.components.storage.models import Files, Recordings
 from viseron.const import CAMERA_SEGMENT_DURATION
+from viseron.domains.camera.schedule import schedule_state_changes
 from viseron.helpers import utcnow
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from sqlalchemy import ColumnElement
     from sqlalchemy.orm import Session
 
     from viseron.components.storage.storage_subprocess import (
@@ -30,6 +32,10 @@ if TYPE_CHECKING:
     )
 
 LOGGER = logging.getLogger(__name__)
+
+# Upper bound on the schedule windows the fast-path gate resolves before giving
+# up and letting the full check decide.
+MAX_SCHEDULE_CHANGES = 100
 
 FILES_DTYPE = np.dtype(
     [
@@ -76,6 +82,94 @@ class Worker:
         self._check_locks: dict[str, threading.Lock] = {}
         self._checks_in_progress: dict[str, bool] = {}
 
+    @staticmethod
+    def _tier_files_filter(item: DataItem) -> tuple[ColumnElement[bool], ...]:
+        """Return the filter selecting the files a DataItem covers."""
+        return (
+            Files.camera_identifier == item.camera_identifier,
+            Files.tier_id == item.tier_id,
+            Files.category == item.category,
+            Files.subcategory.in_(item.subcategories),
+        )
+
+    def _inactive_files_exist(
+        self,
+        session: Session,
+        item: DataItem,
+        oldest_ctime: datetime.datetime,
+        now: datetime.datetime,
+    ) -> bool:
+        """Return if the continuous schedule has anything left to evict.
+
+        Files recorded while the schedule was inactive are kept only as event
+        pre-roll, so they can go once they are older than the lookback buffer.
+
+        Age alone is not enough to ask about: a tier nearly always holds files
+        older than the lookback buffer, which would make the answer yes for
+        every camera with a schedule. The inactive windows are worked out first
+        instead, and only files falling inside one of them count.
+        """
+        cutoff = now - datetime.timedelta(
+            seconds=item.continuous_lookback_seconds + CAMERA_SEGMENT_DURATION
+        )
+        if oldest_ctime >= cutoff:
+            return False
+
+        changes = schedule_state_changes(
+            cast("list[dict[str, str]]", item.continuous_schedule),
+            item.continuous_schedule_timezone or "UTC",
+            oldest_ctime,
+            cutoff,
+            max_changes=MAX_SCHEDULE_CHANGES,
+        )
+        if len(changes) > MAX_SCHEDULE_CHANGES:
+            # Too many windows to express as one query, let the full check decide
+            return True
+
+        inactive_windows: list[tuple[datetime.datetime, datetime.datetime]] = []
+        for index, (timestamp, active) in enumerate(changes):
+            if active:
+                continue
+            inactive_windows.append(
+                (
+                    # The first change is the range start, which is oldest_ctime
+                    # itself. Use it verbatim to keep sub-second precision.
+                    oldest_ctime
+                    if index == 0
+                    else datetime.datetime.fromtimestamp(
+                        timestamp, tz=datetime.timezone.utc
+                    ),
+                    datetime.datetime.fromtimestamp(
+                        changes[index + 1][0], tz=datetime.timezone.utc
+                    )
+                    if index + 1 < len(changes)
+                    else cutoff,
+                )
+            )
+
+        if not inactive_windows:
+            return False
+
+        return (
+            session.execute(
+                select(Files.id)
+                .where(
+                    *self._tier_files_filter(item),
+                    or_(
+                        *[
+                            and_(
+                                Files.orig_ctime >= window_start,
+                                Files.orig_ctime < window_end,
+                            )
+                            for window_start, window_end in inactive_windows
+                        ]
+                    ),
+                )
+                .limit(1)
+            ).first()
+            is not None
+        )
+
     def _should_check_tier_files(self, item: DataItem) -> bool:
         """Quick aggregate check if tier actually needs processing.
 
@@ -88,10 +182,7 @@ class Worker:
         with self._get_session() as session:
             result = session.execute(
                 select(func.sum(Files.size), func.min(Files.orig_ctime)).where(
-                    Files.camera_identifier == item.camera_identifier,
-                    Files.tier_id == item.tier_id,
-                    Files.category == item.category,
-                    Files.subcategory.in_(item.subcategories),
+                    *self._tier_files_filter(item)
                 )
             ).first()
 
@@ -104,10 +195,15 @@ class Worker:
 
             if item.max_bytes > 0 and total_size >= item.max_bytes:
                 return True
-            if (  # noqa: SIM103
+            if (
                 item.max_age.total_seconds() > 0
                 and total_size >= item.min_bytes
                 and oldest_ctime < now - item.max_age
+            ):
+                return True
+            if (  # noqa: SIM103
+                item.continuous_schedule is not None
+                and self._inactive_files_exist(session, item, oldest_ctime, now)
             ):
                 return True
 
@@ -305,6 +401,12 @@ class Worker:
         else:
             max_age_timestamp = 0
 
+        # We want to ignore files that are less than 5 times the
+        # segment duration old. This is to improve HLS streaming
+        file_min_age = (
+            now - datetime.timedelta(seconds=CAMERA_SEGMENT_DURATION * 5)
+        ).timestamp()
+
         LOGGER.debug(
             "Files to move parameters: "
             "camera_identifier(%s), tier_id(%s), category(%s), subcategories(%s), "
@@ -320,13 +422,18 @@ class Worker:
             max_age_timestamp,
         )
 
-        return get_files_to_move(
-            data,
-            item.max_bytes,
-            min_age_timestamp,
-            item.min_bytes,
-            max_age_timestamp,
-            item.drain,
+        return get_continuous_files_to_move(
+            data=data,
+            max_bytes=item.max_bytes,
+            min_age_timestamp=min_age_timestamp,
+            min_bytes=item.min_bytes,
+            max_age_timestamp=max_age_timestamp,
+            file_min_age_timestamp=file_min_age,
+            drain=item.drain,
+            now=now,
+            schedule_entries=item.continuous_schedule,
+            timezone=item.continuous_schedule_timezone,
+            lookback_seconds=item.continuous_lookback_seconds,
         )
 
     def check_tier_recordings(
@@ -476,6 +583,7 @@ def get_files_to_move(
     min_age_timestamp: float,
     min_bytes: int,
     max_age_timestamp: float,
+    file_min_age_timestamp: float,
     drain: bool,
 ):
     """Get id of files to move.
@@ -485,6 +593,11 @@ def get_files_to_move(
     2. np.cumsum is used to calculate the cumulative sum of the sizes.
     3. Any rows where the cumulative size exceeds the tier size are marked
         for moving to the next tier.
+    4. file_min_age_timestamp is applied as a hard floor on the selected files,
+        the same way get_recordings_to_move does it. min_age_timestamp only
+        gates the bytes branch, so this is what keeps files that are still
+        being written to from being moved by the age branch. Like
+        get_recordings_to_move, drain bypasses it.
     """
     # Sort by timestamp
     sorted_indices = np.argsort(data["orig_ctime"])
@@ -519,8 +632,89 @@ def get_files_to_move(
         if indices_to_move.size > 0:
             rows_to_move = data[indices_to_move]
 
+        rows_to_move = rows_to_move[
+            rows_to_move["orig_ctime"] <= file_min_age_timestamp
+        ]
+
     stripped_rows = rows_to_move[["id", "path", "tier_path"]]
     return stripped_rows[::-1]
+
+
+def get_continuous_files_to_move(
+    *,
+    data: np.ndarray,
+    max_bytes: int,
+    min_age_timestamp: float,
+    min_bytes: int,
+    max_age_timestamp: float,
+    file_min_age_timestamp: float,
+    drain: bool,
+    now: datetime.datetime,
+    schedule_entries: list[dict[str, str]] | None,
+    timezone: str | None,
+    lookback_seconds: int,
+) -> np.ndarray:
+    """Get id of continuous files to move, aware of an optional recording schedule.
+
+    Without a schedule this is identical to get_files_to_move. With a schedule,
+    each file's own orig_ctime decides whether continuous recording was active
+    when it was written:
+    - Files written while active keep the full configured retention
+      (max_bytes/max_age/etc), exactly as if there were no schedule.
+    - Files written while inactive are capped to the lookback buffer, so they
+      age out once no longer needed as event pre-roll instead of accumulating
+      for the full retention window.
+    """
+    if schedule_entries is None or data.size == 0:
+        return get_files_to_move(
+            data=data,
+            max_bytes=max_bytes,
+            min_age_timestamp=min_age_timestamp,
+            min_bytes=min_bytes,
+            max_age_timestamp=max_age_timestamp,
+            file_min_age_timestamp=file_min_age_timestamp,
+            drain=drain,
+        )
+
+    # Evaluating the schedule per file parses two cron expressions per entry,
+    # which does not scale to the thousands of rows a tier holds. The state only
+    # flips where a cron fires, so the range the files span is resolved once and
+    # each file is bisected into it.
+    ctimes = data["orig_ctime"]
+    changes = schedule_state_changes(
+        schedule_entries,
+        cast("str", timezone),
+        datetime.datetime.fromtimestamp(int(ctimes.min()), tz=datetime.timezone.utc),
+        datetime.datetime.fromtimestamp(int(ctimes.max()), tz=datetime.timezone.utc),
+    )
+    boundaries = np.array([timestamp for timestamp, _ in changes])
+    states = np.array([active for _, active in changes], dtype=bool)
+    active_mask = states[np.searchsorted(boundaries, ctimes, side="right") - 1]
+
+    active_rows = get_files_to_move(
+        data=data[active_mask],
+        max_bytes=max_bytes,
+        min_age_timestamp=min_age_timestamp,
+        min_bytes=min_bytes,
+        max_age_timestamp=max_age_timestamp,
+        file_min_age_timestamp=file_min_age_timestamp,
+        drain=drain,
+    )
+
+    inactive_max_age_timestamp = (
+        now - datetime.timedelta(seconds=lookback_seconds + CAMERA_SEGMENT_DURATION)
+    ).timestamp()
+    inactive_rows = get_files_to_move(
+        data=data[~active_mask],
+        max_bytes=0,
+        min_age_timestamp=0,
+        min_bytes=0,
+        max_age_timestamp=inactive_max_age_timestamp,
+        file_min_age_timestamp=file_min_age_timestamp,
+        drain=False,
+    )
+
+    return np.concatenate((active_rows, inactive_rows))
 
 
 def get_recordings_to_move(

--- a/viseron/components/storage/storage_subprocess.py
+++ b/viseron/components/storage/storage_subprocess.py
@@ -63,6 +63,9 @@ class DataItem:
     events_min_age: datetime.timedelta | None = None
     events_max_age: datetime.timedelta | None = None
     events_min_bytes: int | None = None
+    continuous_schedule: list[dict[str, str]] | None = None
+    continuous_schedule_timezone: str | None = None
+    continuous_lookback_seconds: int = 0
     callback_id: str | None = None
     data: np.ndarray | None = None
     error: str | None = None

--- a/viseron/components/storage/tier_handler.py
+++ b/viseron/components/storage/tier_handler.py
@@ -85,10 +85,14 @@ from viseron.domains.camera.const import (
     CONFIG_CONTINUOUS_RECORDING,
     CONFIG_RECORDER,
     CONFIG_RETAIN,
+    CONFIG_SCHEDULE,
+    CONFIG_SCHEDULE_CONTINUOUS,
 )
+from viseron.domains.camera.schedule import resolve_timezone
 from viseron.events import Event, EventEmptyData
 from viseron.helpers import utcnow
 from viseron.helpers.named_timer import NamedTimer
+from viseron.helpers.validators import UNDEFINED
 from viseron.watchdog.thread_watchdog import RestartableThread
 
 if TYPE_CHECKING:
@@ -576,7 +580,7 @@ class SegmentsTierHandler(TierHandler):
         ]
 
         self._events_enabled = any(self._events_params)
-        self._continuous_enabled = (
+        self._continuous_configured = (
             any(self._continuous_params)
             and self._camera.config[CONFIG_RECORDER][CONFIG_CONTINUOUS_RECORDING]
         )
@@ -596,6 +600,31 @@ class SegmentsTierHandler(TierHandler):
         self.add_file_handler(self._path, rf"{self._path}/(.*.m4s$)")
         self.add_file_handler(self._path, rf"{self._path}/(.*.mp4$)")
 
+    def _continuous_schedule_entries(self) -> list[dict[str, str]] | None:
+        """Return the configured continuous-recording schedule entries, if any.
+
+        None means continuous recording is unrestricted by a schedule (either
+        no schedule is configured, or the schedule doesn't restrict
+        continuous).
+        """
+        schedule = self._camera.config[CONFIG_RECORDER][CONFIG_SCHEDULE]
+        if not schedule or schedule == UNDEFINED:
+            return None
+        entries = schedule[CONFIG_SCHEDULE_CONTINUOUS]
+        if not entries or entries == UNDEFINED:
+            return None
+        return entries
+
+    def _continuous_schedule_timezone(self) -> str | None:
+        """Return the timezone the continuous-recording schedule is evaluated in.
+
+        None when there is no continuous schedule to evaluate.
+        """
+        if self._continuous_schedule_entries() is None:
+            return None
+        schedule = self._camera.config[CONFIG_RECORDER][CONFIG_SCHEDULE]
+        return resolve_timezone(schedule)
+
     def _create_dataitem(self) -> DataItem:
         """Create a DataItem for the check tier command."""
         return DataItem(
@@ -609,7 +638,7 @@ class SegmentsTierHandler(TierHandler):
                 TIER_SUBCATEGORY_EVENT_CLIPS,
             ],
             throttle_period=self._throttle_period,
-            files_enabled=self._continuous_enabled,
+            files_enabled=self._continuous_configured,
             max_bytes=self._continuous_max_bytes,
             min_age=max(
                 self._continuous_min_age,
@@ -623,6 +652,9 @@ class SegmentsTierHandler(TierHandler):
             events_min_age=self._events_min_age,
             events_max_age=self._events_max_age,
             events_min_bytes=self._events_min_bytes,
+            continuous_schedule=self._continuous_schedule_entries(),
+            continuous_schedule_timezone=self._continuous_schedule_timezone(),
+            continuous_lookback_seconds=self._camera.recorder.lookback,
         )
 
     @property
@@ -633,7 +665,7 @@ class SegmentsTierHandler(TierHandler):
     @property
     def continuous_enabled(self) -> bool:
         """Return if continuous is enabled."""
-        return self._continuous_enabled
+        return self._continuous_configured
 
     def _handle_events(
         self,
@@ -772,12 +804,12 @@ class SegmentsTierHandler(TierHandler):
     def _check_tier(self, get_session: Callable[[], Session], data: np.ndarray) -> None:
         events_next_tier = None
         recording_ids: list[int] = []
-        if self._events_enabled and not self._continuous_enabled:
+        if self._events_enabled and not self.continuous_enabled:
             events_next_tier = find_next_tier_segments(
                 self._storage, self._tier_id, self._camera, "events"
             )
             recording_ids = self._handle_events(get_session, data, events_next_tier)
-        elif self._continuous_enabled and not self._events_enabled:
+        elif self.continuous_enabled and not self._events_enabled:
             continuous_next_tier = find_next_tier_segments(
                 self._storage, self._tier_id, self._camera, "continuous"
             )

--- a/viseron/components/webserver/__init__.py
+++ b/viseron/components/webserver/__init__.py
@@ -18,7 +18,7 @@ from viseron.components.webserver.auth import Auth
 from viseron.components.webserver.rate_limit import RateLimiter
 from viseron.const import DEFAULT_PORT, VISERON_SIGNAL_SHUTDOWN
 from viseron.exceptions import ComponentNotReady
-from viseron.helpers import current_system_datetime, normalize_subpath
+from viseron.helpers import normalize_subpath, utcnow
 from viseron.helpers.storage import Storage
 from viseron.helpers.validators import CoerceNoneToDict, Deprecated
 
@@ -374,7 +374,7 @@ class Webserver(threading.Thread):
     def _cleanup_expired_public_images(self) -> None:
         """Clean up expired public images (files older than max expiry)."""
         try:
-            timestamp_limit = current_system_datetime().timestamp() - (
+            timestamp_limit = utcnow().timestamp() - (
                 self.public_url_expiry_hours * 3600
             )
             cleaned_count = 0

--- a/viseron/domains/camera/config.py
+++ b/viseron/domains/camera/config.py
@@ -1,4 +1,5 @@
 """Camera domain config."""
+
 import voluptuous as vol
 
 from viseron.components.storage.config import (
@@ -17,9 +18,11 @@ from viseron.components.storage.const import (
 from viseron.helpers.validators import (
     UNDEFINED,
     CoerceNoneToDict,
+    CronExpression,
     Deprecated,
     Maybe,
     Slug,
+    Timezone,
 )
 
 from .const import (
@@ -51,6 +54,12 @@ from .const import (
     CONFIG_REFRESH_INTERVAL,
     CONFIG_RETAIN,
     CONFIG_SAVE_TO_DISK,
+    CONFIG_SCHEDULE,
+    CONFIG_SCHEDULE_CONTINUOUS,
+    CONFIG_SCHEDULE_END,
+    CONFIG_SCHEDULE_EVENTS,
+    CONFIG_SCHEDULE_START,
+    CONFIG_SCHEDULE_TIMEZONE,
     CONFIG_STILL_IMAGE,
     CONFIG_STILL_IMAGE_HEIGHT,
     CONFIG_STILL_IMAGE_WIDTH,
@@ -122,6 +131,12 @@ from .const import (
     DESC_REFRESH_INTERVAL,
     DESC_RETAIN,
     DESC_SAVE_TO_DISK,
+    DESC_SCHEDULE,
+    DESC_SCHEDULE_CONTINUOUS,
+    DESC_SCHEDULE_END,
+    DESC_SCHEDULE_EVENTS,
+    DESC_SCHEDULE_START,
+    DESC_SCHEDULE_TIMEZONE,
     DESC_STILL_IMAGE,
     DESC_STILL_IMAGE_HEIGHT,
     DESC_STILL_IMAGE_WIDTH,
@@ -209,6 +224,37 @@ THUMBNAIL_SCHEMA = vol.Schema(
 )
 
 
+SCHEDULE_ENTRY_SCHEMA = vol.Schema(
+    {
+        vol.Required(
+            CONFIG_SCHEDULE_START, description=DESC_SCHEDULE_START
+        ): CronExpression(),
+        vol.Required(
+            CONFIG_SCHEDULE_END, description=DESC_SCHEDULE_END
+        ): CronExpression(),
+    }
+)
+
+RECORDING_SCHEDULE_SCHEMA = vol.Schema(
+    {
+        vol.Optional(
+            CONFIG_SCHEDULE_EVENTS,
+            default=UNDEFINED,
+            description=DESC_SCHEDULE_EVENTS,
+        ): Maybe([SCHEDULE_ENTRY_SCHEMA]),
+        vol.Optional(
+            CONFIG_SCHEDULE_CONTINUOUS,
+            default=UNDEFINED,
+            description=DESC_SCHEDULE_CONTINUOUS,
+        ): Maybe([SCHEDULE_ENTRY_SCHEMA]),
+        vol.Optional(
+            CONFIG_SCHEDULE_TIMEZONE,
+            default=UNDEFINED,
+            description=DESC_SCHEDULE_TIMEZONE,
+        ): Maybe(Timezone()),
+    }
+)
+
 RECORDER_SCHEMA = vol.Schema(
     {
         vol.Optional(
@@ -270,6 +316,11 @@ RECORDER_SCHEMA = vol.Schema(
             default=DEFAULT_CONTINUOUS_RECORDING,
             description=DESC_CONTINUOUS_RECORDING,
         ): bool,
+        vol.Optional(
+            CONFIG_SCHEDULE,
+            default=UNDEFINED,
+            description=DESC_SCHEDULE,
+        ): Maybe(RECORDING_SCHEDULE_SCHEMA),
     }
 )
 

--- a/viseron/domains/camera/const.py
+++ b/viseron/domains/camera/const.py
@@ -97,6 +97,12 @@ CONFIG_THUMBNAIL = "thumbnail"
 CONFIG_CREATE_EVENT_CLIP: Final = "create_event_clip"
 CONFIG_CONTINUOUS_RECORDING: Final = "continuous_recording"
 CONFIG_STORAGE = "storage"
+CONFIG_SCHEDULE: Final = "schedule"
+CONFIG_SCHEDULE_EVENTS: Final = "events"
+CONFIG_SCHEDULE_CONTINUOUS: Final = "continuous"
+CONFIG_SCHEDULE_START: Final = "start"
+CONFIG_SCHEDULE_END: Final = "end"
+CONFIG_SCHEDULE_TIMEZONE: Final = "timezone"
 
 DEFAULT_LOOKBACK = 5
 DEFAULT_IDLE_TIMEOUT = 10
@@ -167,6 +173,33 @@ DESC_CONTINUOUS_RECORDING = (
     "Enable continuous (24/7) recording. Has to be used in combination with "
     "<code>continuous</code>, <code>storage > tiers > continuous</code> or the "
     "<a href=/components-explorer/components/storage>storage component</a>."
+)
+DESC_SCHEDULE = (
+    "Restrict event and/or continuous recording to specific times of day. "
+    "If omitted, recording is not restricted by a schedule."
+)
+DESC_SCHEDULE_EVENTS = (
+    "Schedule for event recordings. If omitted, event recording is allowed at any time."
+)
+DESC_SCHEDULE_CONTINUOUS = (
+    "Schedule for continuous recording. If omitted, continuous recording "
+    "(when <code>continuous_recording</code> is enabled) is allowed at any time."
+)
+DESC_SCHEDULE_START = (
+    "A <a href=https://en.wikipedia.org/wiki/Cron>cron expression</a> for when "
+    "this schedule entry starts, e.g. <code>0 8 * * mon-fri</code> for 08:00 "
+    "on weekdays."
+)
+DESC_SCHEDULE_END = (
+    "A <a href=https://en.wikipedia.org/wiki/Cron>cron expression</a> for when "
+    "this schedule entry ends. Can occur 'before' <code>start</code> in the day "
+    "to span midnight, e.g. <code>start: 0 22 * * *</code>, "
+    "<code>end: 0 6 * * *</code>."
+)
+DESC_SCHEDULE_TIMEZONE = (
+    "An <a href=https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>"
+    "IANA timezone</a> (e.g. <code>Europe/Stockholm</code>) used to evaluate "
+    "the schedule's cron expressions. Defaults to the server's own timezone."
 )
 
 # STILL_IMAGE_SCHEMA constants

--- a/viseron/domains/camera/recorder.py
+++ b/viseron/domains/camera/recorder.py
@@ -7,24 +7,22 @@ import logging
 import os
 import shutil
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from time import sleep
 from typing import TYPE_CHECKING, Any, TypedDict
 
 import cv2
-import numpy as np
 from sqlalchemy import delete, func, insert, select, update
-from sqlalchemy.orm import Session
 
 from viseron.components.storage.const import COMPONENT as STORAGE_COMPONENT
 from viseron.components.storage.models import Recordings
 from viseron.components.storage.queries import get_recording_fragments
 from viseron.const import CAMERA_SEGMENT_DURATION
 from viseron.domains.camera.fragmenter import Fragment
-from viseron.domains.object_detector.detected_object import DetectedObject
+from viseron.domains.camera.schedule import resolve_timezone
 from viseron.events import EventData
 from viseron.helpers import create_directory, draw_objects, get_utc_offset, utcnow
+from viseron.helpers.validators import UNDEFINED
 from viseron.watchdog.thread_watchdog import RestartableThread
 
 from .const import (
@@ -35,6 +33,7 @@ from .const import (
     CONFIG_MAX_RECORDING_TIME,
     CONFIG_RECORDER,
     CONFIG_SAVE_TO_DISK,
+    CONFIG_SCHEDULE,
     CONFIG_THUMBNAIL,
     DEFAULT_LOOKBACK,
     DOMAIN,
@@ -44,12 +43,19 @@ from .const import (
 )
 from .entity.binary_sensor import RecorderBinarySensor
 from .entity.image import ThumbnailImage
-from .shared_frames import SharedFrame
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    import numpy as np
+    from sqlalchemy.orm import Session
+
     from viseron import Viseron
     from viseron.components.storage.models import TriggerTypes
     from viseron.domains.camera import AbstractCamera, FailedCamera
+    from viseron.domains.object_detector.detected_object import DetectedObject
+
+    from .shared_frames import SharedFrame
 
 
 class RecordingDict(TypedDict):
@@ -141,6 +147,14 @@ class RecorderBase:
         self._camera = camera
 
         self._storage = vis.data[STORAGE_COMPONENT]
+
+        schedule = config.get(CONFIG_RECORDER, {}).get(CONFIG_SCHEDULE)
+        if schedule and schedule != UNDEFINED:
+            self._logger.info(
+                "Recording schedule is configured, evaluating cron "
+                "expressions using timezone: %s",
+                resolve_timezone(schedule),
+            )
 
     def get_recordings(
         self, utc_offset: datetime.timedelta, date=None, subpath: str = ""

--- a/viseron/domains/camera/schedule.py
+++ b/viseron/domains/camera/schedule.py
@@ -1,0 +1,140 @@
+"""Recording schedule evaluation."""
+
+from __future__ import annotations
+
+import datetime
+import functools
+from typing import Any, cast
+from zoneinfo import ZoneInfo
+
+from croniter import croniter
+
+from viseron.helpers import get_local_timezone, utcnow
+from viseron.helpers.validators import UNDEFINED
+
+from .const import (
+    CONFIG_SCHEDULE_END,
+    CONFIG_SCHEDULE_START,
+    CONFIG_SCHEDULE_TIMEZONE,
+)
+
+# Each schedule entry as the (start, end) pair of cron expressions, which is all
+# that is needed to evaluate it and is hashable so it can key the cache.
+ScheduleKey = tuple[tuple[str, str], ...]
+
+
+def _entry_active(entry: tuple[str, str], now: datetime.datetime) -> bool:
+    """Return if a single schedule entry is currently active.
+
+    croniter.get_prev() is exclusive, so `now` is nudged by one second to make it
+    inclusive.
+    """
+    start_expression, end_expression = entry
+    inclusive_now = now + datetime.timedelta(seconds=1)
+    start_prev = croniter(start_expression, inclusive_now).get_prev(datetime.datetime)
+    end_prev = croniter(end_expression, inclusive_now).get_prev(datetime.datetime)
+    return start_prev > end_prev
+
+
+def _schedule_key(entries: list[dict[str, Any]]) -> ScheduleKey:
+    """Return the hashable cache key for a list of schedule entries."""
+    return tuple(
+        (entry[CONFIG_SCHEDULE_START], entry[CONFIG_SCHEDULE_END]) for entry in entries
+    )
+
+
+@functools.lru_cache(maxsize=256)
+def _schedule_active_at_minute(
+    entries: ScheduleKey, timezone: str, minute: int
+) -> bool:
+    """Return if the schedule is active during the given minute of the epoch.
+
+    Cron says nothing finer than a minute, so every instant within the same
+    minute has the same answer and only the first one has to be computed. That
+    matters because the NVR asks per frame, and each miss parses two cron
+    expressions per entry.
+
+    The cron expressions and the timezone are part of the cache key, so a
+    reloaded config never reads a stale answer.
+    """
+    now = datetime.datetime.fromtimestamp(
+        minute * 60, tz=datetime.timezone.utc
+    ).astimezone(ZoneInfo(timezone))
+    return any(_entry_active(entry, now) for entry in entries)
+
+
+def resolve_timezone(schedule: dict[str, Any]) -> str:
+    """Return the timezone a schedule's cron expressions are evaluated in."""
+    timezone = schedule.get(CONFIG_SCHEDULE_TIMEZONE)
+    if not timezone or timezone is UNDEFINED:
+        return get_local_timezone()
+    return cast("str", timezone)
+
+
+def schedule_active(
+    entries: list[dict[str, Any]] | None | type[UNDEFINED],
+    timezone: str,
+    now: datetime.datetime | None = None,
+) -> bool:
+    """Return if recording should be active according to the schedule.
+
+    A None/UNDEFINED/empty list of entries means there is no restriction, so
+    recording is always considered active.
+
+    `now` is converted to `timezone` before evaluation, so cron fields are
+    matched against that zone's wall-clock time (DST-aware) rather than UTC.
+    """
+    if not entries or entries == UNDEFINED:
+        return True
+    resolved_entries = cast("list[dict[str, Any]]", entries)
+
+    now = now or utcnow()
+    return _schedule_active_at_minute(
+        _schedule_key(resolved_entries), timezone, int(now.timestamp()) // 60
+    )
+
+
+def schedule_state_changes(
+    entries: list[dict[str, Any]],
+    timezone: str,
+    start: datetime.datetime,
+    end: datetime.datetime,
+    max_changes: int | None = None,
+) -> list[tuple[float, bool]]:
+    """Return when the schedule turns on and off between start and end.
+
+    The first pair is `start` and the state at `start`, and every pair after it
+    is a point where the state flips, so an 08:00-18:00 schedule over one day
+    reads as [(00:00, False), (08:00, True), (18:00, False)]. Bisect on the
+    timestamps to resolve any instant in the range.
+
+    A schedule can only flip when one of its cron expressions fires, so this
+    costs a handful of evaluations no matter how many instants are looked up.
+
+    `max_changes` stops the walk early, for callers that only need to know the
+    schedule is too fine-grained to enumerate. The returned list is longer than
+    `max_changes` when that happened.
+    """
+    zone = ZoneInfo(timezone)
+    start = start.astimezone(zone)
+    end = end.astimezone(zone)
+
+    firings: set[float] = set()
+    for entry in _schedule_key(entries):
+        for expression in entry:
+            iterator = croniter(expression, start)
+            while (firing := iterator.get_next(datetime.datetime)) <= end:
+                firings.add(firing.timestamp())
+
+    changes = [(start.timestamp(), schedule_active(entries, timezone, start))]
+    for timestamp in sorted(firings):
+        active = schedule_active(
+            entries,
+            timezone,
+            datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc),
+        )
+        if active is not changes[-1][1]:
+            changes.append((timestamp, active))
+            if max_changes is not None and len(changes) > max_changes:
+                break
+    return changes

--- a/viseron/helpers/__init__.py
+++ b/viseron/helpers/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import functools
 import inspect
 import linecache
 import logging
@@ -17,6 +18,7 @@ import tracemalloc
 import urllib.parse
 from queue import Empty, Full, Queue
 from typing import TYPE_CHECKING, Any, Literal, overload
+from zoneinfo import ZoneInfoNotFoundError
 
 import cv2
 import numpy as np
@@ -24,6 +26,7 @@ import psutil
 import slugify as unicode_slug
 import supervision as sv
 import tornado.queues as tq
+import tzlocal
 
 from viseron.const import (
     FONT,
@@ -52,6 +55,23 @@ def get_utc_offset() -> datetime.timedelta:
     return datetime.timedelta(seconds=time.localtime().tm_gmtoff)
 
 
+@functools.lru_cache(maxsize=1)
+def get_local_timezone() -> str:
+    """Return the server's IANA timezone name, detected via tzlocal."""
+    try:
+        name = getattr(tzlocal.get_localzone(), "key", None)
+    except ZoneInfoNotFoundError:
+        name = None
+
+    if not name or name == "local":
+        LOGGER.warning(
+            "Could not determine the server's timezone, defaulting to UTC. "
+            "Set recorder.schedule.timezone explicitly to override."
+        )
+        return "UTC"
+    return name
+
+
 def daterange_to_utc(
     date: str, utc_offset: datetime.timedelta
 ) -> tuple[datetime.datetime, datetime.datetime]:
@@ -75,11 +95,6 @@ def daterange_to_utc(
 def client_current_datetime(utc_offset: datetime.timedelta) -> datetime.datetime:
     """Return the current datetime adjusted to the clients timezone."""
     return utcnow() + utc_offset
-
-
-def current_system_datetime() -> datetime.datetime:
-    """Return the current system datetime."""
-    return datetime.datetime.now()
 
 
 def calculate_relative_contours(

--- a/viseron/helpers/validators.py
+++ b/viseron/helpers/validators.py
@@ -3,8 +3,10 @@
 import logging
 from collections.abc import Callable
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import voluptuous as vol
+from croniter import croniter
 from jinja2 import BaseLoader, Environment
 
 from viseron.helpers import slugify
@@ -309,6 +311,53 @@ class PathExists:
         return self.path_exists_validator(
             value,
         )
+
+
+class CronExpression:
+    """Validate value is a valid cron expression."""
+
+    def __init__(
+        self,
+        description: str = "A cron expression, e.g. <code>0 8 * * mon-fri</code>.",
+    ) -> None:
+        self.description = description
+
+    def __call__(self, value: Any) -> str:
+        """Validate cron expression."""
+        if not isinstance(value, str) or not croniter.is_valid(value):
+            msg = f"Invalid cron expression: {value}"
+            LOGGER.error(msg)
+            raise vol.Invalid(msg)
+        return value
+
+
+class Timezone:
+    """Validate value is a valid IANA timezone name."""
+
+    def __init__(
+        self,
+        description: str = "An IANA timezone name, e.g. <code>Europe/Stockholm</code>.",
+    ) -> None:
+        self.description = description
+
+    def __call__(self, value: Any) -> Any:
+        """Validate timezone name."""
+        if value is UNDEFINED or isinstance(value, UNDEFINED):
+            return value
+
+        if not isinstance(value, str):
+            msg = f"Invalid timezone: {value}"
+            LOGGER.error(msg)
+            raise vol.Invalid(msg)
+        try:
+            ZoneInfo(value)
+        except (ZoneInfoNotFoundError, ValueError) as error:
+            # ZoneInfo raises ZoneInfoNotFoundError for unknown zones, but a
+            # plain ValueError for empty, absolute or non-normalized keys.
+            msg = f"Invalid timezone: {value}"
+            LOGGER.error(msg)
+            raise vol.Invalid(msg) from error
+        return value
 
 
 def request_argument_bool(value):


### PR DESCRIPTION
This PR allows users to configure a schedule per camera for when to allow continuous/event recordings.

Closes #1155 