### PR TITLE
feat(face_recognition): add latest recognized face image entity

### DIFF
--- a/tests/domains/face_recognition/__init__.py
+++ b/tests/domains/face_recognition/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the face_recognition domain."""

--- a/tests/domains/face_recognition/test__init__.py
+++ b/tests/domains/face_recognition/test__init__.py
@@ -41,6 +41,10 @@ COORDINATES = (0, 0, 10, 10)
 class ConcreteFaceRecognition(AbstractFaceRecognition):
     """Concrete implementation for testing AbstractFaceRecognition."""
 
+    def preprocess(self, frame: np.ndarray) -> np.ndarray:
+        """Return the frame unchanged."""
+        return frame
+
     def face_recognition(
         self, post_processor_frame: PostProcessorFrame, detected_object
     ) -> None:

--- a/tests/domains/face_recognition/test__init__.py
+++ b/tests/domains/face_recognition/test__init__.py
@@ -1,0 +1,195 @@
+"""Tests for AbstractFaceRecognition and the LatestFaceImage entity."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from viseron.domains.camera.shared_frames import SharedFrame
+from viseron.domains.face_recognition import AbstractFaceRecognition, EventFaceDetected
+from viseron.domains.face_recognition.const import (
+    CONFIG_EXPIRE_AFTER,
+    CONFIG_SAVE_FACES,
+    CONFIG_SAVE_UNKNOWN_FACES,
+)
+from viseron.domains.face_recognition.image import LatestFaceImage
+from viseron.domains.post_processor.const import (
+    CONFIG_CAMERAS,
+    CONFIG_LABELS,
+    CONFIG_MASK,
+)
+
+from tests.common import MockCamera, MockComponent
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from viseron.domains.post_processor import PostProcessorFrame
+
+    from tests.conftest import MockViseron
+
+
+CAMERA_IDENTIFIER = "test_camera"
+COMPONENT = "test_face_recognition"
+SNAPSHOT_PATH = "/snapshots/face_recognition/test.jpg"
+COORDINATES = (0, 0, 10, 10)
+
+
+class ConcreteFaceRecognition(AbstractFaceRecognition):
+    """Concrete implementation for testing AbstractFaceRecognition."""
+
+    def face_recognition(
+        self, post_processor_frame: PostProcessorFrame, detected_object
+    ) -> None:
+        """Not exercised directly in these tests."""
+
+
+@pytest.fixture(autouse=True)
+def patch_restartable_thread() -> Iterator[MagicMock]:
+    """Patch RestartableThread so no live thread is spawned by the constructor."""
+    with patch(
+        "viseron.domains.post_processor.RestartableThread", autospec=True
+    ) as mock_thread_cls:
+        mock_thread_cls.return_value = MagicMock()
+        yield mock_thread_cls
+
+
+@pytest.fixture(name="mock_camera")
+def fixture_mock_camera(vis: MockViseron) -> MockCamera:
+    """Return a registered mock camera with mocked snapshots and frames."""
+    camera = MockCamera(vis, identifier=CAMERA_IDENTIFIER)
+    camera.save_snapshot.return_value = SNAPSHOT_PATH
+    camera.shared_frames.get_decoded_frame_rgb.return_value = np.zeros(
+        (10, 10, 3), dtype=np.uint8
+    )
+    return camera
+
+
+@pytest.fixture(name="face_recognition_processor")
+def fixture_face_recognition_processor(
+    vis: MockViseron,
+    mock_camera: MockCamera,  # noqa: ARG001  # pylint: disable=unused-argument
+) -> ConcreteFaceRecognition:
+    """Return a face recognition post processor with a registered camera."""
+    MockComponent(vis, COMPONENT)
+    config = {
+        CONFIG_CAMERAS: {CAMERA_IDENTIFIER: {CONFIG_MASK: [], CONFIG_LABELS: []}},
+        CONFIG_EXPIRE_AFTER: 9999,
+        CONFIG_SAVE_FACES: True,
+        CONFIG_SAVE_UNKNOWN_FACES: True,
+    }
+    # Entity generation lists the face folders on disk, which isn't relevant here.
+    return ConcreteFaceRecognition(
+        vis, COMPONENT, config, CAMERA_IDENTIFIER, generate_entities=False
+    )
+
+
+@pytest.fixture(name="mock_shared_frame")
+def fixture_mock_shared_frame() -> SharedFrame:
+    """Return a mock SharedFrame."""
+    shared_frame = MagicMock(spec=SharedFrame)
+    shared_frame.camera_identifier = CAMERA_IDENTIFIER
+    return shared_frame
+
+
+def _dispatched_face_events(vis: MockViseron) -> list[EventFaceDetected]:
+    """Return the EventFaceDetected payloads dispatched so far.
+
+    _save_face() also dispatches a DB-operation event via _insert_result(), on
+    the same mocked dispatch_event, so this filters those out by type rather
+    than assuming call order/count.
+    """
+    return [
+        call.args[1]
+        for call in vis.dispatch_event.call_args_list
+        if isinstance(call.args[1], EventFaceDetected)
+    ]
+
+
+class TestAbstractFaceRecognitionLatestImage:
+    """Test that face detected events only carry an image on first appearance."""
+
+    def test_known_face_includes_image_only_on_first_appearance(
+        self,
+        face_recognition_processor: ConcreteFaceRecognition,
+        vis: MockViseron,
+        mock_shared_frame: SharedFrame,
+    ) -> None:
+        """Repeated detections of an already-tracked face shouldn't re-crop."""
+        face_recognition_processor.known_face_found(
+            "alice", COORDINATES, mock_shared_frame
+        )
+        face_recognition_processor.known_face_found(
+            "alice", COORDINATES, mock_shared_frame
+        )
+
+        events = _dispatched_face_events(vis)
+        assert len(events) == 2
+        assert events[0].image is not None
+        assert events[1].image is None
+
+    def test_unknown_face_includes_image_only_on_first_appearance(
+        self,
+        face_recognition_processor: ConcreteFaceRecognition,
+        vis: MockViseron,
+        mock_shared_frame: SharedFrame,
+    ) -> None:
+        """Repeated unknown-face detections shouldn't re-crop either."""
+        face_recognition_processor.unknown_face_found(COORDINATES, mock_shared_frame)
+        face_recognition_processor.unknown_face_found(COORDINATES, mock_shared_frame)
+
+        events = _dispatched_face_events(vis)
+        assert len(events) == 2
+        assert events[0].image is not None
+        assert events[1].image is None
+
+    def test_known_face_without_shared_frame_has_no_image(
+        self,
+        face_recognition_processor: ConcreteFaceRecognition,
+        vis: MockViseron,
+    ) -> None:
+        """No shared frame means no image, even on first appearance."""
+        face_recognition_processor.known_face_found("alice", COORDINATES, None)
+
+        events = _dispatched_face_events(vis)
+        assert len(events) == 1
+        assert events[0].image is None
+
+
+class TestLatestFaceImage:
+    """Test the LatestFaceImage entity."""
+
+    def test_handle_event_ignores_events_without_image(
+        self, vis: MockViseron, mock_camera: MockCamera
+    ) -> None:
+        """The entity should be left untouched when there's no fresh image."""
+        entity = LatestFaceImage(vis, mock_camera)
+        event = MagicMock()
+        event.data.image = None
+
+        with patch.object(entity, "set_state") as mock_set_state:
+            entity.handle_event(event)
+
+        mock_set_state.assert_not_called()
+        assert entity.image is None
+
+    def test_handle_event_updates_image_when_present(
+        self, vis: MockViseron, mock_camera: MockCamera
+    ) -> None:
+        """A fresh image should update the entity's image and attributes."""
+        entity = LatestFaceImage(vis, mock_camera)
+        image = np.zeros((10, 10, 3), dtype=np.uint8)
+        event = MagicMock()
+        event.data.face.name = "alice"
+        event.data.face.confidence = 0.93
+        event.data.image = image
+
+        with patch.object(entity, "set_state") as mock_set_state:
+            entity.handle_event(event)
+
+        mock_set_state.assert_called_once()
+        assert entity.image is image
+        assert entity.extra_attributes == {"face": "alice", "confidence": 0.93}

