### PR TITLE
fix(camera): store bytes on SharedFrame to avoid leaks

### DIFF
--- a/tests/components/nvr/test_nvr.py
+++ b/tests/components/nvr/test_nvr.py
@@ -79,7 +79,6 @@ def configure_camera_for_recording_tests(
     camera.shared_frames.get_decoded_frame_rgb.return_value = np.zeros(
         (2, 2, 3), dtype=np.uint8
     )
-    camera.shared_frames.remove = MagicMock()
 
     def start_recorder_side_effect(_shared_frame, _objects_in_fov, trigger_type):
         camera.is_recording = True

--- a/tests/domains/camera/test_shared_frames.py
+++ b/tests/domains/camera/test_shared_frames.py
@@ -1,0 +1,134 @@
+"""Tests for shared frames."""
+
+from __future__ import annotations
+
+import weakref
+from collections import deque
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+
+from viseron.domains.camera.shared_frames import (
+    COLOR_MODEL_GRAY,
+    COLOR_MODEL_RGB,
+    PIXEL_FORMAT_YUV420P,
+    SharedFrame,
+    SharedFrames,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+WIDTH = 32
+HEIGHT = 32
+COLOR_PLANE_HEIGHT = HEIGHT * 3 // 2
+FRAME_BYTES = b"\x00" * (WIDTH * COLOR_PLANE_HEIGHT)
+
+
+def _create_frame() -> SharedFrame:
+    """Return a frame holding FRAME_BYTES."""
+    return SharedFrame(
+        FRAME_BYTES,
+        WIDTH,
+        COLOR_PLANE_HEIGHT,
+        PIXEL_FORMAT_YUV420P,
+        (WIDTH, HEIGHT),
+        "test_camera_identifier",
+    )
+
+
+@pytest.fixture(name="shared_frame")
+def fixture_shared_frame() -> SharedFrame:
+    """Return a frame holding FRAME_BYTES."""
+    return _create_frame()
+
+
+class TestLifetime:
+    """Tests for the lifetime of the memory a frame holds.
+
+    A frame is owned by the SharedFrame object, so frames that never reach a
+    consumer, such as the ones dropped by a full subscriber queue, are freed
+    along with the object instead of being held forever.
+    """
+
+    def test_frame_is_freed_once_it_is_dropped(self) -> None:
+        """Nothing outlives the last reference to a frame."""
+        shared_frame = _create_frame()
+        shared_frame.color_convert(COLOR_MODEL_RGB)
+        reference = weakref.ref(shared_frame)
+
+        del shared_frame
+
+        assert reference() is None
+
+    def test_frame_dropped_by_a_full_queue_is_freed(self) -> None:
+        """A frame evicted from a full consumer queue is freed, a queued one is not."""
+        queue: deque[SharedFrame] = deque(maxlen=1)
+
+        dropped = _create_frame()
+        queue.append(dropped)
+        dropped_reference = weakref.ref(dropped)
+        del dropped
+
+        queued = _create_frame()
+        queue.append(queued)
+        queued_reference = weakref.ref(queued)
+        del queued
+
+        assert dropped_reference() is None
+        assert queued_reference() is not None
+
+
+class TestColorConvert:
+    """Tests for color conversion of a frame."""
+
+    @pytest.mark.parametrize(
+        ("color_model", "expected_shape"),
+        [
+            pytest.param(COLOR_MODEL_RGB, (HEIGHT, WIDTH, 3), id="rgb"),
+            pytest.param(COLOR_MODEL_GRAY, (HEIGHT, WIDTH), id="gray"),
+        ],
+    )
+    def test_color_convert(
+        self,
+        shared_frame: SharedFrame,
+        color_model: str,
+        expected_shape: tuple[int, ...],
+    ) -> None:
+        """A frame is converted to the requested color model."""
+        assert shared_frame.color_convert(color_model).shape == expected_shape
+
+    def test_color_convert_is_cached(self, shared_frame: SharedFrame) -> None:
+        """A frame is only converted once per color model."""
+        assert shared_frame.color_convert(COLOR_MODEL_RGB) is (
+            shared_frame.color_convert(COLOR_MODEL_RGB)
+        )
+
+    def test_decoded_frame_is_not_copied(self, shared_frame: SharedFrame) -> None:
+        """The undecoded frame is handed out as is."""
+        assert (
+            SharedFrames.get_decoded_frame(shared_frame) is shared_frame.decoded_frame
+        )
+
+    @pytest.mark.parametrize(
+        ("get_frame", "color_model"),
+        [
+            pytest.param(SharedFrames.get_decoded_frame_rgb, COLOR_MODEL_RGB, id="rgb"),
+            pytest.param(
+                SharedFrames.get_decoded_frame_gray, COLOR_MODEL_GRAY, id="gray"
+            ),
+        ],
+    )
+    def test_converted_frames_are_copies(
+        self,
+        shared_frame: SharedFrame,
+        get_frame: Callable[[SharedFrame], np.ndarray],
+        color_model: str,
+    ) -> None:
+        """Consumers get a copy so their edits don't leak into the cached frame."""
+        frame = get_frame(shared_frame)
+        frame[:] = 255
+
+        assert not np.array_equal(frame, get_frame(shared_frame))
+        assert not np.array_equal(frame, shared_frame.color_convert(color_model))

--- a/viseron/components/ffmpeg/camera.py
+++ b/viseron/components/ffmpeg/camera.py
@@ -486,6 +486,7 @@ class Camera(AbstractCamera):
 
             if len(frame_bytes) == self.stream.frame_bytes_size:
                 shared_frame = SharedFrame(
+                    frame_bytes,
                     self.stream.color_plane_width,
                     self.stream.color_plane_height,
                     self.stream.pixel_format,
@@ -496,7 +497,6 @@ class Camera(AbstractCamera):
                 continue
 
             self._poll_timer = utcnow().timestamp()
-            self.shared_frames.create(shared_frame, frame_bytes)
             self.current_frame = shared_frame
             self._vis.dispatch_event(
                 self.frame_bytes_topic,

--- a/viseron/components/gstreamer/stream.py
+++ b/viseron/components/gstreamer/stream.py
@@ -273,15 +273,14 @@ class Stream(FFmpegStream):
                     return None
 
                 if frame_bytes and len(frame_bytes) == self._frame_bytes_size:
-                    shared_frame = SharedFrame(
+                    return SharedFrame(
+                        frame_bytes,
                         self._color_plane_width,
                         self._color_plane_height,
                         self._pixel_format,
                         (self.width, self.height),
                         self._camera_identifier,
                     )
-                    self._camera.shared_frames.create(shared_frame, frame_bytes)
-                    return shared_frame
         except Exception as err:  # pylint: disable=broad-except
             self._logger.error(f"Error reading frame from pipe: {err}")
         return None

--- a/viseron/components/nvr/nvr.py
+++ b/viseron/components/nvr/nvr.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import datetime
 import logging
-import threading
 import time
 from dataclasses import dataclass
 from enum import Enum
@@ -280,7 +279,6 @@ class NVR(AbstractNVR):
         self._manual_recording: ManualRecording | None = None
         self._start_manual_recording = False
         self._kill_received = False
-        self._removal_timers: list[threading.Timer] = []
         self._operation_state: OperationState | None = None
 
         self._frame_scanners: dict[str, FrameIntervalCalculator] = {}
@@ -878,26 +876,6 @@ class NVR(AbstractNVR):
             self._stop_recorder_at = None
             self._seconds_left = 0
 
-    def remove_frame(self, shared_frame: SharedFrame) -> None:
-        """Remove frame after a delay.
-
-        This makes sure all frames are cleaned up eventually.
-        """
-
-        def _remove() -> None:
-            self._camera.shared_frames.remove(shared_frame, self._camera)
-            self._removal_timers.remove(timer)
-
-        timer = threading.Timer(
-            2,
-            _remove,
-            args=(),
-        )
-        timer.name = f"{self!s}.remove_frame.{shared_frame.name}"
-        timer.daemon = True
-        self._removal_timers.append(timer)
-        timer.start()
-
     def run(self) -> None:
         """Frame processing loop."""
         self._logger.debug("Waiting for first frame")
@@ -923,7 +901,6 @@ class NVR(AbstractNVR):
         shared_frame = frame.data.shared_frame
         if (frame_age := time.time() - shared_frame.capture_time) > 1:
             self._logger.debug(f"Frame is {frame_age} seconds old. Discarding")
-            self.remove_frame(shared_frame)
             return
 
         self.process_frame(shared_frame)
@@ -943,7 +920,6 @@ class NVR(AbstractNVR):
             ),
             store=False,
         )
-        self.remove_frame(shared_frame)
 
     def unload(self) -> None:
         """Unload nvr."""
@@ -966,9 +942,6 @@ class NVR(AbstractNVR):
         # Stop potential recording
         if self._camera.is_recording:
             self._camera.stop_recorder()
-
-        for timer in self._removal_timers:
-            timer.cancel()
 
     @property
     def camera(self) -> AbstractCamera:

--- a/viseron/components/webserver/api/v1/camera.py
+++ b/viseron/components/webserver/api/v1/camera.py
@@ -155,14 +155,14 @@ class CameraAPIHandler(BaseAPIHandler):
 
     def _snapshot_from_memory(self, camera: AbstractCamera) -> bytes | None:
         """Return snapshot from camera memory."""
-        if camera.current_frame:
-            with camera.current_frame:
-                _ret, jpg = camera.get_snapshot(
-                    camera.current_frame,
-                    self.request_arguments["width"],
-                    self.request_arguments["height"],
-                )
-                return jpg
+        current_frame = camera.current_frame
+        if current_frame:
+            _ret, jpg = camera.get_snapshot(
+                current_frame,
+                self.request_arguments["width"],
+                self.request_arguments["height"],
+            )
+            return jpg
         return None
 
     async def get_snapshot(self, camera_identifier: str) -> None:

--- a/viseron/components/webserver/stream_handler.py
+++ b/viseron/components/webserver/stream_handler.py
@@ -206,13 +206,12 @@ class DynamicStreamHandler(StreamHandler):
         while True:
             try:
                 processed_frame = await frame_queue.get()
-                with processed_frame.data.shared_frame:
-                    ret, jpg = await self.run_in_executor(
-                        self.process_frame,
-                        nvr,
-                        processed_frame.data,
-                        mjpeg_stream_config,
-                    )
+                ret, jpg = await self.run_in_executor(
+                    self.process_frame,
+                    nvr,
+                    processed_frame.data,
+                    mjpeg_stream_config,
+                )
 
                 if ret:
                     await self.write_jpg(jpg)
@@ -254,10 +253,9 @@ class StaticStreamHandler(StreamHandler):
 
         while self.active_streams[(nvr.camera.identifier, mjpeg_stream)]:
             processed_frame = await frame_queue.get()
-            with processed_frame.data.shared_frame:
-                ret, jpg = await self.run_in_executor(
-                    self.process_frame, nvr, processed_frame.data, mjpeg_stream_config
-                )
+            ret, jpg = await self.run_in_executor(
+                self.process_frame, nvr, processed_frame.data, mjpeg_stream_config
+            )
 
             if ret:
                 self._vis.dispatch_event(

--- a/viseron/domains/camera/__init__.py
+++ b/viseron/domains/camera/__init__.py
@@ -142,7 +142,7 @@ class AbstractCamera(AbstractDomain):
         self.stopped = Event()
         self.stopped.set()
         self.current_frame: SharedFrame | None = None
-        self.shared_frames = SharedFrames(vis)
+        self.shared_frames = SharedFrames()
         self.frame_bytes_topic = EVENT_FRAME_BYTES_TOPIC.format(
             camera_identifier=self.identifier
         )

--- a/viseron/domains/camera/shared_frames.py
+++ b/viseron/domains/camera/shared_frames.py
@@ -3,20 +3,13 @@
 from __future__ import annotations
 
 import logging
-import threading
 import time
 import uuid
-from functools import lru_cache
-from typing import TYPE_CHECKING
 
 import cv2
 import numpy as np
 
 from viseron.helpers.decorators import return_copy
-
-if TYPE_CHECKING:
-    from viseron import Viseron
-    from viseron.domains.camera import AbstractCamera
 
 LOGGER = logging.getLogger(__name__)
 
@@ -54,10 +47,11 @@ PIXEL_FORMATS = {
 
 
 class SharedFrame:
-    """Information about a frame shared in memory."""
+    """A frame shared in memory, along with its color converted copies."""
 
     def __init__(
         self,
+        frame_bytes: bytes,
         color_plane_width: int,
         color_plane_height: int,
         pixel_format: str,
@@ -71,83 +65,42 @@ class SharedFrame:
         self.resolution = resolution
         self.camera_identifier = camera_identifier
         self.capture_time = time.time()
-        self.reference_count = 0
+        self.decoded_frame = np.frombuffer(frame_bytes, np.uint8).reshape(
+            color_plane_height, color_plane_width
+        )
+        self._color_converted: dict[str, np.ndarray] = {}
 
-    def __enter__(self) -> None:
-        """Increase reference count."""
-        self.reference_count += 1
+    def color_convert(self, color_model: str) -> np.ndarray:
+        """Return the frame in the given color model, converting it once."""
+        try:
+            return self._color_converted[color_model]
+        except KeyError:
+            pass
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
-        """Decrease reference count."""
-        self.reference_count -= 1
+        converted_frame = cv2.cvtColor(
+            self.decoded_frame,
+            PIXEL_FORMATS[self.pixel_format][color_model][CONVERTER],
+        )
+        self._color_converted[color_model] = converted_frame
+        return converted_frame
 
 
 class SharedFrames:
-    """Byte frame shared in memory."""
+    """Access the frames held by a SharedFrame."""
 
-    def __init__(self, vis: Viseron) -> None:
-        self._vis = vis
-        self._frames: dict[uuid.UUID | str, np.ndarray] = {}
-
-    def create(self, shared_frame: SharedFrame, frame_bytes: bytes) -> None:
-        """Create frame in shared memory."""
-        self._frames[shared_frame.name] = np.frombuffer(frame_bytes, np.uint8).reshape(
-            shared_frame.color_plane_height, shared_frame.color_plane_width
-        )
-
-    def get_decoded_frame(self, shared_frame: SharedFrame) -> np.ndarray:
+    @staticmethod
+    def get_decoded_frame(shared_frame: SharedFrame) -> np.ndarray:
         """Return byte frame in numpy format."""
-        return self._frames[shared_frame.name]
+        return shared_frame.decoded_frame
 
+    @staticmethod
     @return_copy
-    @lru_cache(maxsize=2)
-    def _color_convert(self, shared_frame: SharedFrame, color_model: str) -> np.ndarray:
-        """Return decoded frame in specified color format."""
-        shared_frame_name = f"{shared_frame.name}_{color_model}"
-        try:
-            return self._frames[shared_frame_name]
-        except KeyError:
-            pass
-
-        pixel_format = PIXEL_FORMATS[shared_frame.pixel_format]
-        decoded_frame = self.get_decoded_frame(shared_frame)
-        decoded_frame = cv2.cvtColor(
-            decoded_frame, pixel_format[color_model][CONVERTER]
-        )
-
-        self._frames[shared_frame_name] = decoded_frame
-        return decoded_frame
-
-    def get_decoded_frame_rgb(self, shared_frame: SharedFrame) -> np.ndarray:
+    def get_decoded_frame_rgb(shared_frame: SharedFrame) -> np.ndarray:
         """Return decoded frame in rgb numpy format."""
-        return self._color_convert(shared_frame, COLOR_MODEL_RGB)
+        return shared_frame.color_convert(COLOR_MODEL_RGB)
 
-    def get_decoded_frame_gray(self, shared_frame: SharedFrame) -> np.ndarray:
+    @staticmethod
+    @return_copy
+    def get_decoded_frame_gray(shared_frame: SharedFrame) -> np.ndarray:
         """Return decoded frame in gray numpy format."""
-        return self._color_convert(shared_frame, COLOR_MODEL_GRAY)
-
-    def _remove(self, name: uuid.UUID | str) -> None:
-        try:
-            del self._frames[name]
-        except KeyError:
-            pass
-
-    def remove(self, shared_frame: SharedFrame, camera: AbstractCamera) -> None:
-        """Remove frame from shared memory."""
-        if (
-            shared_frame.reference_count > 0
-            or (camera and camera.current_frame == shared_frame)
-        ) and self._vis.shutdown_stage is None:
-            threading.Timer(1, self.remove, args=(shared_frame, camera)).start()
-            return
-
-        self._remove(shared_frame.name)
-        for color_model in PIXEL_FORMATS[PIXEL_FORMAT_YUV420P]:
-            self._remove(f"{shared_frame.name}_{color_model}")
-
-    def remove_all(self) -> None:
-        """Remove all frames still in shared memory."""
-        for frame_name in self._frames.copy():
-            self._remove(frame_name)
-            for color_model in PIXEL_FORMATS[PIXEL_FORMAT_YUV420P]:
-                self._remove(f"{frame_name}_{color_model}")
+        return shared_frame.color_convert(COLOR_MODEL_GRAY)

--- a/viseron/domains/motion_detector/__init__.py
+++ b/viseron/domains/motion_detector/__init__.py
@@ -442,24 +442,23 @@ class AbstractMotionDetectorScanner(AbstractMotionDetector):
                 continue
 
             shared_frame = frame_to_scan.data.shared_frame
-            with shared_frame:
-                decoded_frame = self._get_frame_function(shared_frame).copy()
-                if self._mask:
-                    apply_mask(decoded_frame, self._mask_image)
-                preprocessed_frame = self.preprocess(decoded_frame)
+            decoded_frame = self._get_frame_function(shared_frame).copy()
+            if self._mask:
+                apply_mask(decoded_frame, self._mask_image)
+            preprocessed_frame = self.preprocess(decoded_frame)
 
-                contours = self.return_motion(preprocessed_frame)
-                self._filter_motion(shared_frame, contours)
-                self._vis.dispatch_event(
-                    EVENT_MOTION_DETECTOR_RESULT.format(
-                        camera_identifier=shared_frame.camera_identifier
-                    ),
-                    EventMotionDetectorScannerResult(
-                        camera_identifier=shared_frame.camera_identifier,
-                        contours=contours,
-                    ),
-                    store=False,
-                )
+            contours = self.return_motion(preprocessed_frame)
+            self._filter_motion(shared_frame, contours)
+            self._vis.dispatch_event(
+                EVENT_MOTION_DETECTOR_RESULT.format(
+                    camera_identifier=shared_frame.camera_identifier
+                ),
+                EventMotionDetectorScannerResult(
+                    camera_identifier=shared_frame.camera_identifier,
+                    contours=contours,
+                ),
+                store=False,
+            )
         self._logger.debug("Motion detection thread stopped")
 
     @abstractmethod

--- a/viseron/domains/object_detector/__init__.py
+++ b/viseron/domains/object_detector/__init__.py
@@ -538,8 +538,7 @@ class AbstractObjectDetector(AbstractDomain):
                 self._logger.debug(f"Frame is {frame_age} seconds old. Discarding")
                 continue
 
-            with shared_frame:
-                self._detect(shared_frame, frame_time)
+            self._detect(shared_frame, frame_time)
 
         self._logger.debug("Object detection thread stopped")
 

--- a/viseron/domains/post_processor/__init__.py
+++ b/viseron/domains/post_processor/__init__.py
@@ -195,19 +195,18 @@ class AbstractPostProcessor(AbstractDomain):
             if detected_objects_data.shared_frame is None:
                 return
 
-            with detected_objects_data.shared_frame:
-                decoded_frame = self.apply_mask(detected_objects_data.shared_frame)
-                preprocessed_frame = self.preprocess(decoded_frame)
-                self.process(
-                    PostProcessorFrame(
-                        camera_identifier=detected_objects_data.camera_identifier,
-                        shared_frame=detected_objects_data.shared_frame,
-                        frame=preprocessed_frame,
-                        detected_objects=detected_objects_data.objects,
-                        filtered_objects=filtered_objects,
-                        zone=detected_objects_data.zone,
-                    )
+            decoded_frame = self.apply_mask(detected_objects_data.shared_frame)
+            preprocessed_frame = self.preprocess(decoded_frame)
+            self.process(
+                PostProcessorFrame(
+                    camera_identifier=detected_objects_data.camera_identifier,
+                    shared_frame=detected_objects_data.shared_frame,
+                    frame=preprocessed_frame,
+                    detected_objects=detected_objects_data.objects,
+                    filtered_objects=filtered_objects,
+                    zone=detected_objects_data.zone,
                 )
+            )
 
         while not self._kill_received:
             try:


### PR DESCRIPTION
Store frame bytes on the `SharedFrame` directly instead of using a dict on the `SharedFrames` class.
This removes the need to manually clear frames, and the garbage collector will automatically remove frames when they are no longer referenced.

`SharedFrames` was created the way it was in order to share frames between processes but that never came through.

The `SharedFrames` class is now redundant and will be removed in a future PR.