### PR TITLE
feat(data_stream): refactor data stream bus

### DIFF
--- a/docs/docs/developers/backend/data_stream_component.mdx
+++ b/docs/docs/developers/backend/data_stream_component.mdx
@@ -2,10 +2,47 @@
 title: Data stream
 ---
 
-_Information has not yet been added._
+`data_stream` is the publish/subscribe bus that carries frames, detections and events
+between the different parts of Viseron. It is a core component and is always loaded.
 
-:::info
+Most code does not use it directly. `vis.dispatch_event` / `vis.listen_event` publish and
+subscribe to `event/<name>` topics, and `vis.register_signal_handler` subscribes to the
+shutdown signals.
 
-The developer documentation is still under construction and this page is not complete.
+## Topics
 
-:::
+A topic can be any string. Subscribing to a topic containing `*` matches using
+[fnmatch](https://docs.python.org/3/library/fnmatch.html) semantics, so
+`domain/setup/*/*/*` matches `domain/setup/loaded/camera/camera_1`. A star matches across
+`/` as well.
+
+## Subscriber types
+
+`subscribe_data` accepts four kinds of subscriber, and rejects anything else immediately:
+
+| Subscriber                        | Delivery                                                      |
+| --------------------------------- | ------------------------------------------------------------- |
+| `Callable`                        | Runs on a shared thread pool                                  |
+| `Callable` + `ioloop`             | Scheduled on the given Tornado IOLoop, coroutines are awaited |
+| `queue.Queue`                     | Put on the queue by the consumer thread                       |
+| `tornado.queues.Queue` + `ioloop` | Put on the queue from the given IOLoop                        |
+
+## Ordering
+
+A single consumer thread reads published data and hands it to subscribers, so subscribers
+observe messages in publish order. Callback subscribers are drained one message at a time,
+meaning a subscriber never has two of its own invocations running concurrently.
+
+## Backpressure
+
+Nothing on the bus ever blocks a publisher.
+
+- **Signals** (`viseron/signal/*`) go on their own unbounded queue and are handled before
+  any queued data, so a shutdown signal can never be dropped.
+- **Data** is put on a bounded queue. If it fills, the oldest message is dropped and a warning
+  is logged.
+- **Callback subscribers** each have a bounded backlog. A subscriber that cannot keep up
+  drops its own oldest messages, and is named in the resulting warning, rather than
+  slowing down the rest of the bus.
+- **Queue subscribers** drops the oldest message by using the helper `pop_if_full`.
+  Used primarily by the frame pipeline with `maxsize=1` so slow consumers always works on the newest frame.

--- a/tests/components/data_stream/__init__.py
+++ b/tests/components/data_stream/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the data_stream component."""

--- a/tests/components/data_stream/conftest.py
+++ b/tests/components/data_stream/conftest.py
@@ -1,0 +1,85 @@
+"""Fixtures for data_stream tests."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from queue import Empty
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+import pytest
+from tornado.ioloop import IOLoop
+
+from viseron.components.data_stream import DataStream
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator
+
+
+def _reset_data_stream_state() -> None:
+    """Clear the class level state shared by every DataStream instance."""
+    DataStream.remove_all_subscriptions()
+    for queue in (DataStream._data_queue, DataStream._signal_queue):
+        while True:
+            try:
+                queue.get_nowait()
+            except Empty:
+                break
+
+
+@pytest.fixture
+def data_stream() -> Generator[DataStream, Any, None]:
+    """Yield a running DataStream with isolated class level state."""
+    _reset_data_stream_state()
+    stream = DataStream(MagicMock())
+    yield stream
+    stream.stop()
+    stream.join()
+    _reset_data_stream_state()
+
+
+@pytest.fixture
+def stopped_data_stream() -> Generator[DataStream, Any, None]:
+    """Yield a DataStream whose consumer thread has already exited.
+
+    Lets a test fill the queues and drive the consumer by hand.
+    """
+    _reset_data_stream_state()
+    stream = DataStream(MagicMock())
+    stream.stop()
+    stream.join()
+    yield stream
+    _reset_data_stream_state()
+
+
+@pytest.fixture
+def ioloop() -> Generator[IOLoop, Any, None]:
+    """Yield a Tornado IOLoop running in a background thread."""
+    started = threading.Event()
+    loop: dict[str, IOLoop] = {}
+
+    def _run() -> None:
+        asyncio.set_event_loop(asyncio.new_event_loop())
+        loop["ioloop"] = IOLoop.current()
+        started.set()
+        loop["ioloop"].start()
+
+    thread = threading.Thread(target=_run, daemon=True, name="test_ioloop")
+    thread.start()
+    assert started.wait(timeout=5)
+
+    yield loop["ioloop"]
+
+    loop["ioloop"].add_callback(loop["ioloop"].stop)
+    thread.join(timeout=5)
+
+
+@pytest.fixture
+def wait_for() -> Callable[..., None]:
+    """Return a helper that blocks until an event fires, failing the test if not."""
+
+    def _wait_for(event: threading.Event, timeout: float = 5) -> None:
+        assert event.wait(timeout=timeout), "Timed out waiting for delivery"
+
+    return _wait_for

--- a/tests/components/data_stream/test__init__.py
+++ b/tests/components/data_stream/test__init__.py
@@ -1,0 +1,449 @@
+"""Tests for the data_stream component."""
+
+from __future__ import annotations
+
+import threading
+import time
+import uuid
+from queue import Empty, Queue
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from tornado.queues import Queue as TornadoQueue
+
+from viseron.components.data_stream import DataStream
+from viseron.components.data_stream.const import DATA_QUEUE_MAXSIZE
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from tornado.ioloop import IOLoop
+
+
+class TestSubscribeData:
+    """Test subscribe_data."""
+
+    def test_returns_unique_ids(self, data_stream: DataStream) -> None:
+        """Every subscription gets its own id."""
+        first = data_stream.subscribe_data("topic", lambda _data: None)
+        second = data_stream.subscribe_data("topic", lambda _data: None)
+        assert first != second
+
+    def test_literal_topic_does_not_match_other_topics(
+        self, data_stream: DataStream
+    ) -> None:
+        """A subscription without a star only receives its exact topic."""
+        queue: Queue = Queue()
+        data_stream.subscribe_data("plain/topic", queue)
+        data_stream.publish_data("plain/other", data="payload")
+
+        with pytest.raises(Empty):
+            queue.get(timeout=1)
+
+    def test_invalid_subscriber_raises_at_subscribe_time(
+        self, data_stream: DataStream
+    ) -> None:
+        """A non-callable, non-queue subscriber is rejected once, not per message."""
+        subscriber: Any = "not a callback"
+        with pytest.raises(ValueError, match="not a valid subscriber"):
+            data_stream.subscribe_data("topic", subscriber)
+
+    def test_tornado_queue_without_ioloop_is_rejected(
+        self, data_stream: DataStream
+    ) -> None:
+        """A tornado queue is useless without an ioloop to put onto."""
+        with pytest.raises(ValueError, match="requires an ioloop"):
+            data_stream.subscribe_data("topic", TornadoQueue())
+
+
+class TestCallbackSubscriber:
+    """Test plain callable subscribers."""
+
+    @pytest.mark.parametrize(
+        ("publish_kwargs", "expected_args"),
+        [
+            pytest.param({}, (), id="no_data_calls_with_no_arguments"),
+            pytest.param({"data": {"key": "value"}}, ({"key": "value"},), id="dict"),
+            pytest.param({"data": {}}, ({},), id="falsy_empty_dict"),
+            pytest.param({"data": []}, ([],), id="falsy_empty_list"),
+            pytest.param({"data": 0}, (0,), id="falsy_zero"),
+            pytest.param({"data": False}, (False,), id="falsy_false"),
+            pytest.param({"data": ""}, ("",), id="falsy_empty_string"),
+        ],
+    )
+    def test_callback_receives_published_data(
+        self,
+        data_stream: DataStream,
+        wait_for: Callable[..., None],
+        publish_kwargs: dict[str, Any],
+        expected_args: tuple[Any, ...],
+    ) -> None:
+        """A callable subscriber is invoked with the published payload.
+
+        Publishing without data invokes the callback with no arguments, which is
+        what register_signal_handler relies on. A payload that is present but
+        falsy must still be passed as an argument.
+        """
+        received: list[tuple[Any, ...]] = []
+        done = threading.Event()
+
+        def _callback(*args: Any) -> None:
+            received.append(args)
+            done.set()
+
+        data_stream.subscribe_data("topic", _callback)
+        data_stream.publish_data("topic", **publish_kwargs)
+
+        wait_for(done)
+        assert received == [expected_args]
+
+    def test_all_subscribers_on_a_topic_are_invoked(
+        self, data_stream: DataStream, wait_for: Callable[..., None]
+    ) -> None:
+        """Every subscriber on a topic receives the payload."""
+        first = threading.Event()
+        second = threading.Event()
+
+        data_stream.subscribe_data("topic", lambda _data: first.set())
+        data_stream.subscribe_data("topic", lambda _data: second.set())
+        data_stream.publish_data("topic", data="payload")
+
+        wait_for(first)
+        wait_for(second)
+
+    def test_messages_are_delivered_in_order(
+        self, data_stream: DataStream, wait_for: Callable[..., None]
+    ) -> None:
+        """A slow first message must not overtake the messages behind it."""
+        message_count = 20
+        received: list[int] = []
+        done = threading.Event()
+
+        def _callback(data: int) -> None:
+            if data == 0:
+                time.sleep(0.2)
+            received.append(data)
+            if data == message_count - 1:
+                done.set()
+
+        data_stream.subscribe_data("topic", _callback)
+        for index in range(message_count):
+            data_stream.publish_data("topic", data=index)
+
+        wait_for(done)
+        assert received == list(range(message_count))
+
+    @pytest.mark.parametrize(
+        ("stage", "expected_daemon"),
+        [
+            pytest.param(None, True, id="no_stage_runs_daemon"),
+            pytest.param("shutdown", False, id="stage_runs_non_daemon"),
+        ],
+    )
+    def test_stage_controls_thread_daemon_flag(
+        self,
+        data_stream: DataStream,
+        wait_for: Callable[..., None],
+        stage: str | None,
+        expected_daemon: bool,
+    ) -> None:
+        """Viseron.shutdown joins non-daemon threads tagged with a stage.
+
+        See wait_for_threads_and_processes_to_exit in viseron/__init__.py.
+        """
+        observed: dict[str, Any] = {}
+        done = threading.Event()
+
+        def _callback(_data: Any) -> None:
+            thread = threading.current_thread()
+            observed["daemon"] = thread.daemon
+            observed["stage"] = getattr(thread, "__stage__", None)
+            done.set()
+
+        data_stream.subscribe_data("topic", _callback, stage=stage)
+        data_stream.publish_data("topic", data="payload")
+
+        wait_for(done)
+        assert observed["daemon"] is expected_daemon
+        assert observed["stage"] == stage
+
+
+class TestQueueSubscriber:
+    """Test queue.Queue subscribers."""
+
+    def test_queue_receives_published_data(self, data_stream: DataStream) -> None:
+        """A queue subscriber has the payload put on it."""
+        queue: Queue = Queue(maxsize=1)
+        data_stream.subscribe_data("topic", queue)
+        data_stream.publish_data("topic", data="payload")
+
+        assert queue.get(timeout=5) == "payload"
+
+    def test_full_queue_drops_oldest(
+        self, data_stream: DataStream, wait_for: Callable[..., None]
+    ) -> None:
+        """A full subscriber queue drops its oldest entry rather than blocking."""
+        queue: Queue = Queue(maxsize=1)
+        queue.put("stale")
+        settled = threading.Event()
+
+        data_stream.subscribe_data("topic", queue)
+        # Subscribers run in subscription order, so this fires after the queue
+        # has been updated with the final payload.
+        data_stream.subscribe_data(
+            "topic", lambda data: settled.set() if data == "fresh_3" else None
+        )
+
+        for payload in ("fresh_1", "fresh_2", "fresh_3"):
+            data_stream.publish_data("topic", data=payload)
+
+        wait_for(settled)
+        assert queue.qsize() == 1
+        assert queue.get_nowait() == "fresh_3"
+
+
+class TestTornadoQueueSubscriber:
+    """Test tornado Queue subscribers."""
+
+    def test_tornado_queue_receives_published_data(
+        self, data_stream: DataStream, ioloop: IOLoop, wait_for: Callable[..., None]
+    ) -> None:
+        """A tornado queue subscriber with an ioloop has the payload put on it."""
+        queue: TornadoQueue = TornadoQueue(maxsize=1)
+        received: list[Any] = []
+        done = threading.Event()
+
+        async def _fetch() -> None:
+            received.append(await queue.get())
+            done.set()
+
+        data_stream.subscribe_data("topic", queue, ioloop=ioloop)
+        ioloop.add_callback(_fetch)
+        data_stream.publish_data("topic", data="payload")
+
+        wait_for(done)
+        assert received == ["payload"]
+
+
+class TestIOLoopCallbackSubscriber:
+    """Test callable subscribers dispatched onto an ioloop."""
+
+    def test_sync_callback_runs(
+        self, data_stream: DataStream, ioloop: IOLoop, wait_for: Callable[..., None]
+    ) -> None:
+        """A synchronous callable with an ioloop receives the payload."""
+        received: list[Any] = []
+        done = threading.Event()
+
+        def _callback(data: Any) -> None:
+            received.append(data)
+            done.set()
+
+        data_stream.subscribe_data("topic", _callback, ioloop=ioloop)
+        data_stream.publish_data("topic", data="payload")
+
+        wait_for(done)
+        assert received == ["payload"]
+
+    def test_async_callback_runs(
+        self, data_stream: DataStream, ioloop: IOLoop, wait_for: Callable[..., None]
+    ) -> None:
+        """A coroutine function with an ioloop receives the payload."""
+        received: list[Any] = []
+        done = threading.Event()
+
+        async def _callback(data: Any) -> None:
+            received.append(data)
+            done.set()
+
+        data_stream.subscribe_data("topic", _callback, ioloop=ioloop)
+        data_stream.publish_data("topic", data="payload")
+
+        wait_for(done)
+        assert received == ["payload"]
+
+
+class TestWildcardSubscriptions:
+    """Test wildcard topic matching."""
+
+    @pytest.mark.parametrize(
+        ("pattern", "topic", "expect_delivery"),
+        [
+            pytest.param("camera/*/event", "camera/one/event", True, id="single_star"),
+            pytest.param("domain/setup/*/*/*", "domain/setup/a/b/c", True, id="three"),
+            pytest.param("camera/*/event", "camera/one/other", False, id="no_match"),
+            pytest.param(
+                "camera/*/event", "camera/a/b/event", True, id="star_spans_separators"
+            ),
+        ],
+    )
+    def test_wildcard_matching(
+        self,
+        data_stream: DataStream,
+        pattern: str,
+        topic: str,
+        expect_delivery: bool,
+    ) -> None:
+        """Wildcard subscribers are selected with fnmatch semantics."""
+        queue: Queue = Queue()
+        data_stream.subscribe_data(pattern, queue)
+        data_stream.publish_data(topic, data="payload")
+
+        delivered = True
+        try:
+            queue.get(timeout=1)
+        except Empty:
+            delivered = False
+        assert delivered is expect_delivery
+
+    def test_static_and_wildcard_subscribers_both_invoked(
+        self, data_stream: DataStream
+    ) -> None:
+        """A message reaches static and wildcard subscribers alike."""
+        static_queue: Queue = Queue()
+        wildcard_queue: Queue = Queue()
+        data_stream.subscribe_data("camera/one/event", static_queue)
+        data_stream.subscribe_data("camera/*/event", wildcard_queue)
+
+        data_stream.publish_data("camera/one/event", data="payload")
+
+        assert static_queue.get(timeout=5) == "payload"
+        assert wildcard_queue.get(timeout=5) == "payload"
+
+
+class TestUnsubscribe:
+    """Test unsubscribe_data and remove_all_subscriptions."""
+
+    @pytest.mark.parametrize(
+        "topic",
+        [
+            pytest.param("plain/topic", id="static_topic"),
+            pytest.param("wild/*/topic", id="wildcard_topic"),
+        ],
+    )
+    def test_unsubscribe_stops_delivery(
+        self, data_stream: DataStream, topic: str
+    ) -> None:
+        """After unsubscribing, no further data is delivered."""
+        queue: Queue = Queue()
+        unique_id = data_stream.subscribe_data(topic, queue)
+        data_stream.unsubscribe_data(topic, unique_id)
+
+        data_stream.publish_data(topic.replace("*", "any"), data="payload")
+
+        with pytest.raises(Empty):
+            queue.get(timeout=1)
+
+    @pytest.mark.parametrize(
+        "topic",
+        [
+            pytest.param("camera_1/event", id="static_topic"),
+            pytest.param("camera_1/*/event", id="wildcard_topic"),
+        ],
+    )
+    def test_unsubscribe_prunes_empty_topics(
+        self, data_stream: DataStream, topic: str
+    ) -> None:
+        """The registry must not grow monotonically with per-camera topic names."""
+        unique_id = data_stream.subscribe_data(topic, lambda _data: None)
+        assert DataStream._registry.topic_count == 1
+
+        data_stream.unsubscribe_data(topic, unique_id)
+
+        assert DataStream._registry.topic_count == 0
+
+    def test_remove_all_subscriptions_stops_static_and_wildcard_delivery(
+        self, data_stream: DataStream
+    ) -> None:
+        """remove_all_subscriptions drops static and wildcard subscribers alike."""
+        static_queue: Queue = Queue()
+        wildcard_queue: Queue = Queue()
+        data_stream.subscribe_data("plain/topic", static_queue)
+        data_stream.subscribe_data("wild/*/topic", wildcard_queue)
+
+        data_stream.remove_all_subscriptions()
+
+        data_stream.publish_data("plain/topic", data="payload")
+        data_stream.publish_data("wild/any/topic", data="payload")
+
+        with pytest.raises(Empty):
+            static_queue.get(timeout=1)
+        with pytest.raises(Empty):
+            wildcard_queue.get(timeout=1)
+
+    def test_unsubscribe_unknown_topic_does_not_raise(
+        self, data_stream: DataStream
+    ) -> None:
+        """Unsubscribing from a topic that was never subscribed to is a no-op.
+
+        Every unsub() closure handed out by Viseron.listen_event is called
+        during teardown, which happens after Viseron.shutdown has already
+        called remove_all_subscriptions.
+        """
+        data_stream.unsubscribe_data("never/subscribed", uuid.uuid4())
+
+    def test_unsubscribe_after_remove_all_does_not_raise(
+        self, data_stream: DataStream
+    ) -> None:
+        """The unsub closure still works after remove_all_subscriptions."""
+        unique_id = data_stream.subscribe_data("topic", lambda _data: None)
+        data_stream.remove_all_subscriptions()
+
+        data_stream.unsubscribe_data("topic", unique_id)
+
+
+class TestSignalTopics:
+    """Shutdown signals must survive a saturated data queue."""
+
+    def test_signal_queue_is_unbounded_while_data_queue_drops(
+        self, stopped_data_stream: DataStream
+    ) -> None:
+        """Flooding the bus must not be able to discard a shutdown signal."""
+        overflow = DATA_QUEUE_MAXSIZE + 50
+        for index in range(overflow):
+            stopped_data_stream.publish_data("some/data/topic", data=index)
+        for index in range(overflow):
+            stopped_data_stream.publish_data("viseron/signal/shutdown", data=index)
+
+        assert DataStream._data_queue.qsize() == DATA_QUEUE_MAXSIZE
+        assert DataStream._signal_queue.qsize() == overflow
+
+    def test_signals_are_drained_ahead_of_a_data_backlog(
+        self, stopped_data_stream: DataStream
+    ) -> None:
+        """The consumer handles pending signals before it touches queued data."""
+        delivered: Queue = Queue()
+        stopped_data_stream.subscribe_data("some/data/topic", delivered)
+        stopped_data_stream.subscribe_data("viseron/signal/shutdown", delivered)
+
+        for index in range(500):
+            stopped_data_stream.publish_data("some/data/topic", data=f"data_{index}")
+        stopped_data_stream.publish_data("viseron/signal/shutdown", data="signal")
+
+        stopped_data_stream._drain_signals()
+
+        assert delivered.get_nowait() == "signal"
+
+    def test_a_signal_is_delivered_to_a_shutdown_stage_subscriber(
+        self, data_stream: DataStream, wait_for: Callable[..., None]
+    ) -> None:
+        """A signal reaches its handler through the separate signal queue."""
+        seen = threading.Event()
+        data_stream.subscribe_data(
+            "viseron/signal/shutdown", seen.set, stage="shutdown"
+        )
+
+        data_stream.publish_data("viseron/signal/shutdown")
+
+        wait_for(seen)
+
+
+class TestStop:
+    """Test stopping the data stream."""
+
+    def test_stop_ends_the_consumer_thread(self) -> None:
+        """stop() followed by join() terminates the consumer thread."""
+        stream = DataStream(object())
+        stream.stop()
+        stream.join()
+        assert not stream._data_consumer.is_alive()

--- a/viseron/components/data_stream/__init__.py
+++ b/viseron/components/data_stream/__init__.py
@@ -2,51 +2,33 @@
 
 from __future__ import annotations
 
-import fnmatch
-import inspect
 import logging
-import subprocess
-import threading
 import time
 import uuid
-from queue import Empty, Queue
-from typing import TYPE_CHECKING, Any, Final, TypedDict
+from queue import Empty, Full, Queue
+from typing import TYPE_CHECKING, Any
 
-from tornado.ioloop import IOLoop
-from tornado.queues import Queue as TornadoQueue
-
-from viseron import helpers
+from viseron.components.data_stream.const import (
+    COMPONENT,
+    DATA_QUEUE_MAXSIZE,
+    DROP_WARNING_INTERVAL,
+    PUBLISH_MAX_ATTEMPTS,
+    SIGNAL_TOPIC_PREFIX,
+)
+from viseron.components.data_stream.delivery import Dispatcher
+from viseron.components.data_stream.registry import SubscriberRegistry
+from viseron.components.data_stream.subscriber import create_subscriber
 from viseron.watchdog.thread_watchdog import RestartableThread
 
 if TYPE_CHECKING:
-    import multiprocessing as mp
     from collections.abc import Callable
 
-COMPONENT: Final = "data_stream"
+    from tornado.ioloop import IOLoop
+    from tornado.queues import Queue as TornadoQueue
+
+__all__ = ["COMPONENT", "DataStream", "setup"]
 
 LOGGER = logging.getLogger(__name__)
-
-
-class DataSubscriber(TypedDict):
-    """Data subscriber type."""
-
-    callback: Callable | Queue | TornadoQueue
-    ioloop: IOLoop | None
-    stage: str | None
-
-
-class Subscribe(TypedDict):
-    """Subscribe to data from process."""
-
-    data_topic: str
-    callback: mp.Queue
-
-
-class Publish(TypedDict):
-    """Data to publish from process."""
-
-    data_topic: str
-    data: Any
 
 
 def setup(vis, _) -> bool:
@@ -63,49 +45,63 @@ class DataStream:
     A data topic can have any value.
     You can subscribe to wildcard topics using '*', eg topic/*/event_name
 
-    Data is published to topics using a thread.
+    Data is published to topics using a thread. A single consumer thread looks
+    up subscribers and hands the data off, so it never blocks on subscriber
+    work. Callback subscribers are delivered to on a shared pool, in publish
+    order per subscriber.
     """
 
-    _subscribers: dict[str, Any] = {}
-    _wildcard_subscribers: dict[str, Any] = {}
-    _data_queue: Queue = Queue(maxsize=1000)
+    _registry: SubscriberRegistry = SubscriberRegistry()
+    _data_queue: Queue = Queue(maxsize=DATA_QUEUE_MAXSIZE)
+    # Signals must never be dropped, so they bypass the bounded data queue.
+    _signal_queue: Queue = Queue()
+
+    _dropped_count: int = 0
+    _last_drop_warning: float = 0.0
 
     def __init__(self, vis) -> None:
         self._vis = vis
-        self._max_threads = self._get_max_threads()
-        LOGGER.debug(f"Max threads: {self._max_threads}")
-
         self._kill_received = False
+        self._dispatcher = Dispatcher()
         self._data_consumer = RestartableThread(
             name="data_stream", target=self.consume_data, daemon=True, register=True
         )
         self._data_consumer.start()
 
-    def _get_max_threads(self) -> int:
-        """Get the maximum number of threads allowed."""
-        command = ["ulimit", "-u"]
-        result = subprocess.run(
-            command, shell=True, capture_output=True, text=True, check=False
-        )
-
-        # Check if the command executed successfully
-        if result.returncode == 0:
-            ulimit_output = result.stdout.strip()
-            LOGGER.debug(f"ulimit -u output: {ulimit_output}")
-        else:
-            LOGGER.error(f"Error executing ulimit -u command: {result.stderr}")
-            return 999999
-
-        try:
-            return int(ulimit_output)
-        except ValueError:
-            return 999999
-
     @staticmethod
     def publish_data(data_topic: str, data: Any = None) -> None:
         """Publish data to topic."""
-        helpers.pop_if_full(
-            DataStream._data_queue, {"data_topic": data_topic, "data": data}
+        item = {"data_topic": data_topic, "data": data}
+
+        if data_topic.startswith(SIGNAL_TOPIC_PREFIX):
+            DataStream._signal_queue.put(item)
+            return
+
+        for _ in range(PUBLISH_MAX_ATTEMPTS):
+            try:
+                DataStream._data_queue.put_nowait(item)
+                return
+            except Full:
+                try:
+                    DataStream._data_queue.get_nowait()
+                except Empty:
+                    pass
+                DataStream._record_drop()
+
+        LOGGER.warning(f"Failed to publish to data topic {data_topic}, discarding")
+
+    @staticmethod
+    def _record_drop() -> None:
+        """Count a dropped message and warn at most once per interval."""
+        DataStream._dropped_count += 1
+        now = time.time()
+        if now - DataStream._last_drop_warning < DROP_WARNING_INTERVAL:
+            return
+        DataStream._last_drop_warning = now
+        LOGGER.warning(
+            "data_stream queue is full, dropped %s messages so far. "
+            "A subscriber is not keeping up",
+            DataStream._dropped_count,
         )
 
     @staticmethod
@@ -118,178 +114,77 @@ class DataStream:
         """Subscribe to data on a topic.
 
         Returns a Unique ID which can be used to unsubscribe later.
+
+        Raises:
+            ValueError: If the callback can never be delivered to.
         """
-        LOGGER.debug(f"Subscribing to data topic {data_topic}, {callback}")
+        LOGGER.debug("Subscribing to data topic %s, %s", data_topic, callback)
         unique_id = uuid.uuid4()
-
-        if "*" in data_topic:
-            DataStream._wildcard_subscribers.setdefault(data_topic, {})[unique_id] = (
-                DataSubscriber(
-                    callback=callback,
-                    ioloop=ioloop,
-                    stage=stage,
-                )
-            )
-            return unique_id
-
-        DataStream._subscribers.setdefault(data_topic, {})[unique_id] = DataSubscriber(
-            callback=callback,
-            ioloop=ioloop,
-            stage=stage,
+        DataStream._registry.add(
+            create_subscriber(unique_id, data_topic, callback, ioloop, stage)
         )
         return unique_id
 
     @staticmethod
     def unsubscribe_data(data_topic: str, unique_id: uuid.UUID) -> None:
         """Unsubscribe from a topic using the Unique ID returned from subscribe_data."""
-        LOGGER.debug(f"Unsubscribing from data topic {data_topic}, {unique_id}")
-        if "*" in data_topic:
-            DataStream._wildcard_subscribers[data_topic].pop(unique_id)
-            return
-
-        DataStream._subscribers[data_topic].pop(unique_id)
+        LOGGER.debug("Unsubscribing from data topic %s, %s", data_topic, unique_id)
+        DataStream._registry.remove(data_topic, unique_id)
 
     @staticmethod
     def remove_all_subscriptions() -> None:
         """Remove all subscriptions."""
-        DataStream._subscribers.clear()
-        DataStream._wildcard_subscribers.clear()
+        DataStream._registry.clear()
 
-    async def run_callback_in_ioloop(
-        self,
-        callback: Callable,
-        data: Any,
-        ioloop: IOLoop,
-    ) -> None:
-        """Run callback in IOLoop."""
-
-        def _wrapper():
-            IOLoop.current()
-            if data:
-                callback(data)
-                return
-            callback()
-
-        if inspect.iscoroutinefunction(callback):
-            if data:
-                await callback(data)
-                return
-            await callback()
-        else:
-            await ioloop.run_in_executor(None, _wrapper)
-
-    def run_callbacks(
-        self,
-        callbacks: dict[uuid.UUID, DataSubscriber],
-        data: Any,
-    ) -> None:
-        """Run callbacks or put to queues."""
-        for callback in callbacks.copy().values():
-            if callable(callback["callback"]) and callback["ioloop"] is None:
-                name = f"data_stream.callback.{callback['callback']}"
-                daemon = bool(callback["stage"] is None)
-                if data:
-                    thread = RestartableThread(
-                        name=name,
-                        target=callback["callback"],
-                        args=(data,),
-                        daemon=daemon,
-                        register=False,
-                        stage=callback["stage"],
-                    )
-                else:
-                    thread = RestartableThread(
-                        name=name,
-                        target=callback["callback"],
-                        daemon=daemon,
-                        register=False,
-                        stage=callback["stage"],
-                    )
-
-                while True:
-                    # Check if we can start a new thread
-                    active_threads = threading.active_count()
-                    if active_threads > self._max_threads:
-                        time.sleep(0.01)
-                        continue
-
-                    try:
-                        thread.start()
-                    except RuntimeError as err:
-                        if "can't start new thread" in str(err):
-                            LOGGER.debug(
-                                "Unable to start new thread, "
-                                "Max threads: %s, Active threads: %s",
-                                self._max_threads,
-                                active_threads,
-                            )
-                            self._max_threads = int(active_threads * 0.95)
-                            continue
-                    break
-                continue
-
-            if callable(callback["callback"]) and callback["ioloop"] is not None:
-                callback["ioloop"].add_callback(
-                    self.run_callback_in_ioloop,
-                    callback["callback"],
-                    data,
-                    callback["ioloop"],
-                )
-                continue
-
-            if isinstance(callback["callback"], Queue):
-                helpers.pop_if_full(callback["callback"], data)
-                continue
-
-            if callback["ioloop"] is not None and isinstance(
-                callback["callback"], TornadoQueue
-            ):
-                callback["ioloop"].add_callback(
-                    helpers.pop_if_full,
-                    callback["callback"],
-                    data,
-                )
-                continue
-
-            LOGGER.error(
-                f"Callback {callback} is not valid. "
-                "Needs to be of type Callable, Queue or "
-                f"Tornado Queue with ioloop supplied, got {type(callback['callback'])}"
-            )
+    def run_callbacks(self, subscribers, data: Any) -> None:
+        """Deliver data to every given subscriber."""
+        for subscriber in subscribers:
+            self._dispatcher.deliver(subscriber, data)
 
     def static_subscriptions(self, data_item: dict[str, Any]) -> None:
         """Run callbacks for static subscriptions."""
         self.run_callbacks(
-            DataStream._subscribers.get(data_item["data_topic"], {}),
+            DataStream._registry.static_subscribers(data_item["data_topic"]),
             data_item["data"],
         )
 
     def wildcard_subscriptions(self, data_item: dict[str, Any]) -> None:
         """Run callbacks for wildcard subscriptions."""
-        for data_topic, callbacks in DataStream._wildcard_subscribers.copy().items():
-            if fnmatch.fnmatch(data_item["data_topic"], data_topic):
-                # LOGGER.debug(
-                #     f"Got data on topic {data_item['data_topic']} "
-                #     f"matching with subscriber on topic {data_topic}"
-                # )
+        self.run_callbacks(
+            DataStream._registry.wildcard_subscribers(data_item["data_topic"]),
+            data_item["data"],
+        )
 
-                self.run_callbacks(callbacks, data_item["data"])
+    def _dispatch(self, data_item: dict[str, Any]) -> None:
+        self.static_subscriptions(data_item)
+        self.wildcard_subscriptions(data_item)
+
+    def _drain_signals(self) -> None:
+        """Handle every pending signal before any queued data."""
+        while not DataStream._signal_queue.empty():
+            try:
+                self._dispatch(DataStream._signal_queue.get_nowait())
+            except Empty:
+                return
 
     def consume_data(self) -> None:
         """Publish data to topics."""
         while not self._kill_received:
+            self._drain_signals()
             try:
                 data_item = self._data_queue.get(timeout=0.1)
             except Empty:
                 continue
 
-            self.static_subscriptions(data_item)
-            self.wildcard_subscriptions(data_item)
+            self._dispatch(data_item)
+
+        self._drain_signals()
         LOGGER.debug("Data stream stopped")
 
     def join(self) -> None:
         """Join the data stream."""
         self._data_consumer.join()
+        self._dispatcher.shutdown()
 
     def stop(self) -> None:
         """Stop the data stream."""

--- a/viseron/components/data_stream/const.py
+++ b/viseron/components/data_stream/const.py
@@ -1,0 +1,27 @@
+"""data_stream constants."""
+
+from __future__ import annotations
+
+from typing import Final
+
+COMPONENT: Final = "data_stream"
+
+# Absorbs publisher bursts. Drained as fast as subscriber lookup allows.
+DATA_QUEUE_MAXSIZE: Final = 10000
+
+# Per subscriber backlog. A full queue drops its oldest instead of stalling the bus.
+SUBSCRIBER_QUEUE_MAXSIZE: Final = 1000
+
+# Shared by callback subscribers, sized for I/O bound work.
+CALLBACK_WORKERS: Final = 32
+
+# Signal topics bypass the bounded data queue so shutdown can never be dropped.
+SIGNAL_TOPIC_PREFIX: Final = "viseron/signal/"
+
+# Cleared past this size since wildcard patterns are user supplied.
+MATCH_CACHE_MAXSIZE: Final = 4096
+
+DROP_WARNING_INTERVAL: Final = 10.0
+
+# Publishing gives up after this many attempts to make room in a full queue.
+PUBLISH_MAX_ATTEMPTS: Final = 10

--- a/viseron/components/data_stream/delivery.py
+++ b/viseron/components/data_stream/delivery.py
@@ -1,0 +1,203 @@
+"""Delivery of published data to subscribers."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING, Any, cast
+
+from viseron.components.data_stream.const import (
+    CALLBACK_WORKERS,
+    DROP_WARNING_INTERVAL,
+    SUBSCRIBER_QUEUE_MAXSIZE,
+)
+from viseron.components.data_stream.subscriber import SubscriberKind, describe
+from viseron.helpers import pop_if_full
+from viseron.watchdog.thread_watchdog import RestartableThread
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from tornado.ioloop import IOLoop
+
+    from viseron.components.data_stream.subscriber import Subscriber
+
+LOGGER = logging.getLogger(__name__)
+
+
+class SerialDelivery:
+    """Deliver one subscriber's messages in publish order on a shared pool.
+
+    The backlog is bounded, so a subscriber that cannot keep up drops its own
+    oldest messages rather than stalling the bus for everyone else.
+    """
+
+    __slots__ = (
+        "_backlog",
+        "_dropped",
+        "_executor",
+        "_invoke",
+        "_last_warning",
+        "_lock",
+        "_maxsize",
+        "_running",
+        "_subscriber",
+    )
+
+    def __init__(
+        self,
+        executor: ThreadPoolExecutor,
+        subscriber: Subscriber,
+        invoke: Callable[[Subscriber, Any], None],
+        maxsize: int = SUBSCRIBER_QUEUE_MAXSIZE,
+    ) -> None:
+        self._executor = executor
+        self._subscriber = subscriber
+        self._invoke = invoke
+        self._maxsize = maxsize
+        self._backlog: deque[Any] = deque(maxlen=maxsize)
+        self._lock = threading.Lock()
+        self._running = False
+        self._dropped = 0
+        self._last_warning = 0.0
+
+    def submit(self, data: Any) -> None:
+        """Queue data for delivery, starting a drain task if one is not running."""
+        with self._lock:
+            if len(self._backlog) == self._maxsize:
+                self._dropped += 1
+                self._warn_dropped()
+            self._backlog.append(data)
+            if self._running:
+                return
+            self._running = True
+
+        try:
+            self._executor.submit(self._drain)
+        except RuntimeError:  # Executor already shut down
+            with self._lock:
+                self._running = False
+
+    def _warn_dropped(self) -> None:
+        """Warn about a saturated backlog, at most once per interval."""
+        now = time.time()
+        if now - self._last_warning < DROP_WARNING_INTERVAL:
+            return
+        self._last_warning = now
+        LOGGER.warning(
+            "Subscriber %s on data topic %s is too slow, dropped %s messages so far",
+            describe(self._subscriber),
+            self._subscriber.data_topic,
+            self._dropped,
+        )
+
+    def _drain(self) -> None:
+        while True:
+            with self._lock:
+                if not self._backlog:
+                    self._running = False
+                    return
+                data = self._backlog.popleft()
+
+            try:
+                self._invoke(self._subscriber, data)
+            except Exception:  # pylint: disable=broad-except
+                LOGGER.exception(
+                    f"Error in subscriber {describe(self._subscriber)} "
+                    f"on data topic {self._subscriber.data_topic}"
+                )
+
+
+class Dispatcher:
+    """Route published data to a subscriber using its resolved delivery kind."""
+
+    def __init__(self, workers: int = CALLBACK_WORKERS) -> None:
+        self._executor = ThreadPoolExecutor(
+            max_workers=workers, thread_name_prefix="data_stream_callback"
+        )
+
+    def deliver(self, subscriber: Subscriber, data: Any) -> None:
+        """Deliver data to a single subscriber."""
+        kind = subscriber.kind
+
+        if kind is SubscriberKind.QUEUE:
+            pop_if_full(subscriber.callback, data)  # type: ignore[arg-type]
+            return
+
+        if kind is SubscriberKind.TORNADO_QUEUE:
+            ioloop = cast("IOLoop", subscriber.ioloop)
+            ioloop.add_callback(pop_if_full, subscriber.callback, data)
+            return
+
+        if kind in (SubscriberKind.IOLOOP_CALLBACK, SubscriberKind.IOLOOP_COROUTINE):
+            ioloop = cast("IOLoop", subscriber.ioloop)
+            ioloop.add_callback(run_in_ioloop, subscriber, data)
+            return
+
+        if kind is SubscriberKind.SIGNAL_CALLBACK:
+            self._run_in_signal_thread(subscriber, data)
+            return
+
+        if subscriber.delivery is None:
+            subscriber.delivery = SerialDelivery(
+                self._executor, subscriber, _invoke_callback
+            )
+        subscriber.delivery.submit(data)
+
+    @staticmethod
+    def _run_in_signal_thread(subscriber: Subscriber, data: Any) -> None:
+        """Run a signal handler in its own non-daemon thread.
+
+        Viseron.shutdown enumerates live threads and joins the ones tagged with
+        the stage it is currently draining, so these must not share the pool.
+        """
+        args = () if data is None else (data,)
+        thread = RestartableThread(
+            name=subscriber.thread_name,
+            target=subscriber.callback,
+            args=args,
+            daemon=False,
+            register=False,
+            stage=subscriber.stage,
+        )
+        thread.start()
+
+    def shutdown(self) -> None:
+        """Stop accepting new callback deliveries."""
+        self._executor.shutdown(wait=False)
+
+
+def _invoke_callback(subscriber: Subscriber, data: Any) -> None:
+    """Call a plain callable subscriber."""
+    if data is None:
+        subscriber.callback()  # type: ignore[operator]
+        return
+    subscriber.callback(data)  # type: ignore[operator]
+
+
+async def run_in_ioloop(subscriber: Subscriber, data: Any) -> None:
+    """Run a callback on the subscriber's ioloop."""
+    callback = subscriber.callback
+    try:
+        if subscriber.kind is SubscriberKind.IOLOOP_COROUTINE:
+            if data is None:
+                await callback()  # type: ignore[operator]
+            else:
+                await callback(data)  # type: ignore[operator]
+            return
+
+        def _wrapper() -> None:
+            if data is None:
+                callback()  # type: ignore[operator]
+                return
+            callback(data)  # type: ignore[operator]
+
+        await cast("IOLoop", subscriber.ioloop).run_in_executor(None, _wrapper)
+    except Exception:  # pylint: disable=broad-except
+        LOGGER.exception(
+            f"Error in subscriber {describe(subscriber)} "
+            f"on data topic {subscriber.data_topic}"
+        )

--- a/viseron/components/data_stream/registry.py
+++ b/viseron/components/data_stream/registry.py
@@ -1,0 +1,118 @@
+"""Subscriber storage and topic matching for the data_stream component."""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+import re
+import threading
+from typing import TYPE_CHECKING
+
+from viseron.components.data_stream.const import MATCH_CACHE_MAXSIZE
+
+if TYPE_CHECKING:
+    import uuid
+
+    from viseron.components.data_stream.subscriber import Subscriber
+
+LOGGER = logging.getLogger(__name__)
+
+
+class SubscriberRegistry:
+    """Hold subscribers and resolve which ones a topic reaches.
+
+    Subscriber lists are stored as immutable tuples that are rebuilt on
+    subscribe/unsubscribe, so the publish path can iterate them without copying
+    or locking. Wildcard patterns are compiled once and the topics they match
+    are memoized, turning wildcard dispatch into a single dict lookup.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._static: dict[str, tuple[Subscriber, ...]] = {}
+        self._wildcard: dict[str, tuple[Subscriber, ...]] = {}
+        self._patterns: dict[str, re.Pattern[str]] = {}
+        self._match_cache: dict[str, tuple[Subscriber, ...]] = {}
+
+    @property
+    def topic_count(self) -> int:
+        """Return the number of topics that still have a subscriber."""
+        return len(self._static) + len(self._wildcard)
+
+    def add(self, subscriber: Subscriber) -> None:
+        """Register a subscriber."""
+        data_topic = subscriber.data_topic
+        with self._lock:
+            if "*" in data_topic:
+                self._wildcard[data_topic] = (
+                    *self._wildcard.get(data_topic, ()),
+                    subscriber,
+                )
+                if data_topic not in self._patterns:
+                    self._patterns[data_topic] = re.compile(
+                        fnmatch.translate(data_topic)
+                    )
+                self._match_cache.clear()
+                return
+
+            self._static[data_topic] = (*self._static.get(data_topic, ()), subscriber)
+
+    def remove(self, data_topic: str, unique_id: uuid.UUID) -> None:
+        """Unregister a subscriber.
+
+        Unknown topics and ids are ignored. Every unsub() closure handed out by
+        Viseron.listen_event runs during teardown, which is after shutdown has
+        already called clear().
+        """
+        with self._lock:
+            store = self._wildcard if "*" in data_topic else self._static
+            existing = store.get(data_topic)
+            if existing is None:
+                LOGGER.debug(f"No subscribers left on data topic {data_topic}")
+                return
+
+            remaining = tuple(
+                subscriber
+                for subscriber in existing
+                if subscriber.unique_id != unique_id
+            )
+            if remaining:
+                store[data_topic] = remaining
+            else:
+                del store[data_topic]
+                self._patterns.pop(data_topic, None)
+
+            if store is self._wildcard:
+                self._match_cache.clear()
+
+    def clear(self) -> None:
+        """Remove every subscriber."""
+        with self._lock:
+            self._static.clear()
+            self._wildcard.clear()
+            self._patterns.clear()
+            self._match_cache.clear()
+
+    def static_subscribers(self, data_topic: str) -> tuple[Subscriber, ...]:
+        """Return subscribers registered on an exact topic."""
+        return self._static.get(data_topic, ())
+
+    def wildcard_subscribers(self, data_topic: str) -> tuple[Subscriber, ...]:
+        """Return subscribers whose pattern matches a topic."""
+        if not self._wildcard:
+            return ()
+
+        cached = self._match_cache.get(data_topic)
+        if cached is not None:
+            return cached
+
+        with self._lock:
+            matched: tuple[Subscriber, ...] = ()
+            for pattern_topic, subscribers in self._wildcard.items():
+                if self._patterns[pattern_topic].match(data_topic):
+                    matched += subscribers
+
+            if len(self._match_cache) >= MATCH_CACHE_MAXSIZE:
+                self._match_cache.clear()
+            self._match_cache[data_topic] = matched
+            return matched

--- a/viseron/components/data_stream/subscriber.py
+++ b/viseron/components/data_stream/subscriber.py
@@ -1,0 +1,113 @@
+"""Subscriber representation for the data_stream component."""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass, field
+from enum import IntEnum, auto
+from queue import Queue
+from typing import TYPE_CHECKING, Any
+
+from tornado.queues import Queue as TornadoQueue
+
+if TYPE_CHECKING:
+    import uuid
+    from collections.abc import Callable
+
+    from tornado.ioloop import IOLoop
+
+    from viseron.components.data_stream.delivery import SerialDelivery
+
+
+class SubscriberKind(IntEnum):
+    """How a subscriber wants its data delivered."""
+
+    CALLBACK = auto()
+    SIGNAL_CALLBACK = auto()
+    IOLOOP_CALLBACK = auto()
+    IOLOOP_COROUTINE = auto()
+    QUEUE = auto()
+    TORNADO_QUEUE = auto()
+
+
+@dataclass(slots=True, eq=False)
+class Subscriber:
+    """A single subscription with its delivery strategy resolved up front.
+
+    Resolving the kind, the thread name and coroutine-ness here keeps the
+    publish path free of introspection, which runs for every message.
+    """
+
+    unique_id: uuid.UUID
+    data_topic: str
+    callback: Callable | Queue | TornadoQueue
+    ioloop: IOLoop | None
+    stage: str | None
+    kind: SubscriberKind
+    thread_name: str | None = None
+    delivery: SerialDelivery | None = field(default=None, repr=False)
+
+
+def resolve_kind(
+    callback: Callable | Queue | TornadoQueue,
+    ioloop: IOLoop | None,
+    stage: str | None,
+) -> SubscriberKind:
+    """Determine how a subscriber must be invoked.
+
+    Raises:
+        ValueError: If the subscriber could never be delivered to.
+    """
+    if isinstance(callback, TornadoQueue):
+        if ioloop is None:
+            raise ValueError(
+                f"Tornado Queue subscriber {callback} requires an ioloop to be "
+                "delivered to"
+            )
+        return SubscriberKind.TORNADO_QUEUE
+
+    if isinstance(callback, Queue):
+        return SubscriberKind.QUEUE
+
+    if callable(callback):
+        if ioloop is not None:
+            if inspect.iscoroutinefunction(callback):
+                return SubscriberKind.IOLOOP_COROUTINE
+            return SubscriberKind.IOLOOP_CALLBACK
+        if stage is not None:
+            return SubscriberKind.SIGNAL_CALLBACK
+        return SubscriberKind.CALLBACK
+
+    raise ValueError(
+        f"{callback} of type {type(callback)} is not a valid subscriber. "
+        "Needs to be of type Callable, Queue or Tornado Queue with ioloop supplied"
+    )
+
+
+def create_subscriber(
+    unique_id: uuid.UUID,
+    data_topic: str,
+    callback: Callable | Queue | TornadoQueue,
+    ioloop: IOLoop | None,
+    stage: str | None,
+) -> Subscriber:
+    """Build a Subscriber, validating that it can be delivered to."""
+    kind = resolve_kind(callback, ioloop, stage)
+    thread_name: str | None = None
+    if kind is SubscriberKind.SIGNAL_CALLBACK:
+        thread_name = f"data_stream.callback.{callback}"
+
+    return Subscriber(
+        unique_id=unique_id,
+        data_topic=data_topic,
+        callback=callback,
+        ioloop=ioloop,
+        stage=stage,
+        kind=kind,
+        thread_name=thread_name,
+    )
+
+
+def describe(subscriber: Subscriber) -> Any:
+    """Return a loggable description of a subscriber."""
+    return subscriber.thread_name or subscriber.callback


### PR DESCRIPTION
This PR refactors the data_stream component (the Viseron event bus)

This provides a number of benefits:
- No need to check the `ulimit` anymore since a shared ThreadPoolExecutor is used
- Shutdown signals are now fast tracked and are never dropped
- Slow subscribers now only affect themselves and wont slow any other subscriber
- A single subscribers callbacks are now guaranteed to never run more than one at a time