### PR TITLE
fix: transcode browser-incompatible recording codecs

### DIFF
--- a/docs/src/pages/components-explorer/components/ffmpeg/config.json
+++ b/docs/src/pages/components-explorer/components/ffmpeg/config.json
@@ -2644,7 +2644,7 @@
                   {
                     "type": "string",
                     "name": "codec",
-                    "description": "FFmpeg video encoder codec, eg <code>h264_nvenc</code>. Defaults to <code>copy</code> except for MJPEG streams where the default is <code>h264</code>.",
+                    "description": "FFmpeg video encoder codec, eg <code>h264_nvenc</code>. Defaults to <code>copy</code>. MJPEG and MPEG-4 Part 2 (<code>mpeg4</code>/<code>mp4v</code>) streams default to <code>h264</code> for browser-compatible recordings.",
                     "optional": true,
                     "default": null
                   },

--- a/docs/src/pages/components-explorer/components/gstreamer/config.json
+++ b/docs/src/pages/components-explorer/components/gstreamer/config.json
@@ -2383,7 +2383,7 @@
                   {
                     "type": "string",
                     "name": "codec",
-                    "description": "FFmpeg video encoder codec, eg <code>h264_nvenc</code>. Defaults to <code>copy</code> except for MJPEG streams where the default is <code>h264</code>.",
+                    "description": "FFmpeg video encoder codec, eg <code>h264_nvenc</code>. Defaults to <code>copy</code>. MJPEG and MPEG-4 Part 2 (<code>mpeg4</code>/<code>mp4v</code>) streams default to <code>h264</code> for browser-compatible recordings.",
                     "optional": true,
                     "default": null
                   },

--- a/tests/components/ffmpeg/test_stream.py
+++ b/tests/components/ffmpeg/test_stream.py
@@ -371,27 +371,31 @@ class TestStream:
             )
 
     @pytest.mark.parametrize(
-        "stream_format, codec, expected_args",
+        "stream_format, stream_codec, recorder_codec, expected_args",
         [
-            ("mjpeg", "h264", ["-tune", "zerolatency"]),
-            ("mjpeg", "hevc", []),
-            ("mjpeg", UNDEFINED, ["-tune", "zerolatency"]),
-            ("rtsp", None, []),
-            ("rtsp", UNDEFINED, []),
-            ("rtmp", None, []),
-            ("rtmp", UNDEFINED, []),
+            ("mjpeg", None, "h264", ["-tune", "zerolatency"]),
+            ("mjpeg", None, "hevc", []),
+            ("mjpeg", None, UNDEFINED, ["-tune", "zerolatency"]),
+            ("rtsp", "mjpeg", "libx264", ["-tune", "zerolatency"]),
+            ("rtsp", "mjpeg", "hevc", []),
+            ("rtsp", "mjpeg", UNDEFINED, ["-tune", "zerolatency"]),
+            ("rtsp", "h264", UNDEFINED, []),
+            ("rtmp", "h264", UNDEFINED, []),
         ],
     )
-    def test_encoder_tuning_args(self, stream_format, codec, expected_args) -> None:
+    def test_encoder_tuning_args(
+        self, stream_format, stream_codec, recorder_codec, expected_args
+    ) -> None:
         """Test that encoder tuning args are only added for MJPEG streams."""
         with patch.object(
             Stream, "__init__", MagicMock(spec=Stream, return_value=None)
         ):
             stream = Stream.__new__(Stream)
+            stream._mainstream = MagicMock(codec=stream_codec)
             stream._config = {
                 CONFIG_STREAM_FORMAT: stream_format,
                 CONFIG_RECORDER: {
-                    CONFIG_RECORDER_CODEC: codec,
+                    CONFIG_RECORDER_CODEC: recorder_codec,
                 },
             }
             mock_logger = MagicMock()
@@ -400,25 +404,37 @@ class TestStream:
             assert result == expected_args
 
     @pytest.mark.parametrize(
-        "stream_format, expected_args",
+        "stream_format, stream_codec, expected_args",
         [
             (
+                "mjpeg",
+                None,
+                [
+                    "-force_key_frames",
+                    f"expr:gte(t,n_forced*{CAMERA_SEGMENT_DURATION})",
+                ],
+            ),
+            (
+                "rtsp",
                 "mjpeg",
                 [
                     "-force_key_frames",
                     f"expr:gte(t,n_forced*{CAMERA_SEGMENT_DURATION})",
                 ],
             ),
-            ("rtsp", []),
-            ("rtmp", []),
+            ("rtsp", "h264", []),
+            ("rtmp", "h264", []),
         ],
     )
-    def test_force_keyframe_args(self, stream_format, expected_args) -> None:
+    def test_force_keyframe_args(
+        self, stream_format, stream_codec, expected_args
+    ) -> None:
         """Test that force keyframe args are only added for MJPEG streams."""
         with patch.object(
             Stream, "__init__", MagicMock(spec=Stream, return_value=None)
         ):
             stream = Stream.__new__(Stream)
+            stream._mainstream = MagicMock(codec=stream_codec)
             stream._config = {
                 CONFIG_STREAM_FORMAT: stream_format,
             }
