### PR TITLE
fix(nvr): pass SharedFrame to stream handler instead of numpy array

### DIFF
--- a/viseron/components/nvr/nvr.py
+++ b/viseron/components/nvr/nvr.py
@@ -58,8 +58,6 @@ from .const import (
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    import numpy as np
-
     from viseron import Viseron
     from viseron.domains.camera import AbstractCamera, EventFrameBytesData
     from viseron.domains.camera.recorder import ManualRecording
@@ -99,7 +97,7 @@ def setup(vis: Viseron, config: dict[str, Any], identifier: str) -> bool:
 class EventProcessedFrame(EventData):
     """Processed frame that is sent on EVENT_PROCESSED_FRAME_TOPIC."""
 
-    frame: np.ndarray
+    shared_frame: SharedFrame
     objects_in_fov: list[DetectedObject] | None
     motion_contours: Contours | None
 
@@ -935,9 +933,7 @@ class NVR(AbstractNVR):
                 camera_identifier=self._camera.identifier
             ),
             EventProcessedFrame(
-                frame=self._camera.shared_frames.get_decoded_frame_rgb(
-                    shared_frame
-                ).copy(),
+                shared_frame=shared_frame,
                 objects_in_fov=self._object_detector.objects_in_fov
                 if self._object_detector
                 else None,

--- a/viseron/components/webserver/stream_handler.py
+++ b/viseron/components/webserver/stream_handler.py
@@ -104,7 +104,9 @@ class StreamHandler(ViseronRequestHandler):
         nvr: NVR, processed_frame: EventProcessedFrame, mjpeg_stream_config: dict
     ) -> tuple[bool, np.ndarray]:
         """Return JPG with drawn objects, zones etc."""
-        _frame = processed_frame.frame.copy()
+        _frame = nvr.camera.shared_frames.get_decoded_frame_rgb(
+            processed_frame.shared_frame
+        )
 
         if mjpeg_stream_config["width"] and mjpeg_stream_config["height"]:
             resolution = mjpeg_stream_config["width"], mjpeg_stream_config["height"]
@@ -204,9 +206,13 @@ class DynamicStreamHandler(StreamHandler):
         while True:
             try:
                 processed_frame = await frame_queue.get()
-                ret, jpg = await self.run_in_executor(
-                    self.process_frame, nvr, processed_frame.data, mjpeg_stream_config
-                )
+                with processed_frame.data.shared_frame:
+                    ret, jpg = await self.run_in_executor(
+                        self.process_frame,
+                        nvr,
+                        processed_frame.data,
+                        mjpeg_stream_config,
+                    )
 
                 if ret:
                     await self.write_jpg(jpg)
@@ -248,9 +254,10 @@ class StaticStreamHandler(StreamHandler):
 
         while self.active_streams[(nvr.camera.identifier, mjpeg_stream)]:
             processed_frame = await frame_queue.get()
-            ret, jpg = await self.run_in_executor(
-                self.process_frame, nvr, processed_frame.data, mjpeg_stream_config
-            )
+            with processed_frame.data.shared_frame:
+                ret, jpg = await self.run_in_executor(
+                    self.process_frame, nvr, processed_frame.data, mjpeg_stream_config
+                )
 
             if ret:
                 self._vis.dispatch_event(


### PR DESCRIPTION
Small optimization to not run frame deccode+copy when no MJPEG stream is active