### PR TITLE
fix(ffmpeg): back off exponentially when camera is unreachable

### DIFF
--- a/tests/components/ffmpeg/test_camera.py
+++ b/tests/components/ffmpeg/test_camera.py
@@ -1,0 +1,119 @@
+"""FFmpeg camera tests."""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock, patch
+
+from viseron.components.ffmpeg.camera import Camera
+from viseron.components.ffmpeg.const import (
+    DEFAULT_RESTART_DELAY,
+    MAX_RESTART_DELAY,
+)
+
+from tests.common import MockCamera
+
+
+def _camera_with_failing_stream(read_values: list, iterations: int = 12) -> MockCamera:
+    """Return a MockCamera whose stream never delivers frames."""
+    camera = MockCamera(identifier="test_camera_identifier")
+    camera.decode_error = threading.Event()
+    camera._capture_frames = MagicMock()
+    camera._capture_frames.is_set.side_effect = [True] * iterations + [False]
+    camera._thread_stuck = False
+    camera.stream = MagicMock()
+    camera.stream.read.side_effect = read_values
+    camera.stream.poll.return_value = 1
+    camera._logger = MagicMock()
+    camera._frame_queue = MagicMock()
+    return camera
+
+
+class TestCameraReadFrames:
+    """Test the read_frames method."""
+
+    def test_read_frames_backs_off_exponentially_on_repeated_failures(self) -> None:
+        """A dead camera must retry less often instead of every 5 seconds."""
+        camera = _camera_with_failing_stream([None] * 20, iterations=12)
+        iterations = 12
+
+        sleeps: list[float] = []
+
+        def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        with (
+            patch("viseron.components.ffmpeg.camera.os.kill"),
+            patch("viseron.components.ffmpeg.camera.setproctitle.setproctitle"),
+            patch(
+                "viseron.components.ffmpeg.camera.time.sleep",
+                side_effect=fake_sleep,
+            ),
+        ):
+            Camera.read_frames(camera, camera._frame_queue)
+
+        # First failure waits the base delay, then each consecutive failure
+        # doubles the wait until it is capped at MAX_RESTART_DELAY.
+        assert sleeps == [
+            DEFAULT_RESTART_DELAY,
+            10,
+            20,
+            40,
+            MAX_RESTART_DELAY,
+            MAX_RESTART_DELAY,
+            MAX_RESTART_DELAY,
+            MAX_RESTART_DELAY,
+            MAX_RESTART_DELAY,
+            MAX_RESTART_DELAY,
+            MAX_RESTART_DELAY,
+        ]
+        assert camera.stream.start_pipe.call_count == iterations
+
+    def test_read_frames_resets_backoff_on_success(self) -> None:
+        """A successful frame must reset the backoff to its base delay."""
+        reads = [
+            None,
+            None,
+            b"frame",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ]
+        camera = _camera_with_failing_stream(reads)
+
+        sleeps: list[float] = []
+
+        def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        with (
+            patch("viseron.components.ffmpeg.camera.os.kill"),
+            patch("viseron.components.ffmpeg.camera.setproctitle.setproctitle"),
+            patch(
+                "viseron.components.ffmpeg.camera.time.sleep",
+                side_effect=fake_sleep,
+            ),
+        ):
+            Camera.read_frames(camera, camera._frame_queue)
+
+        # The frame at read #3 resets the backoff, so the wait after the next
+        # failure is back to the base delay.
+        assert sleeps == [
+            DEFAULT_RESTART_DELAY,
+            10,
+            DEFAULT_RESTART_DELAY,
+            10,
+            20,
+            40,
+            MAX_RESTART_DELAY,
+            MAX_RESTART_DELAY,
+            MAX_RESTART_DELAY,
+            MAX_RESTART_DELAY,
+        ]
+        camera._frame_queue.put_nowait.assert_called_once_with(b"frame")