--- a/viseron/domains/face_recognition/__init__.py
+++ b/viseron/domains/face_recognition/__init__.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from threading import Timer
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
 import voluptuous as vol
 
 from viseron.domains.post_processor import (
@@ -16,7 +17,7 @@ from viseron.domains.post_processor import (
     PostProcessorFrame,
 )
 from viseron.events import EventData
-from viseron.helpers import calculate_relative_coords
+from viseron.helpers import calculate_relative_coords, zoom_boundingbox
 from viseron.helpers.schemas import FLOAT_MIN_ZERO
 from viseron.helpers.validators import Deprecated
 from viseron.viseron_types import SnapshotDomain
@@ -42,6 +43,7 @@ from .const import (
     EVENT_FACE_EXPIRED,
     UNKNOWN_FACE,
 )
+from .image import LatestFaceImage
 
 if TYPE_CHECKING:
     from viseron import Viseron
@@ -104,6 +106,9 @@ class EventFaceDetected(EventData):
 
     camera_identifier: str
     face: FaceDict
+    # Only populated when this event represents a fresh appearance of the face,
+    # not on every re-detection of a face that is already tracked.
+    image: np.ndarray | None = None
 
     def as_dict(self) -> dict[str, Any]:
         """Return as dict."""
@@ -143,6 +148,12 @@ class AbstractFaceRecognition(AbstractPostProcessor):
                 DOMAIN,
                 camera_identifier,
             )
