### PR TITLE
fix: quote environment and Postgres paths in Docker init

### DIFF
--- a/rootfs/etc/cont-init.d/40-set-env-vars
+++ b/rootfs/etc/cont-init.d/40-set-env-vars
@@ -6,7 +6,7 @@ mkdir -p /var/run/environment
 
 # Set Viseron config directory
 log_info "************* Setting Viseron config dir *****************"
-printf $VISERON_CONFIG_DIR > /var/run/environment/VISERON_CONFIG_DIR
+printf '%s' "$VISERON_CONFIG_DIR" > /var/run/environment/VISERON_CONFIG_DIR
 log_info "Viseron config dir: $VISERON_CONFIG_DIR"
 log_info "*********************** Done *****************************"
 
@@ -65,9 +65,9 @@ printf "/home/abc" > /var/run/environment/HOME
 export PG_VERSION=$(psql --version | awk '{print $3}' | awk -F'.' '{print $1}')
 export PG_BIN="/usr/lib/postgresql/$PG_VERSION/bin"
 export PGDATA=${VISERON_PGDATA_DIR:-$VISERON_CONFIG_DIR/postgresql}
-printf "$PG_VERSION" > /var/run/environment/PG_VERSION
-printf "$PG_BIN" > /var/run/environment/PG_BIN
-printf "$PGDATA" > /var/run/environment/PGDATA
+printf '%s' "$PG_VERSION" > /var/run/environment/PG_VERSION
+printf '%s' "$PG_BIN" > /var/run/environment/PG_BIN
+printf '%s' "$PGDATA" > /var/run/environment/PGDATA
 log_info "PostgreSQL major version: $PG_VERSION"
 log_info "PostgreSQL bin: $PG_BIN"
 log_info "PostgreSQL data dir: $PGDATA"

--- a/rootfs/etc/cont-init.d/80-postgres
+++ b/rootfs/etc/cont-init.d/80-postgres
@@ -12,20 +12,20 @@ if [ -n "$POSTGRES_DATABASE_URL" ]; then
   exit 0
 fi
 
-mkdir -p $PGDATA /var/run/postgresql
-chown -R postgres:abc $PGDATA /var/run/postgresql
+mkdir -p "$PGDATA" /var/run/postgresql
+chown -R postgres:abc "$PGDATA" /var/run/postgresql
 
 init_db() {
   path=$1
   createdb=${2:-true}
   log_info "Database has not been initialized. Initializing..."
-  s6-setuidgid postgres $PG_BIN/initdb -D $path
+  s6-setuidgid postgres "$PG_BIN/initdb" -D "$path"
   if [ "$createdb" = true ]; then
     log_info "Starting PostgreSQL..."
-    s6-setuidgid postgres $PG_BIN/pg_ctl -D $path -l $path/logfile start
+    s6-setuidgid postgres "$PG_BIN/pg_ctl" -D "$path" -l "$path/logfile" start
     create_db
     log_info "Stopping PostgreSQL..."
-    s6-setuidgid postgres $PG_BIN/pg_ctl -D $path -l $path/logfile stop
+    s6-setuidgid postgres "$PG_BIN/pg_ctl" -D "$path" -l "$path/logfile" stop
   fi
 }
 