--- a/viseron/components/ffmpeg/camera.py
+++ b/viseron/components/ffmpeg/camera.py
@@ -91,6 +91,7 @@ from .const import (
     DEFAULT_RECORDER_HWACCEL_ARGS,
     DEFAULT_RECORDER_OUTPUT_ARGS,
     DEFAULT_RECORDER_VIDEO_FILTERS,
+    DEFAULT_RESTART_DELAY,
     DEFAULT_RTSP_TRANSPORT,
     DEFAULT_STREAM_FORMAT,
     DEFAULT_SUBSTREAM,
@@ -134,6 +135,7 @@ from .const import (
     FFMPEG_LOGLEVELS,
     HWACCEL_VAAPI,
     MAX_EMPTY_FRAMES,
+    MAX_RESTART_DELAY,
     STREAM_FORMAT_MAP,
 )
 from .recorder import Recorder
@@ -427,6 +429,7 @@ class Camera(AbstractCamera):
         """Read frames from camera."""
         setproctitle.setproctitle("viseron.camera." + self.identifier + ".read_frames")
         self.decode_error.clear()
+        self._restart_delay = DEFAULT_RESTART_DELAY
         empty_frames = 0
         self._thread_stuck = False
 
@@ -434,15 +437,25 @@ class Camera(AbstractCamera):
 
         while self._capture_frames.is_set():
             if self.decode_error.is_set():
-                time.sleep(5)
+                # A dead or unreachable camera would otherwise spawn a new
+                # decode process every few seconds indefinitely. Back off
+                # exponentially so the retry rate drops quickly once failures
+                # are clearly persistent.
+                self._logger.warning(
+                    "Camera failed to produce frames, restarting in %s seconds",
+                    self._restart_delay,
+                )
+                time.sleep(self._restart_delay)
                 self._logger.error("Restarting frame pipe")
                 self.stream.close_pipe()
                 self.stream.start_pipe()
                 self.decode_error.clear()
                 empty_frames = 0
+                self._restart_delay = min(self._restart_delay * 2, MAX_RESTART_DELAY)
 
             frame_bytes = self.stream.read()
             if frame_bytes:
+                self._restart_delay = DEFAULT_RESTART_DELAY
                 empty_frames = 0
                 # Dont queue frames if consumer is not ready
                 with contextlib.suppress(Full):

--- a/viseron/components/ffmpeg/const.py
+++ b/viseron/components/ffmpeg/const.py
@@ -10,6 +10,12 @@ DESC_COMPONENT = "FFmpeg Configuration."
 ENV_FFMPEG_PATH = "VISERON_FFMPEG_PATH"
 MAX_EMPTY_FRAMES = 10
 
+# A dead or unreachable camera would otherwise spawn a new decode process
+# every few seconds indefinitely. Consecutive decode failures back off
+# exponentially between these bounds before retrying.
+DEFAULT_RESTART_DELAY = 5
+MAX_RESTART_DELAY = 60
+
 STREAM_FORMAT_MAP = {
     "rtsp": {"protocol": "rtsp", "timeout_option": ["-timeout", "5000000"]},
     "rtmp": {"protocol": "rtmp", "timeout_option": ["-rw_timeout", "5000000"]},

--- a/viseron/components/gstreamer/camera.py
+++ b/viseron/components/gstreamer/camera.py
@@ -89,6 +89,7 @@ from .const import (
     DEFAULT_PASSWORD,
     DEFAULT_PROTOCOL,
     DEFAULT_RAW_PIPELINE,
+    DEFAULT_RESTART_DELAY,
     DEFAULT_RTSP_TRANSPORT,
     DEFAULT_STREAM_FORMAT,
     DEFAULT_USERNAME,
@@ -117,6 +118,7 @@ from .const import (
     DESC_USERNAME,
     DESC_WIDTH,
     MAX_EMPTY_FRAMES,
+    MAX_RESTART_DELAY,
     STREAM_FORMAT_MAP,
 )
 from .recorder import Recorder
@@ -333,6 +335,7 @@ class Camera(AbstractCamera):
     def read_frames(self) -> None:
         """Read frames from camera."""
         self.decode_error.clear()
+        self._restart_delay = DEFAULT_RESTART_DELAY
         self._poll_timer = utcnow().timestamp()
         empty_frames = 0
         self._thread_stuck = False
@@ -344,15 +347,25 @@ class Camera(AbstractCamera):
                 self._poll_timer = utcnow().timestamp()
                 self.connected = False
                 self.still_image_available = self.still_image_configured
-                time.sleep(5)
+                # A dead or unreachable camera would otherwise spawn a new
+                # decode process every few seconds indefinitely. Back off
+                # exponentially so the retry rate drops quickly once failures
+                # are clearly persistent.
+                self._logger.warning(
+                    "Camera failed to produce frames, restarting in %s seconds",
+                    self._restart_delay,
+                )
+                time.sleep(self._restart_delay)
                 self._logger.error("Restarting frame pipe")
                 self.stream.close_pipe()
                 self.stream.start_pipe()
                 self.decode_error.clear()
                 empty_frames = 0
+                self._restart_delay = min(self._restart_delay * 2, MAX_RESTART_DELAY)
 
             self.current_frame = self.stream.read()
             if self.current_frame:
+                self._restart_delay = DEFAULT_RESTART_DELAY
                 self.connected = True
                 self.still_image_available = True
                 empty_frames = 0

--- a/viseron/components/gstreamer/const.py
+++ b/viseron/components/gstreamer/const.py
@@ -15,6 +15,12 @@ DESC_COMPONENT = "GStreamer Configuration."
 ENV_GSTREAMER_PATH = "VISERON_GSTREAMER_PATH"
 MAX_EMPTY_FRAMES = 10
 
+# A dead or unreachable camera would otherwise spawn a new decode process
+# every few seconds indefinitely. Consecutive decode failures back off
+# exponentially between these bounds before retrying.
+DEFAULT_RESTART_DELAY = 5
+MAX_RESTART_DELAY = 60
+
 RECORDER = "recorder"
 
 # pylint: disable=useless-suppression


### PR DESCRIPTION
## Summary

A dead or unreachable camera makes the frame reader spawn a new decode process every few seconds indefinitely (sleep 5s → spawn ffmpeg → 5s connect timeout → repeat). On a host with a camera that is powered off or off the network, this burns a full CPU core of pure wasted work, forever.

Consecutive decode failures now back off exponentially instead of retrying at a constant 5s:

| Consecutive failures | Wait before next restart |
|---|---|
| 1 | 5s |
| 2 | 10s |
| 3 | 20s |
| 4 | 40s |
| 5+ | 60s (capped) |

A successful frame resets the backoff to the base 5s delay, so a camera that comes back online is reconnected with no noticeable lag.

Applied to both the **ffmpeg** and **gstreamer** camera components (identical logic), with new unit tests covering the exponential sequence and the reset-on-success behavior.

## Motivation

On our standby Viseron instance the EZVIZ camera has been offline for two weeks; the container was spending ~30–40% of one core just cycling 'Restarting frame pipe' against the dead RTSP endpoint (~15k restarts over 3 days). This fix drops that to a single attempt every 60s.

## Tests

- New: `tests/components/ffmpeg/test_camera.py` (2 tests) — exponential backoff sequence and reset-on-success.
- Existing ffmpeg/gstreamer/domain-camera suites: 86 passed (10 pre-existing postgres-fixture errors in the ad-hoc runner, unrelated).