+        vis.add_entity(
+            component,
+            LatestFaceImage(vis, self._camera),
+            DOMAIN,
+            camera_identifier,
+        )
 
     def __post_init__(self, *args, **kwargs) -> None:
         """Post init hook."""
@@ -178,6 +189,15 @@ class AbstractFaceRecognition(AbstractPostProcessor):
             )
         self._insert_result(DOMAIN, snapshot_path, face_dict.as_dict())
 
+    def _get_face_image(
+        self, shared_frame: SharedFrame, coordinates: tuple[int, int, int, int]
+    ) -> np.ndarray | None:
+        """Return a cropped image of the detected face, for the latest-face entity."""
+        if not shared_frame:
+            return None
+        decoded_frame = self._camera.shared_frames.get_decoded_frame_rgb(shared_frame)
+        return zoom_boundingbox(decoded_frame, coordinates, crop_correction_factor=1.2)
+
     def known_face_found(
         self,
         face: str,
@@ -187,6 +207,8 @@ class AbstractFaceRecognition(AbstractPostProcessor):
         extra_attributes: dict[str, Any] | None = None,
     ) -> None:
         """Adds/expires known faces."""
+        is_new_appearance = self._faces.get(face, None) is None
+
         # Cancel the expiry timer if face has already been detected
         if self._faces.get(face, None):
             self._faces[face].timer.cancel()
@@ -201,9 +223,12 @@ class AbstractFaceRecognition(AbstractPostProcessor):
         )
         face_dict.timer.start()
 
-        # Only store face once until it is expired
-        if self._faces.get(face, None) is None and self._config[CONFIG_SAVE_FACES]:
-            self._save_face(face_dict, coordinates, shared_frame)
+        # Only grab an image, and store the face, once per appearance until expired
+        image = None
+        if is_new_appearance:
+            image = self._get_face_image(shared_frame, coordinates)
+            if self._config[CONFIG_SAVE_FACES]:
+                self._save_face(face_dict, coordinates, shared_frame)
 
         self._vis.dispatch_event(
             EVENT_FACE_DETECTED.format(
@@ -212,6 +237,7 @@ class AbstractFaceRecognition(AbstractPostProcessor):
             EventFaceDetected(
                 camera_identifier=self._camera.identifier,
                 face=face_dict,
+                image=image,
             ),
         )
         self._faces[face] = face_dict
@@ -224,6 +250,8 @@ class AbstractFaceRecognition(AbstractPostProcessor):
         extra_attributes: dict[str, Any] | None = None,
     ) -> None:
         """Save unknown faces."""
+        is_new_appearance = self._faces.get(UNKNOWN_FACE, None) is None
+
         # Cancel the expiry timer if face has already been detected
         if self._faces.get(UNKNOWN_FACE, None):
             self._faces[UNKNOWN_FACE].timer.cancel()
@@ -238,6 +266,9 @@ class AbstractFaceRecognition(AbstractPostProcessor):
         )
         face_dict.timer.start()
 