@@ -426,21 +442,26 @@ class TestStream:
             assert result == expected_args
 
     @pytest.mark.parametrize(
-        "recorder_codec, stream_format, expected_cmd",
+        "recorder_codec, stream_format, stream_codec, expected_cmd",
         [
-            # MJPEG with no user-set codec should auto-convert to h264
-            (UNDEFINED, "mjpeg", ["-c:v", "h264"]),
-            # Non-MJPEG with no user-set codec should copy
-            (UNDEFINED, "rtsp", ["-c:v", "copy"]),
-            (UNDEFINED, "rtmp", ["-c:v", "copy"]),
+            # MJPEG transport with no user-set codec should auto-convert to h264
+            (UNDEFINED, "mjpeg", None, ["-c:v", "h264"]),
+            # Browser-incompatible source codecs should auto-convert to h264
+            (UNDEFINED, "rtsp", "mjpeg", ["-c:v", "h264"]),
+            (UNDEFINED, "rtsp", "mpeg4", ["-c:v", "h264"]),
+            (UNDEFINED, "rtmp", "mp4v", ["-c:v", "h264"]),
+            # Browser-compatible source codecs should be copied
+            (UNDEFINED, "rtsp", "h264", ["-c:v", "copy"]),
+            (UNDEFINED, "rtmp", "hevc", ["-c:v", "copy"]),
             # User-set codec should always take precedence
-            ("libx264", "mjpeg", ["-c:v", "libx264"]),
-            ("h264_nvenc", "rtsp", ["-c:v", "h264_nvenc"]),
-            ("hevc", "rtmp", ["-c:v", "hevc"]),
+            ("libx264", "mjpeg", None, ["-c:v", "libx264"]),
+            ("h264_nvenc", "rtsp", "mjpeg", ["-c:v", "h264_nvenc"]),
+            ("hevc", "rtsp", "mpeg4", ["-c:v", "hevc"]),
+            ("copy", "rtmp", "h264", ["-c:v", "copy"]),
         ],
     )
     def test_get_encoder_codec(
-        self, recorder_codec, stream_format, expected_cmd
+        self, recorder_codec, stream_format, stream_codec, expected_cmd
     ) -> None:
         """Test that the correct encoder codec is returned."""
         with patch.object(
@@ -448,6 +469,7 @@ class TestStream:
         ):
             stream = Stream.__new__(Stream)
             stream._logger = MagicMock()
+            stream._mainstream = MagicMock(codec=stream_codec)
             stream._config = {
                 CONFIG_STREAM_FORMAT: stream_format,
                 CONFIG_RECORDER: {

--- a/viseron/components/ffmpeg/const.py
+++ b/viseron/components/ffmpeg/const.py
@@ -162,8 +162,9 @@ DEFAULT_SEGMENTS_FOLDER = "/segments"
 DESC_RECORDER_HWACCEL_ARGS = "FFmpeg encoder hardware acceleration arguments."
 DESC_RECORDER_CODEC = (
     "FFmpeg video encoder codec, eg <code>h264_nvenc</code>. "
-    "Defaults to <code>copy</code> except for MJPEG streams where the default is "
-    "<code>h264</code>."
+    "Defaults to <code>copy</code>. MJPEG and MPEG-4 Part 2 "
+    "(<code>mpeg4</code>/<code>mp4v</code>) streams default to <code>h264</code> "
+    "for browser-compatible recordings."
 )
 DESC_RECORDER_AUDIO_CODEC = (
     "FFmpeg audio encoder codec, eg <code>aac</code>.<br>"

--- a/viseron/components/ffmpeg/stream.py
+++ b/viseron/components/ffmpeg/stream.py
@@ -313,13 +313,22 @@ class Stream:
         return []
 
     @property
+    def is_mjpeg_stream(self) -> bool:
+        """Return whether the mainstream contains MJPEG video."""
+        return (
+            self._config[CONFIG_STREAM_FORMAT] == "mjpeg"
+            or self._mainstream.codec.lower() == "mjpeg"
+        )
+
+    @property
     def encoder_codec(self) -> str:
         """Return encoder codec set in config."""
         if self._config[CONFIG_RECORDER][CONFIG_RECORDER_CODEC] != UNDEFINED:
             return self._config[CONFIG_RECORDER][CONFIG_RECORDER_CODEC]
-        if self._config[CONFIG_STREAM_FORMAT] == "mjpeg":
+        if self.is_mjpeg_stream or self._mainstream.codec.lower() in ["mpeg4", "mp4v"]:
             self._logger.warning(
-                "MJPEG stream detected. Defaulting to h264 encoder codec. "
+                "Browser-incompatible stream codec detected. Defaulting to h264 "
+                "encoder codec. "
                 "Consider setting `codec: h264` under the cameras `recorder` "
                 "section in your config.yaml to avoid this warning. "
             )
@@ -422,9 +431,7 @@ class Stream:
         causing a delay in the output.
         Using -tune zerolatency eliminates this buffering delay.
         """
-        if self._config[
-            CONFIG_STREAM_FORMAT
-        ] == "mjpeg" and self.encoder_codec.lower() in [
+        if self.is_mjpeg_stream and self.encoder_codec.lower() in [
             "libx264",
             "h264",
         ]:
@@ -438,7 +445,7 @@ class Stream:
         MJPEG streams. Force keyframes at the segment
         duration interval to ensure segments are created.
         """
-        if self._config[CONFIG_STREAM_FORMAT] == "mjpeg":
+        if self.is_mjpeg_stream:
             return [
                 "-force_key_frames",
                 f"expr:gte(t,n_forced*{CAMERA_SEGMENT_DURATION})",


### PR DESCRIPTION
Make the automatic recorder encoder decision consider the probed mainstream video codec as well as the configured stream format, while retaining an explicitly configured recorder codec as the highest-priority override. Recording playback can fail with blank video and repeated HLS.js SourceBuffer errors even though the segment files exist.

With no recorder codec override and a probed MPEG-4 Part 2 (`mpeg4`/`mp4v`) mainstream, encoder arguments select H.264 instead of stream copy, preventing an unsupported `mp4v` HLS SourceBuffer type; With no override and a probed MJPEG mainstream delivered over RTSP, encoder arguments select H.264 and the existing MJPEG keyframe/tuning behavior remains enabled.

Closes #1171
