### PR TITLE
fix: do not let /files query params rewrite into arbitrary directories

### DIFF
--- a/tests/components/webserver/api/v1/test_download.py
+++ b/tests/components/webserver/api/v1/test_download.py
@@ -1,0 +1,57 @@
+"""Test the Download API handler."""
+
+from __future__ import annotations
+
+import os
+import shutil
+
+from viseron.components.webserver.download_token import DownloadToken
+
+from tests.components.webserver.common import TestAppBaseNoAuth
+
+DOWNLOAD_DIR = "/tmp/viseron/test/download"
+
+
+class TestDownloadApiHandler(TestAppBaseNoAuth):
+    """Test the DownloadAPIHandler."""
+
+    def _add_download_token(self, filename: str) -> None:
+        """Write a file and register a download token pointing at it."""
+        os.makedirs(DOWNLOAD_DIR, exist_ok=True)
+        with open(os.path.join(DOWNLOAD_DIR, filename), "wb") as download_file:
+            download_file.write(b"test")
+        self.webserver.download_tokens["token"] = DownloadToken(
+            filename=os.path.join(DOWNLOAD_DIR, filename),
+            token="token",
+            delete_after_download=False,
+        )
+
+    def test_download(self):
+        """Test downloading a file."""
+        self._add_download_token("recording.mp4")
+        response = self.fetch("/api/v1/download?token=token")
+        assert response.code == 200
+        assert response.body == b"test"
+        assert (
+            response.headers["Content-Disposition"]
+            == 'attachment; filename="recording.mp4"'
+        )
+        shutil.rmtree(DOWNLOAD_DIR)
+
+    def test_download_unsafe_filename(self):
+        """Test that a basename with CR/LF or quotes cannot split headers."""
+        self._add_download_token('evil"\r\nX-Injected: yes.mp4')
+        response = self.fetch("/api/v1/download?token=token")
+        assert response.code == 200
+        assert response.body == b"test"
+        assert (
+            response.headers["Content-Disposition"]
+            == 'attachment; filename="download.mp4"'
+        )
+        assert "X-Injected" not in response.headers
+        shutil.rmtree(DOWNLOAD_DIR)
+
+    def test_download_token_not_found(self):
+        """Test downloading with an unknown token."""
+        response = self.fetch("/api/v1/download?token=missing")
+        assert response.code == 404

--- a/tests/components/webserver/test_tiered_file_handler.py
+++ b/tests/components/webserver/test_tiered_file_handler.py
@@ -32,6 +32,28 @@ def test_rewrite_tier_hint_path_allows_configured_tiers():
     assert rewritten == "/tmp/viseron/tier2/cam/seg.m4s"
 
 
