### PR TITLE
feat(ci): disable rpi3 builds

### DIFF
--- a/azure-pipelines/azure-pipelines-tools.yml
+++ b/azure-pipelines/azure-pipelines-tools.yml
@@ -44,7 +44,6 @@ jobs:
       architectures:
         - amd64
         - aarch64
-        - rpi3
 
   # Publish hailo wheels and libhailort packages
   - job: publish_hailo_artifacts

--- a/azure-pipelines/azure-pipelines-viseron.yml
+++ b/azure-pipelines/azure-pipelines-viseron.yml
@@ -111,7 +111,6 @@ stages:
                   --debug \
                   --tag roflcoopter/viseron:${release_version} \
                   roflcoopter/viseron:${release_version}-amd64 \
-                  roflcoopter/viseron:${release_version}-rpi3 \
                   roflcoopter/viseron:${release_version}-aarch64
 
                 docker buildx imagetools inspect roflcoopter/viseron:${release_version}
@@ -120,7 +119,6 @@ stages:
                   --debug \
                   --tag ghcr.io/roflcoopter/viseron:${release_version} \
                   ghcr.io/roflcoopter/viseron:${release_version}-amd64 \
-                  ghcr.io/roflcoopter/viseron:${release_version}-rpi3 \
                   ghcr.io/roflcoopter/viseron:${release_version}-aarch64
 
                 docker buildx imagetools inspect ghcr.io/roflcoopter/viseron:${release_version}

--- a/azure-pipelines/templates/build.yaml
+++ b/azure-pipelines/templates/build.yaml
@@ -6,7 +6,6 @@ parameters:
       - amd64
       - amd64-cuda
       - jetson-nano
-      - rpi3
   - name: namespace
     type: string
     default: roflcoopter

--- a/azure-pipelines/templates/smoke_test.yaml
+++ b/azure-pipelines/templates/smoke_test.yaml
@@ -4,7 +4,7 @@ parameters:
     # The base image name without arch prefix, e.g. "viseron".
   - name: architecture
     type: string
-    # One of: amd64, amd64-cuda, aarch64, rpi3
+    # One of: amd64, amd64-cuda, aarch64
   - name: namespace
     type: string
     default: roflcoopter

--- a/azure-pipelines/templates/smoke_test_stage.yaml
+++ b/azure-pipelines/templates/smoke_test_stage.yaml
@@ -5,7 +5,6 @@ parameters:
       - aarch64
       - amd64
       - amd64-cuda
-      - rpi3
   - name: namespace
     type: string
     default: roflcoopter


### PR DESCRIPTION
The Raspberry Pi 3 is getting old at this point, and maintaining the images for it is becoming impossible since new versions of dependencies are failing to build on it.

Because of this i have decided to disable the builds and not support the RPi3 going forward.
The code is still in the repo for a while longer in case someone steps in to figure stuff out.

Sorry for any trouble this may cause