@@ -40,7 +40,7 @@ create_db() {
 }
 
 upgrade_db() {
-  old_version=$(cat $PGDATA/PG_VERSION)
+  old_version=$(cat "$PGDATA/PG_VERSION")
   log_warning "Upgrading database to new PostgreSQL version..."
 
   log_info "Installing PostgreSQL $old_version..."
@@ -53,14 +53,14 @@ upgrade_db() {
   fi
 
   new_db_path=/tmp/postgresql
-  mkdir -p $new_db_path
-  chown postgres:abc $new_db_path
-  init_db $new_db_path false
+  mkdir -p "$new_db_path"
+  chown postgres:abc "$new_db_path"
+  init_db "$new_db_path" false
 
   # Make sure that the rolname for oid 10 is postgres
   # In previous versions the database superuser was set to abc which breaks pg_upgrade
   log_info "Starting PostgreSQL..."
-  s6-setuidgid postgres /usr/lib/postgresql/$old_version/bin/pg_ctl -D $PGDATA -l $PGDATA/logfile start
+  s6-setuidgid postgres "/usr/lib/postgresql/$old_version/bin/pg_ctl" -D "$PGDATA" -l "$PGDATA/logfile" start
   PG_SUPERUSER=$(s6-setuidgid postgres psql -q -d viseron -tc "SELECT rolname FROM pg_roles WHERE oid = 10;" | xargs)
   if [ "$PG_SUPERUSER" != "postgres" ]; then
     log_info "Changing superuser role name to postgres..."
@@ -69,20 +69,21 @@ upgrade_db() {
     log_info "Dropping old postgres user..."
     s6-setuidgid postgres psql -d viseron -U temp -c 'DROP ROLE "postgres";'
     log_info "Renaming old superuser to postgres..."
-    s6-setuidgid postgres psql -d viseron -U temp -c "ALTER ROLE $PG_SUPERUSER RENAME TO postgres;"
+    pg_ident=${PG_SUPERUSER//\"/\"\"}
+    s6-setuidgid postgres psql -d viseron -U temp -c "ALTER ROLE \"${pg_ident}\" RENAME TO postgres;"
     log_info "Dropping temporary superuser..."
     s6-setuidgid postgres psql -d viseron -c 'DROP ROLE "temp";'
     log_info "Create abc user"
     s6-setuidgid postgres createuser abc
   fi
   log_info "Stopping PostgreSQL..."
-  s6-setuidgid postgres /usr/lib/postgresql/$old_version/bin/pg_ctl -D $PGDATA -l $PGDATA/logfile stop
+  s6-setuidgid postgres "/usr/lib/postgresql/$old_version/bin/pg_ctl" -D "$PGDATA" -l "$PGDATA/logfile" stop
 
   log_info "Running pg_upgrade..."
-  cd $new_db_path
-  if ! s6-setuidgid postgres $PG_BIN/pg_upgrade -b /usr/lib/postgresql/$old_version/bin -B $PG_BIN -d $PGDATA -D $new_db_path; then
+  cd "$new_db_path"
+  if ! s6-setuidgid postgres "$PG_BIN/pg_upgrade" -b "/usr/lib/postgresql/$old_version/bin" -B "$PG_BIN" -d "$PGDATA" -D "$new_db_path"; then
     log_error "pg_upgrade failed. Aborting upgrade to preserve data."
-    rm -rf $new_db_path
+    rm -rf "$new_db_path"
     return 1
   fi
 
@@ -91,25 +92,25 @@ upgrade_db() {
   apt-get autoremove -y
   rm -rf /var/lib/apt/lists/*
 
-  mv $PGDATA $PGDATA-$old_version
-  chown -R abc:abc $PGDATA-$old_version
-  mv $new_db_path $PGDATA
+  mv "$PGDATA" "$PGDATA-$old_version"
+  chown -R abc:abc "$PGDATA-$old_version"
+  mv "$new_db_path" "$PGDATA"
   log_info "Upgrade complete. It is recommended to remove the old database files: $PGDATA-$old_version"
 }
 
-if [ -e $PGDATA/PG_VERSION ]; then
+if [ -e "$PGDATA/PG_VERSION" ]; then
   log_info "Database has already been initialized."
-  DATABASE_VERSION=$(cat $PGDATA/PG_VERSION)
-  if [ $DATABASE_VERSION != $PG_VERSION ]; then
+  DATABASE_VERSION=$(cat "$PGDATA/PG_VERSION")
+  if [ "$DATABASE_VERSION" != "$PG_VERSION" ]; then
     log_warning "Database version ($DATABASE_VERSION) is not the same as the installed PostgreSQL version ($PG_VERSION)."
     upgrade_db
   fi
 else
-  init_db $PGDATA
+  init_db "$PGDATA"
 fi
 
 log_info "Updating PostgreSQL configuration..."
 # Disable checkpoint logging to reduce log noise
-sed -i 's/^#log_checkpoints = on/log_checkpoints = off/' $PGDATA/postgresql.conf
+sed -i 's/^#log_checkpoints = on/log_checkpoints = off/' "$PGDATA/postgresql.conf"
 
 log_info "*********************** Done *****************************"

--- a/rootfs/etc/services.d/postgres/run
+++ b/rootfs/etc/services.d/postgres/run
@@ -10,7 +10,7 @@ if [ -n "$POSTGRES_DATABASE_URL" ]; then
   exit 0
 fi
 
-rm -f $VISERON_CONFIG_DIR/postgres.log
+rm -f "${VISERON_CONFIG_DIR}/postgres.log"
 
 log_info "Starting PostgreSQL Server..."
-exec s6-setuidgid postgres $PG_BIN/postgres -D $PGDATA 2>&1 | tee -a $VISERON_CONFIG_DIR/postgres.log
+exec s6-setuidgid postgres "$PG_BIN/postgres" -D "$PGDATA" 2>&1 | tee -a "${VISERON_CONFIG_DIR}/postgres.log"

--- a/rootfs/helpers/set_env.sh
+++ b/rootfs/helpers/set_env.sh
@@ -2,5 +2,8 @@
 
 # Loop over files in /var/run/environment and export them
 for file in /var/run/environment/*; do
-  export $(basename $file)=$(cat $file)
+  [ -f "$file" ] || continue
+  name="$(basename "$file")"
+  # Preserve values with spaces or glob characters (e.g. database URLs).
+  export "${name}=$(cat "$file")"
 done


### PR DESCRIPTION
## Summary

- Exporting `/var/run/environment` via unquoted `export $(basename $file)=$(cat $file)` broke values with spaces (database URLs, passwords) and could mis-parse filenames.
- `printf $PATH` treated `%` in config paths as a format string.
- Quote Postgres data paths throughout init/upgrade, and identifier-quote the superuser rename during `pg_upgrade`.

## Test plan

- [x] `bash -n` on `set_env.sh`, `40-set-env-vars`, `80-postgres`, and `postgres/run`
- [x] Replayed the new export loop with values containing spaces and `|`
- [x] Confirmed `printf '%s'` preserves a path containing `%s`; unquoted `printf` does not
- [x] Confirmed `"$` in a role name is doubled for a Postgres identifier
- Container-level Postgres upgrade was not run here