+def test_rewrite_tier_hint_path_normalizes_trailing_slashes():
+    """Trailing slashes in configured tier paths must not break the rewrite."""
+    rewritten = rewrite_tier_hint_path(
+        "/tmp/viseron/tier1/cam/seg.m4s",
+        "/tmp/viseron/tier1/",
+        "/tmp/viseron/tier2/",
+        ["/tmp/viseron/tier1/", "/tmp/viseron/tier2/"],
+    )
+    assert rewritten == "/tmp/viseron/tier2/cam/seg.m4s"
+
+
+def test_rewrite_tier_hint_path_handles_root_tier():
+    """A root-like tier path is contained correctly and joined without gluing."""
+    rewritten = rewrite_tier_hint_path(
+        "/cam/seg.m4s",
+        "/",
+        "/tmp/viseron/tier2",
+        ["/", "/tmp/viseron/tier2"],
+    )
+    assert rewritten == "/tmp/viseron/tier2/cam/seg.m4s"
+
+
 def test_rewrite_tier_hint_path_rejects_unconfigured_actual():
     """A client must not point actual_tier_path at an arbitrary directory."""
     rewritten = rewrite_tier_hint_path(

--- a/tests/components/webserver/test_tiered_file_handler.py
+++ b/tests/components/webserver/test_tiered_file_handler.py
@@ -54,6 +54,39 @@ def test_rewrite_tier_hint_path_handles_root_tier():
     assert rewritten == "/tmp/viseron/tier2/cam/seg.m4s"
 
 
+def test_rewrite_tier_hint_path_allows_tier_root():
+    """A hint for the tier root itself rewrites to the actual tier root."""
+    rewritten = rewrite_tier_hint_path(
+        "/tmp/viseron/tier1",
+        "/tmp/viseron/tier1",
+        "/tmp/viseron/tier2",
+        ["/tmp/viseron/tier1", "/tmp/viseron/tier2"],
+    )
+    assert rewritten == "/tmp/viseron/tier2"
+
+
+def test_rewrite_tier_hint_path_rejects_path_outside_first_tier():
+    """A path that does not live under first_tier_path is not rewritten."""
+    rewritten = rewrite_tier_hint_path(
+        "/tmp/viseron/tier2/cam/seg.m4s",
+        "/tmp/viseron/tier1",
+        "/tmp/viseron/tier2",
+        ["/tmp/viseron/tier1", "/tmp/viseron/tier2"],
+    )
+    assert rewritten is None
+
+
+def test_rewrite_tier_hint_path_rejects_relative_tier():
+    """A relative tier path cannot be compared against an absolute path."""
+    rewritten = rewrite_tier_hint_path(
+        "/tmp/viseron/tier1/cam/seg.m4s",
+        "tier1",
+        "/tmp/viseron/tier2",
+        ["tier1", "/tmp/viseron/tier2"],
+    )
+    assert rewritten is None
+
+
 def test_rewrite_tier_hint_path_rejects_unconfigured_actual():
     """A client must not point actual_tier_path at an arbitrary directory."""
     rewritten = rewrite_tier_hint_path(
@@ -83,15 +116,15 @@ class TestTieredFileHandler(TestAppBaseNoAuth):
         """Return an app with fake endpoints."""
         return tornado.web.Application()
 
-    def test_get(self):
-        """Test get."""
+    def _setup_tiers(self) -> tuple[str, str]:
+        """Register handlers and tier handlers for two tiers."""
         storage: Storage = self.vis.data[STORAGE_COMPONENT]
         storage.camera_requested_files_count["test_camera"] = RequestedFilesCount()
 
         tier1 = "/tmp/viseron/test/tier1"
         tier2 = "/tmp/viseron/test/tier2"
-        os.makedirs("/tmp/viseron/test/tier1", exist_ok=True)
-        os.makedirs("/tmp/viseron/test/tier2", exist_ok=True)
+        os.makedirs(tier1, exist_ok=True)
+        os.makedirs(tier2, exist_ok=True)
 
         self._app.add_handlers(
             r".*",
@@ -133,6 +166,11 @@ class TestTieredFileHandler(TestAppBaseNoAuth):
         storage._camera_tier_handlers["test_camera"]["recorder"].append(
             {"segmments": tier_handler2}
         )
+        return tier1, tier2
+
+    def test_get(self):
+        """Test get."""
+        tier1, tier2 = self._setup_tiers()
 
         # Test accessing file from tier 2 with tier 1 path
         with open(f"{tier2}/test1.jpg", "wb") as tier2_file:
@@ -149,6 +187,39 @@ class TestTieredFileHandler(TestAppBaseNoAuth):
         response = self.fetch(f"/files{tier1}/test2.jpg")
         assert response.code == 200
         assert response.body == b"test2"
+        assert "Redirecting to" not in self._caplog.text
+
+        shutil.rmtree(tier1)
+        shutil.rmtree(tier2)
+
+    def test_get_tier_hint(self):
+        """Test that a tier hint between configured tiers is followed."""
+        tier1, tier2 = self._setup_tiers()
+
+        with open(f"{tier2}/test1.jpg", "wb") as tier2_file:
+            tier2_file.write(b"test1")
+        response = self.fetch(
+            f"/files{tier1}/test1.jpg?first_tier_path={tier1}&actual_tier_path={tier2}"
+        )
+        assert response.code == 200
+        assert response.body == b"test1"
+        assert f"adjusted path to {tier2}/test1.jpg" in self._caplog.text
+
+        shutil.rmtree(tier1)
+        shutil.rmtree(tier2)
+
+    def test_get_tier_hint_unconfigured_path(self):
+        """Test that a tier hint pointing outside the tiers is ignored."""
+        tier1, tier2 = self._setup_tiers()
+
+        with open(f"{tier1}/test2.jpg", "wb") as tier1_file:
+            tier1_file.write(b"test2")
+        response = self.fetch(
+            f"/files{tier1}/test2.jpg?first_tier_path={tier1}&actual_tier_path=/etc"
+        )
+        assert response.code == 200
+        assert response.body == b"test2"
+        assert "Ignoring tier hint with unconfigured paths" in self._caplog.text
         assert "Redirecting to" not in self._caplog.text
 
         shutil.rmtree(tier1)

--- a/tests/components/webserver/test_tiered_file_handler.py
+++ b/tests/components/webserver/test_tiered_file_handler.py
@@ -10,12 +10,48 @@ import tornado.web
 
 from viseron.components.storage import RequestedFilesCount
 from viseron.components.storage.const import COMPONENT as STORAGE_COMPONENT, CONFIG_PATH
-from viseron.components.webserver.tiered_file_handler import TieredFileHandler
+from viseron.components.webserver.tiered_file_handler import (
+    TieredFileHandler,
+    rewrite_tier_hint_path,
+)
 
 from tests.components.webserver.common import TestAppBaseNoAuth
 
 if TYPE_CHECKING:
     from viseron.components.storage import Storage
+
+
+def test_rewrite_tier_hint_path_allows_configured_tiers():
+    """Legitimate HLS hints rewrite first-tier paths onto the actual tier."""
+    rewritten = rewrite_tier_hint_path(
+        "/tmp/viseron/tier1/cam/seg.m4s",
+        "/tmp/viseron/tier1",
+        "/tmp/viseron/tier2",
+        ["/tmp/viseron/tier1", "/tmp/viseron/tier2"],
+    )
+    assert rewritten == "/tmp/viseron/tier2/cam/seg.m4s"
+
+
+def test_rewrite_tier_hint_path_rejects_unconfigured_actual():
+    """A client must not point actual_tier_path at an arbitrary directory."""
+    rewritten = rewrite_tier_hint_path(
+        "/tmp/viseron/tier1/cam/seg.m4s",
+        "/tmp/viseron/tier1",
+        "/etc",
+        ["/tmp/viseron/tier1", "/tmp/viseron/tier2"],
+    )
+    assert rewritten is None
+
+
+def test_rewrite_tier_hint_path_rejects_prefix_trick():
+    """first_tier_path=/tmp must not match /tmp/viseron/... unless /tmp is a tier."""
+    rewritten = rewrite_tier_hint_path(
+        "/tmp/viseron/tier1/cam/seg.m4s",
+        "/tmp",
+        "/etc",
+        ["/tmp/viseron/tier1", "/tmp/viseron/tier2"],
+    )
+    assert rewritten is None
 
 
 class TestTieredFileHandler(TestAppBaseNoAuth):

--- a/viseron/components/webserver/api/v1/download.py
+++ b/viseron/components/webserver/api/v1/download.py
@@ -64,6 +64,8 @@ class DownloadAPIHandler(BaseAPIHandler):
             return
 
         safe_filename = os.path.basename(download_token.filename)
+        if any(char in safe_filename for char in ("\r", "\n", '"', "\\")):
+            safe_filename = f"download{ext}"
 
         try:
             file_size = os.path.getsize(download_token.filename)
@@ -71,7 +73,7 @@ class DownloadAPIHandler(BaseAPIHandler):
             self.set_header("Content-Type", ALLOWED_EXTENSIONS[ext])
             self.set_header("Content-Length", file_size)
             self.set_header(
-                "Content-Disposition", f"attachment; filename={safe_filename}"
+                "Content-Disposition", f'attachment; filename="{safe_filename}"'
             )
 
             content = StaticFileHandler.get_content(download_token.filename, None, None)

--- a/viseron/components/webserver/tiered_file_handler.py
+++ b/viseron/components/webserver/tiered_file_handler.py
@@ -23,7 +23,13 @@ def _is_same_or_child(path: str, root: str) -> bool:
     """Return True if path is root or a file under root."""
     path_n = os.path.normpath(path)
     root_n = os.path.normpath(root)
-    return path_n == root_n or path_n.startswith(root_n + os.sep)
+    if path_n == root_n:
+        return True
+    try:
+        return os.path.commonpath([path_n, root_n]) == root_n
+    except ValueError:
+        # Raised for a mix of absolute/relative paths, or different drives
+        return False
 
 
 def rewrite_tier_hint_path(
@@ -53,7 +59,12 @@ def rewrite_tier_hint_path(
     if not _is_same_or_child(original, first):
         return None
 
-    rewritten = os.path.normpath(actual + original[len(first) :])
+    relative = os.path.relpath(original, first)
+    rewritten = (
+        actual
+        if relative == os.curdir
+        else os.path.normpath(os.path.join(actual, relative))
+    )
     if not _is_same_or_child(rewritten, actual):
         return None
     return rewritten

--- a/viseron/components/webserver/tiered_file_handler.py
+++ b/viseron/components/webserver/tiered_file_handler.py
@@ -7,6 +7,7 @@ import logging
 import os
 from typing import TYPE_CHECKING
 
+from viseron.components.storage.const import CONFIG_PATH
 from viseron.components.webserver.const import MAX_FILE_SEARCH_TRIES
 from viseron.components.webserver.static_file_handler import (
     AccessTokenStaticFileHandler,
@@ -16,6 +17,46 @@ if TYPE_CHECKING:
     from viseron import Viseron
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _is_same_or_child(path: str, root: str) -> bool:
+    """Return True if path is root or a file under root."""
+    path_n = os.path.normpath(path)
+    root_n = os.path.normpath(root)
+    return path_n == root_n or path_n.startswith(root_n + os.sep)
+
+
+def rewrite_tier_hint_path(
+    original_path: str,
+    first_tier_path: str,
+    actual_tier_path: str,
+    allowed_tier_paths: list[str],
+) -> str | None:
+    """Rewrite a first-tier path to the actual tier, if both are allowlisted.
+
+    Query parameters on /files are attacker-controlled. Without this check a
+    request can replace the storage prefix with an arbitrary directory
+    (for example /etc) and redirect into it.
+    """
+    first = os.path.normpath(first_tier_path)
+    actual = os.path.normpath(actual_tier_path)
+    allowed = {os.path.normpath(path) for path in allowed_tier_paths}
+    if first not in allowed or actual not in allowed:
+        LOGGER.debug(
+            "Ignoring tier hint with unconfigured paths first=%s actual=%s",
+            first,
+            actual,
+        )
+        return None
+
+    original = os.path.normpath(original_path)
+    if not _is_same_or_child(original, first):
+        return None
+
+    rewritten = os.path.normpath(actual + original[len(first) :])
+    if not _is_same_or_child(rewritten, actual):
+        return None
+    return rewritten
 
 
 class TieredFileHandler(AccessTokenStaticFileHandler):
@@ -39,20 +80,39 @@ class TieredFileHandler(AccessTokenStaticFileHandler):
         self._tries = 0
         self._redirect = False
 
+    def _configured_tier_paths(self) -> list[str]:
+        """Return configured storage tier paths for this camera."""
+        paths: list[str] = []
+        camera_handlers = self._storage.camera_tier_handlers.get(
+            self._camera_identifier, {}
+        )
+        for category in camera_handlers.values():
+            for tier in category:
+                for handler in tier.values():
+                    tier_path = handler.tier.get(CONFIG_PATH)
+                    if tier_path:
+                        paths.append(tier_path)
+        return paths
+
     def handle_tier_hint(self, path: str) -> str | None:
         """Handle tier hint arguments."""
-        _path = os.path.join(self.root, path)
         first_tier_path = self.get_argument("first_tier_path", None, strip=True)
         actual_tier_path = self.get_argument("actual_tier_path", None, strip=True)
+        if not first_tier_path or not actual_tier_path:
+            return None
 
-        if first_tier_path and actual_tier_path and _path.startswith(first_tier_path):
-            _path = _path.replace(first_tier_path, actual_tier_path, 1)
+        rewritten = rewrite_tier_hint_path(
+            os.path.join(self.root, path),
+            first_tier_path,
+            actual_tier_path,
+            self._configured_tier_paths(),
+        )
+        if rewritten:
             LOGGER.debug(
                 "first_tier_path and actual_tier_path found, adjusted path to %s",
-                _path,
+                rewritten,
             )
-            return _path
-        return None
+        return rewritten
 
     def _search_file(self, path: str) -> str | None:
         """Search for a file in the tiers."""


### PR DESCRIPTION
## Summary

`/files` HLS URLs include `first_tier_path` and `actual_tier_path` as query parameters. The handler applied them with `startswith` + `str.replace`, so a client could set `actual_tier_path=/etc` and be redirected into an arbitrary directory.

Rewrite only when both prefixes are configured storage tiers for that camera, using directory-boundary checks. Also quote `Content-Disposition` filenames so CR/LF in a basename cannot split headers.

## Test plan

- [x] Unit tests for `rewrite_tier_hint_path`: legitimate tier rewrite, reject `/etc`, reject `/tmp` prefix trick, trailing-slash config paths
- Full `pytest tests/components/webserver/test_tiered_file_handler.py` needs the viseron test extra (not installed in this environment)