+        image = None
+        if is_new_appearance:
+            image = self._get_face_image(shared_frame, coordinates)
         if self._config[CONFIG_SAVE_UNKNOWN_FACES]:
             self._save_face(face_dict, coordinates, shared_frame)
 
@@ -248,6 +279,7 @@ class AbstractFaceRecognition(AbstractPostProcessor):
             EventFaceDetected(
                 camera_identifier=self._camera.identifier,
                 face=face_dict,
+                image=image,
             ),
         )
         self._faces[UNKNOWN_FACE] = face_dict

--- a/viseron/domains/face_recognition/image.py
+++ b/viseron/domains/face_recognition/image.py
@@ -1,0 +1,61 @@
+"""Image entity for the latest recognized face of a camera."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from viseron.domains.camera.entity.image import CameraImage
+
+from .const import EVENT_FACE_DETECTED
+
+if TYPE_CHECKING:
+    from viseron import Event, Viseron
+    from viseron.domains.camera import AbstractCamera
+    from viseron.domains.face_recognition import EventFaceDetected
+
+
+class LatestFaceImage(CameraImage):
+    """Entity that keeps track of the latest recognized face snapshot of a camera."""
+
+    def __init__(self, vis: Viseron, camera: AbstractCamera) -> None:
+        super().__init__(vis, camera)
+        self.device_class = "running"
+        self.object_id = f"{camera.identifier}_latest_face_recognition"
+        self.name = f"{camera.name} Latest Face Recognition"
+
+        self._attr_face: str | None = None
+        self._attr_confidence: float | None = None
+
+    def setup(self) -> None:
+        """Set up event listener."""
+        self._event_listeners.append(
+            self._vis.listen_event(
+                EVENT_FACE_DETECTED.format(
+                    camera_identifier=self._camera.identifier, face="*"
+                ),
+                self.handle_event,
+            )
+        )
+
+    @property
+    def extra_attributes(self) -> dict[str, Any]:
+        """Return extra attributes."""
+        return {
+            "face": self._attr_face,
+            "confidence": self._attr_confidence,
+        }
+
+    def handle_event(self, event_data: Event[EventFaceDetected]) -> None:
+        """Handle face detected event.
+
+        Only updates the image on a fresh appearance of a face, not on every
+        re-detection of a face that is already being tracked.
+        """
+        face = event_data.data.face
+        if event_data.data.image is None:
+            return
+
+        self._attr_face = face.name
+        self._attr_confidence = face.confidence
+        self._image = event_data.data.image
+        self.set_state()


### PR DESCRIPTION
Closes #903.

## What

Adds a new `image.<camera>_latest_face_recognition` entity, mirroring the existing camera-level "Latest Thumbnail" entity pattern (`ThumbnailImage`). Every `face_recognition`-capable camera now gets a "Latest Face Recognition" entity exposing the most recently recognized face (known or unknown) as an image — viewable directly in the frontend/Home Assistant without digging through events.

## How

- `EventFaceDetected` gains an optional `image: np.ndarray | None` field, populated only on a **fresh appearance** of a face — not on every re-detection of a face that's already being tracked, to avoid an unnecessary crop on every processed frame while a face stays in view.
- This is decoupled from the `save_faces`/`save_unknown_faces` disk-persistence settings, so the entity works even if a user has disabled saving snapshots to disk.
- New `LatestFaceImage` entity (`viseron/domains/face_recognition/image.py`) subscribes to the wildcard `EVENT_FACE_DETECTED` topic for the camera (`<camera_identifier>/face/detected/*`) and only updates its image/attributes when a fresh image is actually present on the event.
- Registered unconditionally in `AbstractFaceRecognition.__init__`, independent of `generate_entities` (which only gates the per-known-face binary sensors, based on enumerating the face folder on disk).

## Testing

Added `tests/domains/face_recognition/test__init__.py` covering:
- `known_face_found`/`unknown_face_found` only include an image on the first appearance of a face, not on repeated detections.
- No shared frame → no image, even on a fresh appearance.
- `LatestFaceImage.handle_event` ignores events without an image (state untouched) and correctly updates image/attributes + calls `set_state()` when an image is present.

No new config options, no changes to `CONFIG_SCHEMA`, so no docs regeneration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)