### PR TITLE
Memory optimizations using forkserver

### DIFF
--- a/rootfs/usr/local/bin/viseron
+++ b/rootfs/usr/local/bin/viseron
@@ -34,5 +34,20 @@ if [ "${1:-}" = "--reload" ]; then
   exit "$?"
 fi
 
+# Behave as a plain interpreter when handed interpreter arguments.
+#
+# The line below spoofs argv[0] to "viseron" so that ps and pgrep show a useful
+# name. A side effect is that Python resolves sys.executable back to this script
+# rather than to python3. multiprocessing starts the forkserver and the resource
+# tracker by re-execing sys.executable with "-c <bootstrap>", so without this
+# passthrough those re-execs would land here, ignore -c, and boot a second
+# Viseron.
+#
+# Viseron itself takes no arguments (--reload is handled above), so any argument
+# reaching this point came from such a re-exec.
+if [ "$#" -gt 0 ]; then
+  exec python3 "$@"
+fi
+
 cd "$APP_DIR"
-exec -a "viseron" python3 -u -m viseron "$@"
+exec -a "viseron" python3 -u -m viseron

--- a/tests/components/ffmpeg/test_camera.py
+++ b/tests/components/ffmpeg/test_camera.py
@@ -1,0 +1,95 @@
+"""Tests for viseron.components.ffmpeg.camera."""
+
+from __future__ import annotations
+
+import logging
+import multiprocessing as mp
+from typing import TYPE_CHECKING, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from viseron.components.ffmpeg.camera import Camera
+from viseron.components.ffmpeg.const import (
+    CONFIG_FFMPEG_LOGLEVEL,
+    CONFIG_FFMPEG_RECOVERABLE_ERRORS,
+    CONFIG_RECORD_ONLY,
+    CONFIG_SUBSTREAM,
+)
+from viseron.components.ffmpeg.frame_reader import frame_reader_logger_name
+from viseron.helpers.logs import refresh_child_log_levels
+from viseron.watchdog.process_watchdog import ProcessWatchDog
+from viseron.watchdog.thread_watchdog import ThreadWatchDog
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+LOGGER_NAME = frame_reader_logger_name("cam")
+
+
+@pytest.fixture(name="camera")
+def camera_fixture() -> Iterator[Camera]:
+    """Return a camera with only what the frame reader methods need."""
+    camera = object.__new__(Camera)
+    camera._identifier = "cam"
+    camera._logger = MagicMock()
+    camera._mp_context = cast("mp.context.ForkServerContext", mp.get_context())
+    camera._frame_queue = None  # type: ignore[assignment]
+    camera._capture_frames = MagicMock()
+    camera.decode_error = MagicMock()
+    camera._frame_reader = None
+    camera._frame_relay = None
+    camera._check_segment_process_thread = None
+    camera.stream = MagicMock()
+    camera._config = {
+        CONFIG_SUBSTREAM: None,
+        CONFIG_FFMPEG_LOGLEVEL: "error",
+        CONFIG_FFMPEG_RECOVERABLE_ERRORS: [],
+        CONFIG_RECORD_ONLY: False,
+    }
+
+    registered_processes = ProcessWatchDog.registered_items[:]
+    registered_threads = ThreadWatchDog.registered_items[:]
+    try:
+        yield camera
+    finally:
+        camera._stop_camera()
+        ProcessWatchDog.registered_items[:] = registered_processes
+        ThreadWatchDog.registered_items[:] = registered_threads
+        logging.getLogger(LOGGER_NAME).setLevel(logging.NOTSET)
+
+
+def test_create_frame_reader_registers_the_child_log_levels(camera: Camera) -> None:
+    """A running frame reader must follow the log level of its camera."""
+    frame_reader, _ = camera._create_frame_reader()
+    child_log_levels = frame_reader._child_log_levels
+
+    logging.getLogger(LOGGER_NAME).setLevel(logging.DEBUG)
+    refresh_child_log_levels()
+    # The child is still on the level it started with.
+    logging.getLogger(LOGGER_NAME).setLevel(logging.INFO)
+
+    assert (
+        child_log_levels.wait_and_apply(  # type: ignore[attr-defined]
+            timeout=5,
+        )
+        is True
+    )
+    assert logging.getLogger(LOGGER_NAME).level == logging.DEBUG
+
+
+def test_stop_camera_unregisters_the_child_log_levels(camera: Camera) -> None:
+    """A stopped camera must not be kept alive by the registry."""
+    camera._frame_reader, _ = camera._create_frame_reader()
+    camera._frame_relay = MagicMock()
+    child_log_levels = camera._frame_reader._child_log_levels
+
+    camera._stop_camera()
+    refresh_child_log_levels()
+
+    assert (
+        child_log_levels.wait_and_apply(  # type: ignore[attr-defined]
+            timeout=0.01,
+        )
+        is False
+    )

--- a/tests/components/ffmpeg/test_frame_reader.py
+++ b/tests/components/ffmpeg/test_frame_reader.py
@@ -8,8 +8,13 @@ import queue
 from contextlib import ExitStack
 from unittest.mock import MagicMock, patch
 
+from viseron.components.ffmpeg import stream
 from viseron.components.ffmpeg.const import MAX_EMPTY_FRAMES
-from viseron.components.ffmpeg.frame_reader import FrameReaderConfig, run_frame_reader
+from viseron.components.ffmpeg.frame_reader import (
+    FrameReaderConfig,
+    frame_reader_logger_name,
+    run_frame_reader,
+)
 
 
 class _FakeQueue(queue.Queue):
@@ -57,6 +62,11 @@ def test_config_is_picklable() -> None:
     """The payload crosses a forkserver boundary, so it must pickle."""
     config = _config()
     assert pickle.loads(pickle.dumps(config)) == config  # noqa: S301
+
+
+def test_frame_reader_logger_name_matches_the_parent_stream_logger() -> None:
+    """The child must configure the level of the logger the parent named."""
+    assert frame_reader_logger_name("cam") == f"{stream.__name__}.cam"
 
 
 def test_reads_frames_until_capture_frames_clears() -> None:

--- a/tests/components/ffmpeg/test_frame_reader.py
+++ b/tests/components/ffmpeg/test_frame_reader.py
@@ -1,0 +1,114 @@
+"""Tests for viseron.components.ffmpeg.frame_reader."""
+
+from __future__ import annotations
+
+import logging
+import pickle
+import queue
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+from viseron.components.ffmpeg.const import MAX_EMPTY_FRAMES
+from viseron.components.ffmpeg.frame_reader import FrameReaderConfig, run_frame_reader
+
+
+class _FakeQueue(queue.Queue):
+    """queue.Queue plus the close() that multiprocessing queues have.
+
+    run_frame_reader calls frame_queue.close() on shutdown; a plain queue.Queue
+    would raise AttributeError.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.closed = False
+
+    def close(self) -> None:
+        """Record that the queue was closed."""
+        self.closed = True
+
+
+def _config(**overrides) -> FrameReaderConfig:
+    defaults = {
+        "camera_identifier": "cam",
+        "decoder_command": ["ffmpeg", "-i", "rtsp://x"],
+        "segment_command": None,
+        "frame_bytes_size": 4,
+        "ffmpeg_loglevel": "error",
+        "recoverable_errors": [],
+        "sensitive_strings": ("hunter2",),
+        "log_level": logging.INFO,
+    }
+    defaults.update(overrides)
+    return FrameReaderConfig(**defaults)
+
+
+def _enter_patches(stack: ExitStack) -> tuple[MagicMock, MagicMock]:
+    """Patch the child process side effects, returning the pipe and os.kill mocks."""
+    module = "viseron.components.ffmpeg.frame_reader"
+    ffmpeg_pipe = stack.enter_context(patch(f"{module}.FFmpegPipe"))
+    stack.enter_context(patch(f"{module}.enable_child_logging"))
+    stack.enter_context(patch(f"{module}.setproctitle"))
+    kill = stack.enter_context(patch(f"{module}.os.kill"))
+    return ffmpeg_pipe, kill
+
+
+def test_config_is_picklable() -> None:
+    """The payload crosses a forkserver boundary, so it must pickle."""
+    config = _config()
+    assert pickle.loads(pickle.dumps(config)) == config  # noqa: S301
+
+
+def test_reads_frames_until_capture_frames_clears() -> None:
+    """Frames flow to the queue until the capture event clears."""
+    capture_frames = MagicMock()
+    capture_frames.is_set.side_effect = [True, True, False]
+    decode_error = MagicMock()
+    decode_error.is_set.return_value = False
+    frame_queue = _FakeQueue(maxsize=2)
+
+    with ExitStack() as stack:
+        ffmpeg_pipe, kill = _enter_patches(stack)
+        ffmpeg_pipe.return_value.read.return_value = b"1234"
+        run_frame_reader(_config(), frame_queue, capture_frames, decode_error)
+
+    assert frame_queue.get_nowait() == b"1234"
+    assert frame_queue.get_nowait() == b"1234"
+    assert frame_queue.closed is True
+    ffmpeg_pipe.return_value.start.assert_called_once()
+    ffmpeg_pipe.return_value.close.assert_called_once()
+    kill.assert_called_once()
+
+
+def test_sets_decode_error_when_pipe_exits() -> None:
+    """An exited ffmpeg process must raise decode_error."""
+    capture_frames = MagicMock()
+    capture_frames.is_set.side_effect = [True, False]
+    decode_error = MagicMock()
+    decode_error.is_set.return_value = False
+    frame_queue = _FakeQueue(maxsize=2)
+
+    with ExitStack() as stack:
+        ffmpeg_pipe, _ = _enter_patches(stack)
+        ffmpeg_pipe.return_value.read.return_value = None
+        ffmpeg_pipe.return_value.poll.return_value = 1
+        run_frame_reader(_config(), frame_queue, capture_frames, decode_error)
+
+    decode_error.set.assert_called_once()
+
+
+def test_sets_decode_error_after_max_empty_frames() -> None:
+    """Repeated empty reads must raise decode_error."""
+    capture_frames = MagicMock()
+    capture_frames.is_set.side_effect = [True] * MAX_EMPTY_FRAMES + [False]
+    decode_error = MagicMock()
+    decode_error.is_set.return_value = False
+    frame_queue = _FakeQueue(maxsize=2)
+
+    with ExitStack() as stack:
+        ffmpeg_pipe, _ = _enter_patches(stack)
+        ffmpeg_pipe.return_value.read.return_value = None
+        ffmpeg_pipe.return_value.poll.return_value = None
+        run_frame_reader(_config(), frame_queue, capture_frames, decode_error)
+
+    decode_error.set.assert_called_once()

--- a/tests/components/ffmpeg/test_pipe.py
+++ b/tests/components/ffmpeg/test_pipe.py
@@ -1,0 +1,94 @@
+"""Tests for viseron.components.ffmpeg.pipe."""
+
+from __future__ import annotations
+
+import logging
+import subprocess as sp
+from unittest.mock import patch
+
+from viseron.components.ffmpeg.pipe import FFmpegPipe
+
+LOGGER = logging.getLogger(__name__)
+
+
+def test_start_without_segment_command_starts_only_decoder() -> None:
+    """No substream configured means no segment process."""
+    with (
+        patch("viseron.components.ffmpeg.pipe.RestartablePopen") as popen,
+        patch("viseron.components.ffmpeg.pipe.LogPipe"),
+    ):
+        pipe = FFmpegPipe("cam", LOGGER, 10, decoder_command=["ffmpeg", "-i", "x"])
+        pipe.start()
+
+    assert popen.call_count == 1
+    assert popen.call_args.args[0] == ["ffmpeg", "-i", "x"]
+    assert popen.call_args.kwargs["name"] == "viseron.camera.cam.pipe"
+    assert popen.call_args.kwargs["register"] is False
+    assert pipe.segment_process is None
+
+
+def test_start_with_segment_command_starts_both() -> None:
+    """Segment process starts first, then the decoder."""
+    with (
+        patch("viseron.components.ffmpeg.pipe.RestartablePopen") as popen,
+        patch("viseron.components.ffmpeg.pipe.LogPipe"),
+    ):
+        pipe = FFmpegPipe(
+            "cam",
+            LOGGER,
+            10,
+            decoder_command=["ffmpeg", "-i", "x"],
+            segment_command=["ffmpeg", "-i", "seg"],
+        )
+        pipe.start()
+
+    assert popen.call_count == 2
+    assert popen.call_args_list[0].kwargs["name"] == "viseron.camera.cam.segments"
+    assert popen.call_args_list[1].kwargs["name"] == "viseron.camera.cam.pipe"
+
+
+def test_read_returns_requested_number_of_bytes() -> None:
+    """read() forwards the frame size to the decoder stdout."""
+    with (
+        patch("viseron.components.ffmpeg.pipe.RestartablePopen") as popen,
+        patch("viseron.components.ffmpeg.pipe.LogPipe"),
+    ):
+        popen.return_value.stdout.read.return_value = b"1234"
+        pipe = FFmpegPipe("cam", LOGGER, 10, decoder_command=["ffmpeg"])
+        pipe.start()
+        assert pipe.read(4) == b"1234"
+        popen.return_value.stdout.read.assert_called_once_with(4)
+
+
+def test_read_swallows_errors() -> None:
+    """A read error must not kill the frame reader loop."""
+    with (
+        patch("viseron.components.ffmpeg.pipe.RestartablePopen") as popen,
+        patch("viseron.components.ffmpeg.pipe.LogPipe"),
+    ):
+        popen.return_value.stdout.read.side_effect = OSError("boom")
+        pipe = FFmpegPipe("cam", LOGGER, 10, decoder_command=["ffmpeg"])
+        pipe.start()
+        assert pipe.read(4) is None
+
+
+def test_poll_returns_none_before_start() -> None:
+    """Polling before start() must not raise."""
+    pipe = FFmpegPipe("cam", LOGGER, 10, decoder_command=["ffmpeg"])
+    assert pipe.poll() is None
+
+
+def test_close_terminates_and_kills_on_timeout() -> None:
+    """A stubborn ffmpeg process gets killed after the terminate timeout."""
+    with (
+        patch("viseron.components.ffmpeg.pipe.RestartablePopen") as popen,
+        patch("viseron.components.ffmpeg.pipe.LogPipe"),
+    ):
+        process = popen.return_value
+        process.communicate.side_effect = [sp.TimeoutExpired("ffmpeg", 5), None]
+        pipe = FFmpegPipe("cam", LOGGER, 10, decoder_command=["ffmpeg"])
+        pipe.start()
+        pipe.close()
+
+    process.terminate.assert_called_once()
+    process.kill.assert_called_once()

--- a/tests/components/ffmpeg/test_pipe.py
+++ b/tests/components/ffmpeg/test_pipe.py
@@ -6,6 +6,8 @@ import logging
 import subprocess as sp
 from unittest.mock import patch
 
+import pytest
+
 from viseron.components.ffmpeg.pipe import FFmpegPipe
 
 LOGGER = logging.getLogger(__name__)
@@ -45,6 +47,40 @@ def test_start_with_segment_command_starts_both() -> None:
     assert popen.call_count == 2
     assert popen.call_args_list[0].kwargs["name"] == "viseron.camera.cam.segments"
     assert popen.call_args_list[1].kwargs["name"] == "viseron.camera.cam.pipe"
+
+
+@pytest.mark.parametrize(
+    ("segment_command", "expected_popen_count"),
+    [
+        pytest.param(None, 1, id="single_stream"),
+        pytest.param(["ffmpeg", "-i", "seg"], 2, id="substream"),
+    ],
+)
+def test_start_keeps_ffmpeg_in_the_frame_reader_process_group(
+    segment_command: list[str] | None, expected_popen_count: int
+) -> None:
+    """Ffmpeg must stay in the process group of the frame reader.
+
+    The pipe runs inside the frame reader process, which is the only holder of a
+    handle on the FFmpeg processes. Giving them their own session would make them
+    unreachable, and they would keep running when the frame reader is killed.
+    """
+    with (
+        patch("viseron.components.ffmpeg.pipe.RestartablePopen") as popen,
+        patch("viseron.components.ffmpeg.pipe.LogPipe"),
+    ):
+        pipe = FFmpegPipe(
+            "cam",
+            LOGGER,
+            10,
+            decoder_command=["ffmpeg", "-i", "x"],
+            segment_command=segment_command,
+        )
+        pipe.start()
+
+    assert popen.call_count == expected_popen_count
+    for call in popen.call_args_list:
+        assert call.kwargs["start_new_session"] is False
 
 
 def test_read_returns_requested_number_of_bytes() -> None:

--- a/tests/components/ffmpeg/test_stream.py
+++ b/tests/components/ffmpeg/test_stream.py
@@ -176,7 +176,7 @@ class TestStream:
     ) -> None:
         """Ffmpeg must stay in the process group of the frame reader.
 
-        pipe() runs inside the frame reader process, so nothing else holds a
+        The pipe runs inside the frame reader process, so nothing else holds a
         handle on the FFmpeg processes. Giving them their own session would make
         them unreachable, and they would keep running when the frame reader is
         killed.
@@ -189,18 +189,19 @@ class TestStream:
             stream._logger = MagicMock()
             stream._config = config
             stream._camera = mocked_camera
-            stream._log_pipe = None
+            stream._camera_identifier = "test_camera_identifier"
+            stream._ffmpeg_pipe = None
             with (
                 patch(
-                    "viseron.components.ffmpeg.stream.RestartablePopen"
+                    "viseron.components.ffmpeg.pipe.RestartablePopen"
                 ) as mocked_popen,
-                patch("viseron.components.ffmpeg.stream.LogPipe", MagicMock()),
+                patch("viseron.components.ffmpeg.pipe.LogPipe", MagicMock()),
                 patch.object(Stream, "build_command", MagicMock(return_value=["cmd"])),
                 patch.object(
                     Stream, "build_segment_command", MagicMock(return_value=["cmd"])
                 ),
             ):
-                stream.pipe()
+                stream.start_pipe()
 
         assert mocked_popen.call_count == expected_popen_count
         for call in mocked_popen.call_args_list:

--- a/tests/components/ffmpeg/test_stream.py
+++ b/tests/components/ffmpeg/test_stream.py
@@ -165,49 +165,6 @@ class TestStream:
             assert stream.fps == expected_fps
 
     @pytest.mark.parametrize(
-        ("config", "expected_popen_count"),
-        [
-            pytest.param(CONFIG, 1, id="single_stream"),
-            pytest.param(CONFIG_WITH_SUBSTREAM, 2, id="substream"),
-        ],
-    )
-    def test_pipe_starts_ffmpeg_in_the_frame_reader_process_group(
-        self, config, expected_popen_count
-    ) -> None:
-        """Ffmpeg must stay in the process group of the frame reader.
-
-        The pipe runs inside the frame reader process, so nothing else holds a
-        handle on the FFmpeg processes. Giving them their own session would make
-        them unreachable, and they would keep running when the frame reader is
-        killed.
-        """
-        mocked_camera = MockCamera(identifier="test_camera_identifier")
-        with patch.object(
-            Stream, "__init__", MagicMock(spec=Stream, return_value=None)
-        ):
-            stream = Stream(config, mocked_camera, "test_camera_identifier")
-            stream._logger = MagicMock()
-            stream._config = config
-            stream._camera = mocked_camera
-            stream._camera_identifier = "test_camera_identifier"
-            stream._ffmpeg_pipe = None
-            with (
-                patch(
-                    "viseron.components.ffmpeg.pipe.RestartablePopen"
-                ) as mocked_popen,
-                patch("viseron.components.ffmpeg.pipe.LogPipe", MagicMock()),
-                patch.object(Stream, "build_command", MagicMock(return_value=["cmd"])),
-                patch.object(
-                    Stream, "build_segment_command", MagicMock(return_value=["cmd"])
-                ),
-            ):
-                stream.start_pipe()
-
-        assert mocked_popen.call_count == expected_popen_count
-        for call in mocked_popen.call_args_list:
-            assert call.kwargs["start_new_session"] is False
-
-    @pytest.mark.parametrize(
         "config_codec, stream_codec, device_env, expected_cmd",
         [
             ("test_codec", "hevc", None, ["-c:v", "test_codec"]),

--- a/tests/components/gstreamer/test_gst_process.py
+++ b/tests/components/gstreamer/test_gst_process.py
@@ -1,0 +1,44 @@
+"""Tests for viseron.components.gstreamer.gst_process."""
+
+from __future__ import annotations
+
+import logging
+import pickle
+
+import pytest
+
+gst_process = pytest.importorskip(
+    "viseron.components.gstreamer.gst_process",
+    reason="GStreamer typelibs are not installed",
+)
+
+
+def _config(**overrides):
+    defaults = {
+        "camera_identifier": "cam",
+        "alias": "gstreamer_cam",
+        "pipeline": "videotestsrc ! fakesink",
+        "gst_loglevel": "warning",
+        "temp_segments_folder": "/tmp/segments",
+        "extension": "mp4",
+        "sensitive_strings": ("hunter2",),
+        "log_level": logging.INFO,
+    }
+    defaults.update(overrides)
+    return gst_process.GstProcessConfig(**defaults)
+
+
+def test_config_is_picklable() -> None:
+    """The payload crosses a forkserver boundary, so it must pickle.
+
+    In particular gst_loglevel must be the config string and not a Gst.DebugLevel.
+    """
+    config = _config()
+    assert pickle.loads(pickle.dumps(config))  # noqa: S301 == config
+
+
+def test_segment_location_uses_temp_folder_and_extension() -> None:
+    """Segment paths come from the payload."""
+    location = gst_process.segment_location(_config())
+    assert location.startswith("/tmp/segments/")
+    assert location.endswith(".mp4")

--- a/tests/components/gstreamer/test_gst_process.py
+++ b/tests/components/gstreamer/test_gst_process.py
@@ -5,12 +5,7 @@ from __future__ import annotations
 import logging
 import pickle
 
-import pytest
-
-gst_process = pytest.importorskip(
-    "viseron.components.gstreamer.gst_process",
-    reason="GStreamer typelibs are not installed",
-)
+from viseron.components.gstreamer import gst_process, stream
 
 
 def _config(**overrides):
@@ -42,3 +37,11 @@ def test_segment_location_uses_temp_folder_and_extension() -> None:
     location = gst_process.segment_location(_config())
     assert location.startswith("/tmp/segments/")
     assert location.endswith(".mp4")
+
+
+def test_gst_logger_names_matches_the_parent_stream_loggers() -> None:
+    """The child must configure the levels of the loggers the parent named."""
+    assert gst_process.gst_logger_names("cam") == (
+        f"{stream.__name__}.cam",
+        f"{stream.__name__}.cam.gstreamer",
+    )

--- a/tests/components/gstreamer/test_stream.py
+++ b/tests/components/gstreamer/test_stream.py
@@ -1,0 +1,88 @@
+"""Tests for viseron.components.gstreamer.stream."""
+
+from __future__ import annotations
+
+import logging
+import multiprocessing as mp
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from viseron.components.gstreamer.const import CONFIG_GSTREAMER_LOGLEVEL
+from viseron.components.gstreamer.gst_process import gst_logger_names
+from viseron.components.gstreamer.stream import RestartableProcess, Stream
+from viseron.helpers.logs import (
+    refresh_child_log_levels,
+    unregister_child_log_levels,
+)
+from viseron.watchdog.process_watchdog import ProcessWatchDog
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+LOGGER_NAME = gst_logger_names("cam")[0]
+
+
+@pytest.fixture(name="stream")
+def stream_fixture() -> Iterator[object]:
+    """Return a stream with only what the pipe methods need."""
+    stream = object.__new__(Stream)
+    stream._camera_identifier = "cam"
+    stream._logger = MagicMock()
+    stream._pipeline = MagicMock()
+    stream._pipeline.build_pipeline.return_value = ["videotestsrc", "!", "fakesink"]
+    stream._config = {CONFIG_GSTREAMER_LOGLEVEL: "warning"}
+    stream._camera = MagicMock()
+    stream._mp_context = mp.get_context()
+    stream._frame_queue = MagicMock()
+    stream._process_frames_proc = None
+    stream._process_frames_proc_exit = MagicMock()
+    registered_processes = ProcessWatchDog.registered_items[:]
+    try:
+        yield stream
+    finally:
+        ProcessWatchDog.registered_items[:] = registered_processes
+        unregister_child_log_levels(stream.alias)
+        logging.getLogger(LOGGER_NAME).setLevel(logging.NOTSET)
+
+
+def _start_pipe(stream) -> object:
+    """Start the pipe, without a child process, and return its shared log levels."""
+    with patch.object(RestartableProcess, "start"):
+        stream.start_pipe()
+    return stream._process_frames_proc._child_log_levels
+
+
+def test_start_pipe_registers_the_child_log_levels(stream) -> None:
+    """A running GStreamer child must follow the log level of its camera."""
+    child_log_levels = _start_pipe(stream)
+
+    logging.getLogger(LOGGER_NAME).setLevel(logging.DEBUG)
+    refresh_child_log_levels()
+    # The child is still on the level it started with.
+    logging.getLogger(LOGGER_NAME).setLevel(logging.INFO)
+
+    assert (
+        child_log_levels.wait_and_apply(  # type: ignore[attr-defined]
+            timeout=5,
+        )
+        is True
+    )
+    assert logging.getLogger(LOGGER_NAME).level == logging.DEBUG
+
+
+def test_close_pipe_unregisters_the_child_log_levels(stream) -> None:
+    """A closed pipe must not be kept alive by the registry."""
+    child_log_levels = _start_pipe(stream)
+
+    stream.close_pipe()
+    refresh_child_log_levels()
+
+    assert (
+        child_log_levels.wait_and_apply(  # type: ignore[attr-defined]
+            timeout=0.01,
+        )
+        is False
+    )

--- a/tests/components/logger/test_init.py
+++ b/tests/components/logger/test_init.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import multiprocessing as mp
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
@@ -20,6 +21,10 @@ from viseron.components.logger.const import (
     CONFIG_DEFAULT_LEVEL,
     CONFIG_LOGS,
     PREVIOUS_CONFIG,
+)
+from viseron.helpers.logs import (
+    register_child_log_levels,
+    unregister_child_log_levels,
 )
 
 if TYPE_CHECKING:
@@ -486,3 +491,21 @@ class TestHelpers:
         assert match1 in result
         assert match2 in result
         assert no_match not in result
+
+
+def test_setup_pushes_new_levels_to_child_processes() -> None:
+    """A reload must reach the loggers of already running child processes."""
+    vis = _make_vis()
+    setup(vis, _make_config(default_level="info"))
+    child_log_levels = register_child_log_levels(
+        "test_camera", mp.get_context(), ("test_child_logger",)
+    )
+
+    try:
+        unload(vis)
+        setup(vis, _make_config(default_level="debug"))
+
+        assert child_log_levels.wait_and_apply(timeout=5) is True
+        assert logging.getLogger("test_child_logger").level == logging.DEBUG
+    finally:
+        unregister_child_log_levels("test_camera")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,10 +65,10 @@ class MockViseron(Viseron):
 
     def _mock_add_entity(
         self,
-        component: str,
+        component: str,  # pylint: disable=W0613 # noqa: ARG002
         entity: EntityT,
-        domain: SupportedDomains | None = None,
-        identifier: str | None = None,
+        domain: SupportedDomains | None = None,  # pylint: disable=W0613 # noqa: ARG002
+        identifier: str | None = None,  # pylint: disable=W0613 # noqa: ARG002
     ) -> EntityT:
         """Assign vis the way States.add_entity does, without registering."""
         entity.vis = self
@@ -108,7 +108,7 @@ def patch_tier_check_worker() -> Iterator[None]:
 @pytest.fixture(scope="session", autouse=True)
 def patch_enable_logging() -> Iterator[None]:
     """Patch enable_logging to avoid adding duplicate handlers."""
-    with patch("viseron.enable_logging"):
+    with patch("viseron.helpers.logs.enable_logging"):
         yield
 
 

--- a/tests/container/test_viseron_app.py
+++ b/tests/container/test_viseron_app.py
@@ -27,6 +27,39 @@ def test_viseron_process_running(host: testinfra.host.Host) -> None:
     )
 
 
+def test_viseron_wrapper_passes_interpreter_args_through(
+    host: testinfra.host.Host,
+) -> None:
+    """`viseron` must act as a plain interpreter when given arguments.
+
+    The wrapper spoofs argv[0], so Python resolves sys.executable back to it.
+    multiprocessing boots the forkserver and the resource tracker by re-execing
+    sys.executable with "-c <bootstrap>". If the wrapper swallowed those, each
+    re-exec would start a second Viseron.
+    """
+    cmd = host.run("viseron -c 'print(\"interpreter\")'")
+    assert cmd.rc == 0, (
+        f"viseron -c failed: rc={cmd.rc}\nstdout=\n{cmd.stdout}\nstderr=\n{cmd.stderr}"
+    )
+    assert cmd.stdout.strip() == "interpreter", (
+        "viseron did not behave as an interpreter; it likely booted Viseron "
+        f"instead. stdout=\n{cmd.stdout}"
+    )
+
+
+def test_sys_executable_is_usable_for_reexec(host: testinfra.host.Host) -> None:
+    """Re-execing sys.executable with -c must not boot a second Viseron."""
+    cmd = host.run(
+        "viseron -c 'import subprocess,sys;"
+        'print(subprocess.run([sys.executable,"-c","print(42)"],'
+        "capture_output=True,text=True).stdout.strip())'"
+    )
+    assert cmd.rc == 0, f"re-exec check failed: rc={cmd.rc}\nstderr=\n{cmd.stderr}"
+    assert cmd.stdout.strip() == "42", (
+        f"re-exec of sys.executable did not behave as an interpreter: {cmd.stdout}"
+    )
+
+
 def test_webserver_responds(host: testinfra.host.Host, webserver_url: str) -> None:
     """The nginx-fronted webserver should answer HTTP requests."""
     status = helpers.wait_for_http_in_container(host, webserver_url, timeout=30.0)

--- a/tests/helpers/test_child_process_context.py
+++ b/tests/helpers/test_child_process_context.py
@@ -1,0 +1,52 @@
+"""Tests for viseron.helpers.child_process_context."""
+
+from __future__ import annotations
+
+import os
+
+from viseron.helpers.child_process_context import (
+    CHILD_PROCESS_START_METHOD,
+    get_child_process_context,
+)
+
+# Appended to in the parent after import. A forkserver child re-imports this module
+# from scratch, so it must still be empty there. If someone reverts the start method
+# to fork, the child inherits the parent's value and this test will fail.
+MARKER: list[str] = []
+
+
+def _report(queue) -> None:
+    queue.put((list(MARKER), os.getpid()))
+
+
+def test_start_method_is_forkserver() -> None:
+    """The whole change hinges on not using fork."""
+    assert CHILD_PROCESS_START_METHOD == "forkserver"
+    assert get_child_process_context().get_start_method() == "forkserver"
+
+
+def test_context_is_a_singleton() -> None:
+    """Multiprocessing caches concrete contexts; preload must only be set once."""
+    assert get_child_process_context() is get_child_process_context()
+
+
+def test_child_does_not_inherit_parent_memory() -> None:
+    """The regression test for the whole change.
+
+    A fork child would see MARKER == ["set in parent"]. A forkserver child imports
+    this module fresh from the forkserver snapshot and must see an empty list.
+    """
+    ctx = get_child_process_context()
+    queue = ctx.Queue()
+    MARKER.append("set in parent")
+    try:
+        process = ctx.Process(target=_report, args=(queue,))
+        process.start()
+        try:
+            marker, child_pid = queue.get(timeout=120)
+        finally:
+            process.join(timeout=30)
+        assert marker == []
+        assert child_pid != os.getpid()
+    finally:
+        MARKER.clear()

--- a/tests/helpers/test_logs.py
+++ b/tests/helpers/test_logs.py
@@ -1,0 +1,119 @@
+"""Tests for logging setup."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+from logging.handlers import RotatingFileHandler
+from typing import TYPE_CHECKING
+
+import pytest
+
+from viseron.helpers.logs import (
+    NOISY_LOGGERS,
+    SensitiveInformationFilter,
+    enable_child_logging,
+    enable_logging,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+@pytest.fixture(name="restore_logging", autouse=True)
+def restore_logging_fixture(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[None]:
+    """Restore the root logger and excepthooks after each test."""
+    monkeypatch.setattr(
+        "viseron.helpers.logs.VISERON_LOG_PATH", str(tmp_path / "viseron.log")
+    )
+    root_logger = logging.getLogger()
+    original_handlers = root_logger.handlers[:]
+    original_level = root_logger.level
+    original_excepthook = sys.excepthook
+    original_thread_excepthook = threading.excepthook
+    original_noisy_levels = {
+        logger_name: logging.getLogger(logger_name).level
+        for logger_name in NOISY_LOGGERS
+    }
+    try:
+        yield
+    finally:
+        root_logger.handlers[:] = original_handlers
+        root_logger.setLevel(original_level)
+        sys.excepthook = original_excepthook
+        threading.excepthook = original_thread_excepthook
+        for logger_name, level in original_noisy_levels.items():
+            logging.getLogger(logger_name).setLevel(level)
+
+
+def test_enable_child_logging_seeds_sensitive_strings() -> None:
+    """The child must redact the same strings the parent does."""
+    try:
+        enable_child_logging(("sensitive_string",), logging.INFO)
+        assert "sensitive_string" in SensitiveInformationFilter.sensitive_strings
+    finally:
+        SensitiveInformationFilter.remove_sensitive_string("sensitive_string")
+
+
+def test_enable_child_logging_replaces_handlers() -> None:
+    """Exactly one stream handler and one rotating file handler."""
+    enable_child_logging((), logging.DEBUG)
+    root_logger = logging.getLogger()
+    assert root_logger.level == logging.DEBUG
+    assert len(root_logger.handlers) == 2
+
+
+@pytest.mark.parametrize(
+    "setup_logging",
+    [
+        pytest.param(enable_logging, id="parent"),
+        pytest.param(lambda: enable_child_logging((), logging.INFO), id="child"),
+    ],
+)
+def test_setup_logging_configures_the_same_things(setup_logging) -> None:
+    """Parent and child get identical handlers, filters and logger levels."""
+    setup_logging()
+
+    root_logger = logging.getLogger()
+    assert root_logger.level == logging.INFO
+    assert not root_logger.propagate
+
+    stream_handler, file_handler = root_logger.handlers
+    assert isinstance(stream_handler, logging.StreamHandler)
+    assert isinstance(file_handler, RotatingFileHandler)
+    for handler in (stream_handler, file_handler):
+        assert any(
+            isinstance(log_filter, SensitiveInformationFilter)
+            for log_filter in handler.filters
+        )
+
+    for logger_name, level in NOISY_LOGGERS.items():
+        assert logging.getLogger(logger_name).level == level
+
+    assert sys.excepthook.__module__ == "viseron.helpers.logs"
+    assert threading.excepthook.__module__ == "viseron.helpers.logs"
+
+
+def test_enable_logging_rotates_the_log_file(tmp_path: Path) -> None:
+    """The main process starts every run with a fresh log file."""
+    log_path = tmp_path / "viseron.log"
+    log_path.write_text("old log")
+
+    enable_logging()
+
+    assert (tmp_path / "viseron.log.1").read_text() == "old log"
+
+
+def test_enable_child_logging_does_not_rotate_the_log_file(tmp_path: Path) -> None:
+    """Children must not rotate the log file the parent already rotated."""
+    log_path = tmp_path / "viseron.log"
+    log_path.write_text("parent log")
+
+    enable_child_logging((), logging.INFO)
+
+    assert not (tmp_path / "viseron.log.1").exists()
+    assert log_path.read_text() == "parent log"

--- a/tests/helpers/test_logs.py
+++ b/tests/helpers/test_logs.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import logging
+import multiprocessing as mp
 import sys
 import threading
+import time
 from logging.handlers import RotatingFileHandler
 from typing import TYPE_CHECKING
 
@@ -12,9 +14,13 @@ import pytest
 
 from viseron.helpers.logs import (
     NOISY_LOGGERS,
+    ChildLogLevels,
     SensitiveInformationFilter,
     enable_child_logging,
     enable_logging,
+    refresh_child_log_levels,
+    register_child_log_levels,
+    unregister_child_log_levels,
 )
 
 if TYPE_CHECKING:
@@ -48,6 +54,207 @@ def restore_logging_fixture(
         threading.excepthook = original_thread_excepthook
         for logger_name, level in original_noisy_levels.items():
             logging.getLogger(logger_name).setLevel(level)
+
+
+@pytest.fixture(name="temporary_loggers")
+def temporary_loggers_fixture() -> Iterator[None]:
+    """Remove loggers created by a test from the global logger registry."""
+    existing = set(logging.Logger.manager.loggerDict)
+    try:
+        yield
+    finally:
+        for logger_name in set(logging.Logger.manager.loggerDict) - existing:
+            del logging.Logger.manager.loggerDict[logger_name]
+
+
+@pytest.mark.usefixtures("temporary_loggers")
+def test_child_log_levels_applies_the_levels_resolved_in_the_parent() -> None:
+    """A child restores the levels the parent resolved for it."""
+    logging.getLogger("test_parent").setLevel(logging.DEBUG)
+    child_log_levels = ChildLogLevels(mp.get_context(), ("test_parent",))
+
+    # A forkserver child starts without the parents levels.
+    logging.getLogger("test_parent").setLevel(logging.NOTSET)
+    child_log_levels.apply()
+
+    assert logging.getLogger("test_parent").level == logging.DEBUG
+
+
+@pytest.mark.usefixtures("temporary_loggers")
+def test_child_log_levels_wait_and_apply_picks_up_a_refreshed_level() -> None:
+    """A level changed in the parent reaches the child without a restart."""
+    logging.getLogger("test_parent").setLevel(logging.INFO)
+    child_log_levels = ChildLogLevels(mp.get_context(), ("test_parent",))
+
+    logging.getLogger("test_parent").setLevel(logging.DEBUG)
+    child_log_levels.refresh()
+    # The child is still on the level it started with.
+    logging.getLogger("test_parent").setLevel(logging.INFO)
+
+    assert child_log_levels.wait_and_apply(timeout=5) is True
+    assert logging.getLogger("test_parent").level == logging.DEBUG
+
+
+@pytest.mark.usefixtures("temporary_loggers")
+def test_child_log_levels_wait_and_apply_times_out_when_nothing_changed() -> None:
+    """A child that is not notified must not busy loop."""
+    child_log_levels = ChildLogLevels(mp.get_context(), ("test_parent",))
+
+    assert child_log_levels.wait_and_apply(timeout=0.01) is False
+
+
+def _wait_for_level(logger_name: str, level: int, timeout: float = 5.0) -> int:
+    """Return the level of a logger, waiting for it to reach the expected one."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if logging.getLogger(logger_name).level == level:
+            break
+        time.sleep(0.01)
+    return logging.getLogger(logger_name).level
+
+
+@pytest.mark.usefixtures("temporary_loggers")
+def test_child_log_levels_start_applies_the_shared_levels() -> None:
+    """A starting child applies the levels the parent resolved for it."""
+    logging.getLogger("test_parent").setLevel(logging.DEBUG)
+    child_log_levels = ChildLogLevels(mp.get_context(), ("test_parent",))
+
+    # A forkserver child starts without the parents levels.
+    logging.getLogger("test_parent").setLevel(logging.INFO)
+    child_log_levels.start()
+
+    assert logging.getLogger("test_parent").level == logging.DEBUG
+
+
+def _report_levels(child_log_levels: ChildLogLevels, result_queue) -> None:
+    """Child process entrypoint reporting its level now and after a refresh."""
+    child_log_levels.start()
+    result_queue.put(logging.getLogger("test_parent").level)
+    result_queue.put(_wait_for_level("test_parent", logging.DEBUG))
+
+
+@pytest.mark.usefixtures("temporary_loggers")
+def test_child_log_levels_reach_a_running_child_process() -> None:
+    """A level changed in the parent reaches a running child, without a restart."""
+    mp_context = mp.get_context("forkserver")
+    logging.getLogger("test_parent").setLevel(logging.INFO)
+    child_log_levels = ChildLogLevels(mp_context, ("test_parent",))
+    result_queue = mp_context.Queue()
+
+    process = mp_context.Process(
+        target=_report_levels, args=(child_log_levels, result_queue), daemon=True
+    )
+    process.start()
+    try:
+        assert result_queue.get(timeout=30) == logging.INFO
+
+        logging.getLogger("test_parent").setLevel(logging.DEBUG)
+        child_log_levels.refresh()
+
+        assert result_queue.get(timeout=30) == logging.DEBUG
+    finally:
+        process.join(timeout=30)
+        process.kill()
+
+
+@pytest.mark.usefixtures("temporary_loggers")
+def test_child_log_levels_watcher_thread_is_a_daemon() -> None:
+    """A child must not be kept alive by its log level watcher."""
+    thread = ChildLogLevels(mp.get_context(), ("test_parent",)).start()
+
+    assert thread.daemon
+
+
+def _report_level(child_log_levels: ChildLogLevels, result_queue) -> None:
+    """Child process entrypoint reporting the level it started with."""
+    child_log_levels.start()
+    result_queue.put(logging.getLogger("test_parent").level)
+
+
+@pytest.mark.usefixtures("temporary_loggers")
+def test_child_log_levels_are_current_when_a_child_is_restarted() -> None:
+    """The watchdog restarts a child with the arguments it was created with."""
+    mp_context = mp.get_context("forkserver")
+    logging.getLogger("test_parent").setLevel(logging.INFO)
+    child_log_levels = ChildLogLevels(mp_context, ("test_parent",))
+    result_queue = mp_context.Queue()
+
+    logging.getLogger("test_parent").setLevel(logging.DEBUG)
+    child_log_levels.refresh()
+
+    process = mp_context.Process(
+        target=_report_level, args=(child_log_levels, result_queue), daemon=True
+    )
+    process.start()
+    try:
+        assert result_queue.get(timeout=30) == logging.DEBUG
+    finally:
+        process.join(timeout=30)
+        process.kill()
+
+
+@pytest.fixture(name="registered_child_log_levels")
+def registered_child_log_levels_fixture() -> Iterator[ChildLogLevels]:
+    """Register log levels for a child, unregistering them afterwards."""
+    child_log_levels = register_child_log_levels(
+        "test_camera", mp.get_context(), ("test_parent",)
+    )
+    try:
+        yield child_log_levels
+    finally:
+        unregister_child_log_levels("test_camera")
+
+
+@pytest.mark.usefixtures("temporary_loggers")
+def test_refresh_child_log_levels_pushes_new_levels_to_registered_children(
+    registered_child_log_levels: ChildLogLevels,
+) -> None:
+    """A reload of the logger component reaches every running child."""
+    logging.getLogger("test_parent").setLevel(logging.DEBUG)
+    refresh_child_log_levels()
+    # The child is still on the level it started with.
+    logging.getLogger("test_parent").setLevel(logging.INFO)
+
+    assert registered_child_log_levels.wait_and_apply(timeout=5) is True
+    assert logging.getLogger("test_parent").level == logging.DEBUG
+
+
+@pytest.mark.usefixtures("temporary_loggers")
+def test_unregistered_children_are_not_refreshed(
+    registered_child_log_levels: ChildLogLevels,
+) -> None:
+    """A stopped child must not be kept alive by the registry."""
+    unregister_child_log_levels("test_camera")
+
+    refresh_child_log_levels()
+
+    assert registered_child_log_levels.wait_and_apply(timeout=0.01) is False
+
+
+@pytest.mark.usefixtures("temporary_loggers", "registered_child_log_levels")
+def test_registering_the_same_child_twice_replaces_the_first(
+    registered_child_log_levels: ChildLogLevels,
+) -> None:
+    """A restarted child replaces its predecessor instead of leaking it."""
+    replacement = register_child_log_levels(
+        "test_camera", mp.get_context(), ("test_parent",)
+    )
+
+    refresh_child_log_levels()
+
+    assert registered_child_log_levels.wait_and_apply(timeout=0.01) is False
+    assert replacement.wait_and_apply(timeout=0.01) is True
+
+
+@pytest.mark.usefixtures("temporary_loggers")
+def test_child_log_levels_resolve_the_level_inherited_from_an_ancestor() -> None:
+    """A logger without a level of its own must still reach the child correctly."""
+    logging.getLogger("test_parent").setLevel(logging.DEBUG)
+    child_log_levels = ChildLogLevels(mp.get_context(), ("test_parent.child",))
+
+    child_log_levels.apply()
+
+    assert logging.getLogger("test_parent.child").level == logging.DEBUG
 
 
 def test_enable_child_logging_seeds_sensitive_strings() -> None:

--- a/tests/watchdog/test_process_watchdog.py
+++ b/tests/watchdog/test_process_watchdog.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import gc
 import multiprocessing as mp
+import os
+import pickle
 import subprocess as sp
 import time
 from typing import TYPE_CHECKING
@@ -10,7 +13,10 @@ from typing import TYPE_CHECKING
 import psutil
 import pytest
 
-from viseron.watchdog.process_watchdog import RestartableProcess
+from viseron.watchdog.process_watchdog import (
+    RestartableProcess,
+    _ChildProcessTarget,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -141,3 +147,57 @@ class TestProcessGroupCleanup:
         finally:
             _kill(grandchild_pid)
             _kill(sibling.pid)
+
+
+def _report_child_setup(queue) -> None:
+    """Run in the child; report what the target wrapper set up."""
+    queue.put(
+        {
+            "session_leader": os.getsid(0) == os.getpid(),
+            "frozen_objects": gc.get_freeze_count(),
+        }
+    )
+
+
+class TestChildProcessTarget:
+    """Tests for the picklable wrapper used as the child process entrypoint."""
+
+    def test_is_picklable(self) -> None:
+        """The wrapper must survive pickling; forkserver pickles the target."""
+        restored = pickle.loads(  # noqa: S301
+            pickle.dumps(_ChildProcessTarget(_report_child_setup, False))
+        )
+        assert restored._target is _report_child_setup
+        assert restored._start_watchdogs is False
+
+    def test_defaults_to_current_context(self) -> None:
+        """Passing no context must not change existing behaviour."""
+        process = RestartableProcess(
+            target=_report_child_setup, name="ctx_default", register=False
+        )
+        assert process._ctx.get_start_method() == mp.get_start_method()
+
+    def test_forkserver_child_is_session_leader_and_frozen(self) -> None:
+        """The wrapper calls os.setsid() and gc.freeze() inside the child.
+
+        os.setsid() is what _signal_process_group relies on to reach the
+        subprocesses the child started.
+        """
+        ctx = mp.get_context("forkserver")
+        queue = ctx.Queue()
+        process = RestartableProcess(
+            target=_report_child_setup,
+            args=(queue,),
+            name="forkserver_child",
+            register=False,
+            context="forkserver",
+        )
+        process.start()
+        try:
+            result = queue.get(timeout=120)
+        finally:
+            process.join(timeout=30)
+            process.kill()
+
+        assert result["session_leader"] is True
+        assert result["frozen_objects"] > 0

--- a/tests/watchdog/test_process_watchdog.py
+++ b/tests/watchdog/test_process_watchdog.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import gc
+import logging
 import multiprocessing as mp
 import os
 import pickle
@@ -13,6 +14,10 @@ from typing import TYPE_CHECKING
 import psutil
 import pytest
 
+from viseron.helpers.logs import (
+    refresh_child_log_levels,
+    unregister_child_log_levels,
+)
 from viseron.watchdog.process_watchdog import (
     RestartableProcess,
     _ChildProcessTarget,
@@ -201,3 +206,121 @@ class TestChildProcessTarget:
 
         assert result["session_leader"] is True
         assert result["frozen_objects"] > 0
+
+
+CHILD_LOGGER = "test_child_logger"
+
+
+def _report_log_levels(queue) -> None:
+    """Run in the child; report the level of the logger the parent named."""
+    queue.put(logging.getLogger(CHILD_LOGGER).level)
+    deadline = time.time() + 30
+    while (
+        logging.getLogger(CHILD_LOGGER).level != logging.DEBUG
+        and time.time() < deadline
+    ):
+        time.sleep(0.01)
+    queue.put(logging.getLogger(CHILD_LOGGER).level)
+
+
+def _wait_forever() -> None:
+    """Run in the child; stay alive until the parent stops it."""
+    while True:
+        time.sleep(0.1)
+
+
+class TestChildLogLevels:
+    """Tests for the log levels a process shares with its child."""
+
+    @pytest.fixture(autouse=True)
+    def _child_logger(self) -> Iterator[None]:
+        """Remove the logger the shared levels are created for."""
+        try:
+            yield
+        finally:
+            logging.Logger.manager.loggerDict.pop(CHILD_LOGGER, None)
+
+    def test_child_follows_the_levels_of_the_logger_names_it_was_given(self) -> None:
+        """A child applies its levels on startup and follows every change."""
+        logging.getLogger(CHILD_LOGGER).setLevel(logging.INFO)
+        ctx = mp.get_context("forkserver")
+        queue = ctx.Queue()
+        process = RestartableProcess(
+            target=_report_log_levels,
+            args=(queue,),
+            name="log_levels_child",
+            register=False,
+            context="forkserver",
+            child_logger_names=(CHILD_LOGGER,),
+        )
+
+        process.start()
+        try:
+            assert queue.get(timeout=120) == logging.INFO
+
+            logging.getLogger(CHILD_LOGGER).setLevel(logging.DEBUG)
+            refresh_child_log_levels()
+
+            assert queue.get(timeout=120) == logging.DEBUG
+        finally:
+            process.join(timeout=30)
+            process.kill()
+            unregister_child_log_levels("log_levels_child")
+            del logging.Logger.manager.loggerDict[CHILD_LOGGER]
+
+    @pytest.mark.parametrize("stop_method", ["stop", "terminate", "kill"])
+    def test_stopping_the_process_unregisters_its_log_levels(
+        self, stop_method: str
+    ) -> None:
+        """The levels of a process that is gone must not be refreshed any more."""
+        process = RestartableProcess(
+            target=_wait_forever,
+            name="log_levels_stop",
+            register=False,
+            child_logger_names=(CHILD_LOGGER,),
+        )
+        child_log_levels = process._child_log_levels
+
+        getattr(process, stop_method)()
+        refresh_child_log_levels()
+
+        assert child_log_levels.wait_and_apply(timeout=0.01) is False
+
+    def test_restarting_the_process_keeps_its_log_levels_registered(self) -> None:
+        """A restarted child must keep following the levels it was given."""
+        process = RestartableProcess(
+            target=_wait_forever,
+            name="log_levels_restart",
+            register=False,
+            child_logger_names=(CHILD_LOGGER,),
+        )
+        child_log_levels = process._child_log_levels
+        process.start()
+
+        try:
+            process.restart(timeout=10)
+            refresh_child_log_levels()
+
+            assert child_log_levels.wait_and_apply(timeout=5) is True
+        finally:
+            process.kill()
+            unregister_child_log_levels("log_levels_restart")
+
+    def test_child_logger_names_require_a_process_name(self) -> None:
+        """The name keys the shared levels, so it cannot be left out."""
+        with pytest.raises(ValueError, match="name"):
+            RestartableProcess(
+                target=_wait_forever,
+                register=False,
+                child_logger_names=(CHILD_LOGGER,),
+            )
+
+    def test_child_logger_names_need_the_wrapped_target(self) -> None:
+        """A process that is not wrapped cannot apply the levels in the child."""
+        with pytest.raises(ValueError, match="create_process_method"):
+            RestartableProcess(
+                name="log_levels_unwrapped",
+                register=False,
+                create_process_method=lambda: mp.Process(target=_wait_forever),
+                child_logger_names=(CHILD_LOGGER,),
+            )

--- a/viseron/__init__.py
+++ b/viseron/__init__.py
@@ -8,12 +8,10 @@ import json
 import logging
 import multiprocessing.process
 import os
-import sys
 import threading
 import time
 import tracemalloc
 from functools import partial
-from logging.handlers import RotatingFileHandler
 from timeit import default_timer as timer
 from typing import TYPE_CHECKING, Any, Literal, overload
 
@@ -42,14 +40,11 @@ from viseron.components.nvr.const import (
 from viseron.components.storage.const import COMPONENT as STORAGE_COMPONENT
 from viseron.config import load_config
 from viseron.const import (
-    ENV_LOG_BACKUP_COUNT,
     ENV_LOG_FD,
-    ENV_LOG_MAX_BYTES,
     ENV_PROFILE_MEMORY,
     FAILED,
     LOADED,
     LOADING,
-    VISERON_LOG_PATH,
     VISERON_SIGNAL_LAST_WRITE,
     VISERON_SIGNAL_SHUTDOWN,
     VISERON_SIGNAL_STOPPING,
@@ -63,17 +58,9 @@ from viseron.exceptions import DataStreamNotLoaded
 from viseron.helpers import (
     check_fd_usage,
     memory_usage_profiler,
-    parse_size_to_bytes,
     utcnow,
 )
 from viseron.helpers.json import JSONEncoder
-from viseron.helpers.logs import (
-    LOG_DATE_FORMAT,
-    LOG_FORMAT,
-    DuplicateFilter,
-    SensitiveInformationFilter,
-    ViseronLogFormat,
-)
 from viseron.states import States
 from viseron.viseron_types import Domain, SupportedDomains, ViseronData
 from viseron.watchdog.process_watchdog import ProcessWatchDog
@@ -113,90 +100,6 @@ SIGNAL_SCHEMA = vol.Schema(
 )
 
 LOGGER = logging.getLogger(f"{__name__}.core")
-
-
-def _get_rotation_rules() -> tuple[int, int]:
-    env_max_bytes = os.getenv(ENV_LOG_MAX_BYTES)
-    env_backup_count = os.getenv(ENV_LOG_BACKUP_COUNT)
-
-    max_bytes = 0
-    if env_max_bytes is not None:
-        try:
-            max_bytes = parse_size_to_bytes(env_max_bytes)
-        except ValueError as error:
-            LOGGER.error(
-                f"Failed to parse {ENV_LOG_MAX_BYTES} as int, using default value",
-                exc_info=error,
-            )
-
-    backup_count = 1
-    if env_backup_count is not None:
-        try:
-            backup_count = parse_size_to_bytes(env_backup_count)
-        except ValueError as error:
-            LOGGER.error(
-                f"Failed to parse {ENV_LOG_BACKUP_COUNT} as int, using default value",
-                exc_info=error,
-            )
-
-    return max_bytes, backup_count
-
-
-def enable_logging() -> None:
-    """Enable logging."""
-    root_logger = logging.getLogger()
-    root_logger.propagate = False
-    formatter = ViseronLogFormat()
-    duplicate_filter = DuplicateFilter()
-    sensitive_information_filter = SensitiveInformationFilter()
-
-    handler = logging.StreamHandler()
-    handler.setFormatter(formatter)
-    handler.addFilter(duplicate_filter)
-    handler.addFilter(sensitive_information_filter)
-    root_logger.addHandler(handler)
-
-    max_bytes, backup_count = _get_rotation_rules()
-    file_handler = RotatingFileHandler(
-        VISERON_LOG_PATH,
-        maxBytes=max_bytes,
-        backupCount=backup_count,
-        delay=True,
-    )
-    file_handler.setFormatter(
-        logging.Formatter(fmt=LOG_FORMAT, datefmt=LOG_DATE_FORMAT)
-    )
-    file_handler.addFilter(sensitive_information_filter)
-    file_handler.doRollover()
-    root_logger.addHandler(file_handler)
-
-    root_logger.setLevel(logging.INFO)
-
-    # Silence noisy loggers
-    logging.getLogger("apscheduler.scheduler").setLevel(logging.ERROR)
-    logging.getLogger("apscheduler.executors").setLevel(logging.ERROR)
-    logging.getLogger("requests").setLevel(logging.WARNING)
-    logging.getLogger("urllib3").setLevel(logging.WARNING)
-    logging.getLogger("httpx").setLevel(logging.WARNING)
-    logging.getLogger("httpcore").setLevel(logging.WARNING)
-    logging.getLogger("tornado.access").setLevel(logging.WARNING)
-    logging.getLogger("tornado.application").setLevel(logging.WARNING)
-    logging.getLogger("tornado.general").setLevel(logging.WARNING)
-    logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
-    logging.getLogger("watchdog.observers.inotify_buffer").setLevel(logging.WARNING)
-
-    sys.excepthook = lambda *args: logging.getLogger(None).error(
-        "Uncaught exception", exc_info=args
-    )
-    threading.excepthook = lambda args: logging.getLogger(None).error(
-        "Uncaught thread exception in thread %s",
-        args.thread.name if args.thread else "unknown",
-        exc_info=(
-            args.exc_type,
-            args.exc_value,
-            args.exc_traceback,
-        ),  # type: ignore[arg-type]
-    )
 
 
 def setup_viseron(vis: Viseron) -> None:

--- a/viseron/__main__.py
+++ b/viseron/__main__.py
@@ -9,8 +9,9 @@ import signal
 import sys
 import threading
 
-from viseron import Viseron, enable_logging, setup_viseron
+from viseron import Viseron, setup_viseron
 from viseron.helpers import kill_zombie_processes
+from viseron.helpers.logs import enable_logging
 from viseron.helpers.named_timer import NamedTimer
 from viseron.reload import reload_config
 

--- a/viseron/components/ffmpeg/camera.py
+++ b/viseron/components/ffmpeg/camera.py
@@ -137,7 +137,11 @@ from .const import (
     HWACCEL_VAAPI,
     STREAM_FORMAT_MAP,
 )
-from .frame_reader import FrameReaderConfig, run_frame_reader
+from .frame_reader import (
+    FrameReaderConfig,
+    frame_reader_logger_name,
+    run_frame_reader,
+)
 from .recorder import Recorder
 from .stream import Stream
 
@@ -369,6 +373,11 @@ class Camera(AbstractCamera):
         )
         self._logger.debug(f"Camera {self.name} initialized")
 
+    @property
+    def _frame_reader_name(self) -> str:
+        """Return the name of the frame reader process."""
+        return "viseron.camera." + self.identifier
+
     def _create_frame_reader(self) -> tuple[RestartableProcess, RestartableThread]:
         """Return a frame reader process and its relay thread."""
         if self._frame_queue:
@@ -395,7 +404,7 @@ class Camera(AbstractCamera):
 
         # Start watchdogs for this process since it spawns a RestartablePopen
         return RestartableProcess(
-            name="viseron.camera." + self.identifier,
+            name=self._frame_reader_name,
             args=(
                 frame_reader_config,
                 self._frame_queue,
@@ -407,8 +416,9 @@ class Camera(AbstractCamera):
             register=True,
             start_watchdogs=True,
             context=CHILD_PROCESS_START_METHOD,
+            child_logger_names=(frame_reader_logger_name(self.identifier),),
         ), RestartableThread(
-            name="viseron.camera." + self.identifier + ".relay_frame",
+            name=self._frame_reader_name + ".relay_frame",
             target=self.relay_frame,
             poll_method=self.poll_method,
             poll_target=self.poll_target,

--- a/viseron/components/ffmpeg/camera.py
+++ b/viseron/components/ffmpeg/camera.py
@@ -2,16 +2,14 @@
 
 from __future__ import annotations
 
-import contextlib
+import logging
 import multiprocessing as mp
 import os
-import signal
 import time
-from queue import Empty, Full
+from queue import Empty
 from typing import TYPE_CHECKING, Any
 
 import cv2
-import setproctitle
 import voluptuous as vol
 
 from viseron.const import ENV_CUDA_SUPPORTED, ENV_VAAPI_SUPPORTED
@@ -24,6 +22,10 @@ from viseron.domains.camera.config import (
 from viseron.domains.camera.shared_frames import SharedFrame
 from viseron.exceptions import DomainNotReady, FFprobeError, FFprobeTimeout
 from viseron.helpers import escape_string, utcnow
+from viseron.helpers.child_process_context import (
+    CHILD_PROCESS_START_METHOD,
+    get_child_process_context,
+)
 from viseron.helpers.logs import SensitiveInformationFilter
 from viseron.helpers.validators import (
     UNDEFINED,
@@ -133,9 +135,9 @@ from .const import (
     DESC_WIDTH,
     FFMPEG_LOGLEVELS,
     HWACCEL_VAAPI,
-    MAX_EMPTY_FRAMES,
     STREAM_FORMAT_MAP,
 )
+from .frame_reader import FrameReaderConfig, run_frame_reader
 from .recorder import Recorder
 from .stream import Stream
 
@@ -347,13 +349,13 @@ class Camera(AbstractCamera):
         self.stream = Stream(config, self, identifier, attempt)
 
         super().__init__(vis, COMPONENT, config, identifier)
+        self._mp_context = get_child_process_context()
         self._frame_queue: mp.Queue[  # pylint: disable=unsubscriptable-object
             bytes
-        ] = mp.Queue(maxsize=2)
-        self._capture_frames = mp.Event()
-        self._thread_stuck = False
+        ] = self._mp_context.Queue(maxsize=2)
+        self._capture_frames = self._mp_context.Event()
         self.resolution = self.stream.width, self.stream.height
-        self.decode_error = mp.Event()
+        self.decode_error = self._mp_context.Event()
 
         if cv2.ocl.haveOpenCL():
             cv2.ocl.setUseOpenCL(True)
@@ -368,18 +370,43 @@ class Camera(AbstractCamera):
         self._logger.debug(f"Camera {self.name} initialized")
 
     def _create_frame_reader(self) -> tuple[RestartableProcess, RestartableThread]:
-        """Return a frame reader thread."""
+        """Return a frame reader process and its relay thread."""
         if self._frame_queue:
             self._frame_queue.close()
-        self._frame_queue = mp.Queue(maxsize=2)
+        self._frame_queue = self._mp_context.Queue(maxsize=2)
+
+        frame_reader_config = FrameReaderConfig(
+            camera_identifier=self.identifier,
+            decoder_command=self.stream.build_command(),
+            segment_command=(
+                self.stream.build_segment_command()
+                if self._config.get(CONFIG_SUBSTREAM, None)
+                else None
+            ),
+            frame_bytes_size=self.stream.frame_bytes_size,
+            ffmpeg_loglevel=self._config[CONFIG_FFMPEG_LOGLEVEL],
+            recoverable_errors=list(
+                set(self._config[CONFIG_FFMPEG_RECOVERABLE_ERRORS])
+                | set(DEFAULT_FFMPEG_RECOVERABLE_ERRORS)
+            ),
+            sensitive_strings=tuple(SensitiveInformationFilter.sensitive_strings),
+            log_level=logging.getLogger().level,
+        )
+
         # Start watchdogs for this process since it spawns a RestartablePopen
         return RestartableProcess(
             name="viseron.camera." + self.identifier,
-            args=(self._frame_queue,),
-            target=self.read_frames,
+            args=(
+                frame_reader_config,
+                self._frame_queue,
+                self._capture_frames,
+                self.decode_error,
+            ),
+            target=run_frame_reader,
             daemon=True,
             register=True,
             start_watchdogs=True,
+            context=CHILD_PROCESS_START_METHOD,
         ), RestartableThread(
             name="viseron.camera." + self.identifier + ".relay_frame",
             target=self.relay_frame,
@@ -419,53 +446,6 @@ class Camera(AbstractCamera):
         )
         self._check_segment_process_thread.start()
         self.stream.record_only()
-
-    def read_frames(
-        self,
-        frame_queue: mp.Queue[bytes],  # pylint: disable=unsubscriptable-object
-    ) -> None:
-        """Read frames from camera."""
-        setproctitle.setproctitle("viseron.camera." + self.identifier + ".read_frames")
-        self.decode_error.clear()
-        empty_frames = 0
-        self._thread_stuck = False
-
-        self.stream.start_pipe()
-
-        while self._capture_frames.is_set():
-            if self.decode_error.is_set():
-                time.sleep(5)
-                self._logger.error("Restarting frame pipe")
-                self.stream.close_pipe()
-                self.stream.start_pipe()
-                self.decode_error.clear()
-                empty_frames = 0
-
-            frame_bytes = self.stream.read()
-            if frame_bytes:
-                empty_frames = 0
-                # Dont queue frames if consumer is not ready
-                with contextlib.suppress(Full):
-                    frame_queue.put_nowait(frame_bytes)
-                continue
-
-            if self._thread_stuck:
-                return
-
-            if self.stream.poll() is not None:
-                self._logger.error("Frame reader process has exited")
-                self.decode_error.set()
-                continue
-
-            empty_frames += 1
-            if empty_frames >= MAX_EMPTY_FRAMES:
-                self._logger.error("Did not receive a frame")
-                self.decode_error.set()
-
-        self.stream.close_pipe()
-        self._frame_queue.close()
-        self._logger.debug("Frame reader stopped")
-        os.kill(os.getpid(), signal.SIGKILL)
 
     def relay_frame(self) -> None:
         """Read from the frame queue and create a SharedFrame."""
@@ -514,7 +494,6 @@ class Camera(AbstractCamera):
     def poll_target(self) -> None:
         """Close pipe when RestartableThread.poll_timeout has been reached."""
         self._logger.error("Timeout waiting for frame")
-        self._thread_stuck = True
         self.stop_camera()
 
     def poll_method(self) -> bool:
@@ -573,7 +552,6 @@ class Camera(AbstractCamera):
                 self._frame_reader.kill()
                 self._frame_reader.join(timeout=5)
                 self._frame_reader = None
-                self.stream.close_pipe()
 
         if self._config[CONFIG_RECORD_ONLY] and self._check_segment_process_thread:
             self._logger.debug("Stopping record-only process")

--- a/viseron/components/ffmpeg/frame_reader.py
+++ b/viseron/components/ffmpeg/frame_reader.py
@@ -42,6 +42,15 @@ class FrameReaderConfig:
     log_level: int
 
 
+def frame_reader_logger_name(camera_identifier: str) -> str:
+    """Return the name of the logger the frame reader child process creates.
+
+    Kept here instead of derived from the stream module so that the parent can
+    resolve its log level without the child having to import anything heavy.
+    """
+    return f"viseron.components.ffmpeg.stream.{camera_identifier}"
+
+
 def run_frame_reader(
     config: FrameReaderConfig,
     frame_queue: Queue[bytes],  # pylint: disable=unsubscriptable-object
@@ -52,9 +61,7 @@ def run_frame_reader(
     setproctitle.setproctitle(f"viseron.camera.{config.camera_identifier}.read_frames")
     enable_child_logging(config.sensitive_strings, config.log_level)
 
-    logger = logging.getLogger(
-        f"viseron.components.ffmpeg.stream.{config.camera_identifier}"
-    )
+    logger = logging.getLogger(frame_reader_logger_name(config.camera_identifier))
     logger.addFilter(UnhelpfullLogFilter(config.recoverable_errors))
 
     pipe = FFmpegPipe(

--- a/viseron/components/ffmpeg/frame_reader.py
+++ b/viseron/components/ffmpeg/frame_reader.py
@@ -1,0 +1,103 @@
+"""FFmpeg frame reader, executed in a child process.
+
+This module is the entrypoint of the frame reader child process. It deliberately
+depends on nothing that reaches back into the running Viseron instance. Keeping it
+this way means we can use the forkserver approach to save memory.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import signal
+import time
+from dataclasses import dataclass
+from queue import Full
+from typing import TYPE_CHECKING
+
+import setproctitle
+
+from viseron.helpers.logs import UnhelpfullLogFilter, enable_child_logging
+
+from .const import FFMPEG_LOGLEVELS, MAX_EMPTY_FRAMES
+from .pipe import FFmpegPipe
+
+if TYPE_CHECKING:
+    from multiprocessing import Queue
+    from multiprocessing.synchronize import Event
+
+
+@dataclass(frozen=True)
+class FrameReaderConfig:
+    """Everything the frame reader child process needs, as plain picklable data."""
+
+    camera_identifier: str
+    decoder_command: list[str]
+    segment_command: list[str] | None
+    frame_bytes_size: int
+    ffmpeg_loglevel: str
+    recoverable_errors: list[str]
+    sensitive_strings: tuple[str, ...]
+    log_level: int
+
+
+def run_frame_reader(
+    config: FrameReaderConfig,
+    frame_queue: Queue[bytes],  # pylint: disable=unsubscriptable-object
+    capture_frames: Event,
+    decode_error: Event,
+) -> None:
+    """Read frames from FFmpeg and put them on the queue."""
+    setproctitle.setproctitle(f"viseron.camera.{config.camera_identifier}.read_frames")
+    enable_child_logging(config.sensitive_strings, config.log_level)
+
+    logger = logging.getLogger(
+        f"viseron.components.ffmpeg.stream.{config.camera_identifier}"
+    )
+    logger.addFilter(UnhelpfullLogFilter(config.recoverable_errors))
+
+    pipe = FFmpegPipe(
+        config.camera_identifier,
+        logger,
+        FFMPEG_LOGLEVELS[config.ffmpeg_loglevel],
+        decoder_command=config.decoder_command,
+        segment_command=config.segment_command,
+    )
+
+    decode_error.clear()
+    empty_frames = 0
+
+    pipe.start()
+
+    while capture_frames.is_set():
+        if decode_error.is_set():
+            time.sleep(5)
+            logger.error("Restarting frame pipe")
+            pipe.close()
+            pipe.start()
+            decode_error.clear()
+            empty_frames = 0
+
+        frame_bytes = pipe.read(config.frame_bytes_size)
+        if frame_bytes:
+            empty_frames = 0
+            # Dont queue frames if consumer is not ready
+            with contextlib.suppress(Full):
+                frame_queue.put_nowait(frame_bytes)
+            continue
+
+        if pipe.poll() is not None:
+            logger.error("Frame reader process has exited")
+            decode_error.set()
+            continue
+
+        empty_frames += 1
+        if empty_frames >= MAX_EMPTY_FRAMES:
+            logger.error("Did not receive a frame")
+            decode_error.set()
+
+    pipe.close()
+    frame_queue.close()
+    logger.debug("Frame reader stopped")
+    os.kill(os.getpid(), signal.SIGKILL)

--- a/viseron/components/ffmpeg/pipe.py
+++ b/viseron/components/ffmpeg/pipe.py
@@ -1,0 +1,116 @@
+"""Lifecycle management for the FFmpeg subprocesses of a camera."""
+
+from __future__ import annotations
+
+import subprocess as sp
+from typing import TYPE_CHECKING
+
+from viseron.helpers.logs import LogPipe
+from viseron.watchdog.subprocess_watchdog import RestartablePopen
+
+if TYPE_CHECKING:
+    import logging
+
+
+class FFmpegPipe:
+    """FFmpeg subprocesses for a camera."""
+
+    def __init__(
+        self,
+        camera_identifier: str,
+        logger: logging.Logger,
+        loglevel: int,
+        decoder_command: list[str] | None = None,
+        segment_command: list[str] | None = None,
+    ) -> None:
+        self._camera_identifier = camera_identifier
+        self._logger = logger
+        self._loglevel = loglevel
+        self._decoder_command = decoder_command
+        self._segment_command = segment_command
+
+        self._pipe: RestartablePopen | None = None
+        self._log_pipe: LogPipe | None = None
+        self.segment_process: RestartablePopen | None = None
+
+    def _close_log_pipe(self) -> None:
+        try:
+            if self._log_pipe:
+                self._log_pipe.close()
+                self._log_pipe = None
+        except OSError as error:
+            self._logger.error("Failed to close log pipe: %s", error)
+
+    def start(self) -> None:
+        """Start the FFmpeg subprocesses.
+
+        Called from inside the frame reader process, which is the only holder of
+        a handle on these processes. start_new_session=False keeps them in the
+        frame reader's process group so that killing it takes them with it.
+        """
+        self._close_log_pipe()
+        self._log_pipe = LogPipe(self._logger, self._loglevel)
+
+        if self._segment_command:
+            self._logger.debug(
+                f"FFmpeg segments command: {' '.join(self._segment_command)}"
+            )
+            self.segment_process = RestartablePopen(
+                self._segment_command,
+                name=f"viseron.camera.{self._camera_identifier}.segments",
+                stdin=sp.DEVNULL,
+                stdout=sp.PIPE,
+                stderr=self._log_pipe,
+                start_new_session=False,
+            )
+
+        if self._decoder_command:
+            self._logger.debug(
+                f"FFmpeg decoder command: {' '.join(self._decoder_command)}"
+            )
+            self._pipe = RestartablePopen(
+                self._decoder_command,
+                name=f"viseron.camera.{self._camera_identifier}.pipe",
+                register=False,
+                stdin=sp.DEVNULL,
+                stdout=sp.PIPE,
+                stderr=self._log_pipe,
+                start_new_session=False,
+            )
+
+    def poll(self) -> int | None:
+        """Poll the decoder subprocess."""
+        if self._pipe:
+            return self._pipe.poll()
+        return None
+
+    def read(self, frame_bytes_size: int) -> bytes | None:
+        """Return a single frame from the decoder subprocess."""
+        try:
+            if self._pipe and self._pipe.stdout:
+                return self._pipe.stdout.read(frame_bytes_size)
+        except Exception:  # pylint: disable=broad-except
+            self._logger.exception("Error reading frame from pipe")
+        return None
+
+    def _terminate(self, process: RestartablePopen, description: str) -> None:
+        self._logger.debug(f"Terminating {description}")
+        try:
+            process.terminate()
+            try:
+                process.communicate(timeout=5)
+            except sp.TimeoutExpired:
+                self._logger.debug("FFmpeg did not terminate, killing instead.")
+                process.kill()
+                process.communicate()
+        except (AttributeError, OSError) as error:
+            self._logger.error(f"Failed to close {description}: {error}")
+
+    def close(self) -> None:
+        """Close the FFmpeg subprocesses."""
+        self._logger.debug("Closing pipe")
+        if self.segment_process:
+            self._terminate(self.segment_process, "segment process")
+        if self._pipe:
+            self._terminate(self._pipe, "pipe")
+        self._close_log_pipe()

--- a/viseron/components/ffmpeg/stream.py
+++ b/viseron/components/ffmpeg/stream.py
@@ -22,6 +22,7 @@ from viseron.helpers.logs import LogPipe, UnhelpfullLogFilter
 from viseron.helpers.validators import UNDEFINED
 from viseron.watchdog.subprocess_watchdog import RestartablePopen
 
+from .pipe import FFmpegPipe
 from .const import (
     CAMERA_INPUT_ARGS,
     CONFIG_AUDIO_CODEC,
@@ -109,9 +110,7 @@ class Stream:
 
         self._camera: Camera = camera
 
-        self._pipe: RestartablePopen | None = None
-        self.segment_process: RestartablePopen | None = None
-        self._log_pipe: LogPipe | None = None
+        self._ffmpeg_pipe: FFmpegPipe | None = None
         self._ffprobe = FFprobe(config, camera_identifier, attempt)
 
         self._mainstream = self.get_stream_information(config)
@@ -554,127 +553,54 @@ class Stream:
             + self.output_args
         )
 
-    def pipe(self) -> RestartablePopen:
-        """Return subprocess pipe for FFmpeg.
-
-        Called from inside the frame reader process, which is the only holder of
-        a handle on these processes. They are kept in the frame readers process
-        group so that killing it takes them with it.
-        """
-        try:
-            if self._log_pipe:
-                self._log_pipe.close()
-                self._log_pipe = None
-        except OSError as error:
-            self._logger.error("Failed to close log pipe: %s", error)
-
-        self._log_pipe = LogPipe(
-            self._logger, FFMPEG_LOGLEVELS[self._config[CONFIG_FFMPEG_LOGLEVEL]]
-        )
-
-        if self._config.get(CONFIG_SUBSTREAM, None):
-            self.segment_process = RestartablePopen(
-                self.build_segment_command(),
-                name=f"viseron.camera.{self._camera.identifier}.segments",
-                stdin=sp.DEVNULL,
-                stdout=sp.PIPE,
-                stderr=self._log_pipe,
-                start_new_session=False,
-            )
-
-        return RestartablePopen(
-            self.build_command(),
-            name=f"viseron.camera.{self._camera.identifier}.pipe",
-            register=False,
-            stdin=sp.DEVNULL,
-            stdout=sp.PIPE,
-            stderr=self._log_pipe,
-            start_new_session=False,
-        )
+    @property
+    def segment_process(self) -> RestartablePopen | None:
+        """Return the segment subprocess."""
+        if self._ffmpeg_pipe:
+            return self._ffmpeg_pipe.segment_process
+        return None
 
     def start_pipe(self) -> None:
         """Start piping frames from FFmpeg."""
-        self._logger.debug(f"FFmpeg decoder command: {' '.join(self.build_command())}")
-        if self._config.get(CONFIG_SUBSTREAM, None):
-            self._logger.debug(
-                f"FFmpeg segments command: {' '.join(self.build_segment_command())}"
-            )
-
-        self._pipe = self.pipe()
+        self._ffmpeg_pipe = FFmpegPipe(
+            self._camera_identifier,
+            self._logger,
+            FFMPEG_LOGLEVELS[self._config[CONFIG_FFMPEG_LOGLEVEL]],
+            decoder_command=self.build_command(),
+            segment_command=(
+                self.build_segment_command()
+                if self._config.get(CONFIG_SUBSTREAM, None)
+                else None
+            ),
+        )
+        self._ffmpeg_pipe.start()
 
     def close_pipe(self) -> None:
         """Close FFmpeg pipe."""
-        self._logger.debug("Closing pipe")
-        if self.segment_process:
-            self._logger.debug("Terminating segment process")
-            try:
-                self.segment_process.terminate()
-                try:
-                    self.segment_process.communicate(timeout=5)
-                except sp.TimeoutExpired:
-                    self._logger.debug("FFmpeg did not terminate, killing instead.")
-                    self.segment_process.kill()
-                    self.segment_process.communicate()
-            except (AttributeError, OSError) as error:
-                self._logger.error("Failed to close segment process: %s", error)
-
-        if self._pipe:
-            try:
-                self._pipe.terminate()
-                try:
-                    self._pipe.communicate(timeout=5)
-                except sp.TimeoutExpired:
-                    self._logger.debug("FFmpeg did not terminate, killing instead.")
-                    self._pipe.kill()
-                    self._pipe.communicate()
-            except (AttributeError, OSError) as error:
-                self._logger.error("Failed to close pipe: %s", error)
-
-        try:
-            if self._log_pipe:
-                self._log_pipe.close()
-                self._log_pipe = None
-        except OSError as error:
-            self._logger.error("Failed to close log pipe: %s", error)
+        if self._ffmpeg_pipe:
+            self._ffmpeg_pipe.close()
 
     def poll(self) -> int | None:
         """Poll pipe."""
-        if self._pipe:
-            return self._pipe.poll()
+        if self._ffmpeg_pipe:
+            return self._ffmpeg_pipe.poll()
         return None
 
     def read(self) -> bytes | None:
         """Return a single frame from FFmpeg pipe."""
-        try:
-            if self._pipe and self._pipe.stdout:
-                return self._pipe.stdout.read(self.frame_bytes_size)
-        except Exception:  # pylint: disable=broad-except
-            self._logger.exception("Error reading frame from pipe")
+        if self._ffmpeg_pipe:
+            return self._ffmpeg_pipe.read(self.frame_bytes_size)
         return None
 
     def record_only(self) -> None:
         """Record only the stream."""
-        self._logger.debug(
-            f"Recording only stream: {' '.join(self.build_segment_command())}"
+        self._ffmpeg_pipe = FFmpegPipe(
+            self._camera_identifier,
+            self._logger,
+            FFMPEG_LOGLEVELS[self._config[CONFIG_FFMPEG_LOGLEVEL]],
+            segment_command=self.build_segment_command(),
         )
-        try:
-            if self._log_pipe:
-                self._log_pipe.close()
-                self._log_pipe = None
-        except OSError as error:
-            self._logger.error("Failed to close log pipe: %s", error)
-
-        self._log_pipe = LogPipe(
-            self._logger, FFMPEG_LOGLEVELS[self._config[CONFIG_FFMPEG_LOGLEVEL]]
-        )
-
-        self.segment_process = RestartablePopen(
-            self.build_segment_command(),
-            name=f"viseron.camera.{self._camera.identifier}.segments",
-            stdin=sp.DEVNULL,
-            stdout=sp.PIPE,
-            stderr=self._log_pipe,
-        )
+        self._ffmpeg_pipe.start()
 
 
 class FFprobe:

--- a/viseron/components/ffmpeg/stream.py
+++ b/viseron/components/ffmpeg/stream.py
@@ -560,37 +560,10 @@ class Stream:
             return self._ffmpeg_pipe.segment_process
         return None
 
-    def start_pipe(self) -> None:
-        """Start piping frames from FFmpeg."""
-        self._ffmpeg_pipe = FFmpegPipe(
-            self._camera_identifier,
-            self._logger,
-            FFMPEG_LOGLEVELS[self._config[CONFIG_FFMPEG_LOGLEVEL]],
-            decoder_command=self.build_command(),
-            segment_command=(
-                self.build_segment_command()
-                if self._config.get(CONFIG_SUBSTREAM, None)
-                else None
-            ),
-        )
-        self._ffmpeg_pipe.start()
-
     def close_pipe(self) -> None:
         """Close FFmpeg pipe."""
         if self._ffmpeg_pipe:
             self._ffmpeg_pipe.close()
-
-    def poll(self) -> int | None:
-        """Poll pipe."""
-        if self._ffmpeg_pipe:
-            return self._ffmpeg_pipe.poll()
-        return None
-
-    def read(self) -> bytes | None:
-        """Return a single frame from FFmpeg pipe."""
-        if self._ffmpeg_pipe:
-            return self._ffmpeg_pipe.read(self.frame_bytes_size)
-        return None
 
     def record_only(self) -> None:
         """Record only the stream."""

--- a/viseron/components/gstreamer/gst_process.py
+++ b/viseron/components/gstreamer/gst_process.py
@@ -50,6 +50,16 @@ class GstProcessConfig:
     log_level: int
 
 
+def gst_logger_names(camera_identifier: str) -> tuple[str, ...]:
+    """Return the names of the loggers the GStreamer child process creates.
+
+    Kept here instead of derived from the stream module so that the parent can
+    resolve their log levels without duplicating the names.
+    """
+    logger_name = f"viseron.components.gstreamer.stream.{camera_identifier}"
+    return (logger_name, f"{logger_name}.gstreamer")
+
+
 def segment_location(config: GstProcessConfig) -> str:
     """Return the location of the next segment."""
     timestamp = int(datetime.datetime.now().timestamp())
@@ -71,10 +81,9 @@ class GstRunner:
         self._config = config
         self._frame_queue = frame_queue
         self._exit_event = exit_event
-        self._logger = logging.getLogger(
-            f"viseron.components.gstreamer.stream.{config.camera_identifier}"
-        )
-        self._logger_gstreamer = logging.getLogger(f"{self._logger.name}.gstreamer")
+        logger_name, gstreamer_logger_name = gst_logger_names(config.camera_identifier)
+        self._logger = logging.getLogger(logger_name)
+        self._logger_gstreamer = logging.getLogger(gstreamer_logger_name)
 
     def on_new_sample(self, app_sink: GstApp.AppSink) -> Gst.FlowReturn:
         """Read a sample from the appsink and queue its bytes."""

--- a/viseron/components/gstreamer/gst_process.py
+++ b/viseron/components/gstreamer/gst_process.py
@@ -1,0 +1,163 @@
+"""GStreamer pipeline, executed in a child process.
+
+Entrypoint of the GStreamer child process. Like the ffmpeg frame reader, it takes
+only plain data so the child can be created with the forkserver start method instead
+of fork to reduce memory usage.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import gi
+import setproctitle
+
+from viseron.helpers import pop_if_full
+from viseron.helpers.logs import enable_child_logging
+
+from .const import CONFIG_LOGLEVEL_TO_GSTREAMER, GSTREAMER_LOGLEVEL_TO_PYTHON
+
+# pylint: disable=useless-suppression
+# pylint: disable=wrong-import-position,wrong-import-order,no-name-in-module
+gi.require_version("Gst", "1.0")
+gi.require_version("GstApp", "1.0")
+from gi.repository import GLib, Gst, GstApp  # noqa: E402
+
+# pylint: enable=useless-suppression
+# pylint: enable=wrong-import-position,wrong-import-order,no-name-in-module
+
+if TYPE_CHECKING:
+    from multiprocessing import Queue
+    from multiprocessing.synchronize import Event
+
+
+@dataclass(frozen=True)
+class GstProcessConfig:
+    """Everything the GStreamer child process needs, as plain picklable data."""
+
+    camera_identifier: str
+    alias: str
+    pipeline: str
+    gst_loglevel: str
+    temp_segments_folder: str
+    extension: str
+    sensitive_strings: tuple[str, ...]
+    log_level: int
+
+
+def segment_location(config: GstProcessConfig) -> str:
+    """Return the location of the next segment."""
+    timestamp = int(datetime.datetime.now().timestamp())
+    return os.path.join(
+        config.temp_segments_folder,
+        f"{timestamp}.{config.extension}",
+    )
+
+
+class GstRunner:
+    """Run a GStreamer pipeline and push frames onto a queue."""
+
+    def __init__(
+        self,
+        config: GstProcessConfig,
+        frame_queue: Queue[bytes],  # pylint: disable=unsubscriptable-object
+        exit_event: Event,
+    ) -> None:
+        self._config = config
+        self._frame_queue = frame_queue
+        self._exit_event = exit_event
+        self._logger = logging.getLogger(
+            f"viseron.components.gstreamer.stream.{config.camera_identifier}"
+        )
+        self._logger_gstreamer = logging.getLogger(f"{self._logger.name}.gstreamer")
+
+    def on_new_sample(self, app_sink: GstApp.AppSink) -> Gst.FlowReturn:
+        """Read a sample from the appsink and queue its bytes."""
+        sample = app_sink.emit("pull-sample")
+        if not isinstance(sample, Gst.Sample):
+            self._logger.debug("Could not get sample from appsink")
+            return Gst.FlowReturn.ERROR
+
+        buffer = sample.get_buffer()
+        if not buffer:
+            self._logger.debug("Could not get buffer from sample")
+            return Gst.FlowReturn.ERROR
+
+        success, map_info = buffer.map(Gst.MapFlags.READ)
+        if not success:
+            self._logger.debug("Could not map buffer data")
+            return Gst.FlowReturn.ERROR
+
+        pop_if_full(self._frame_queue, bytes(map_info.data))
+
+        buffer.unmap(map_info)
+        return Gst.FlowReturn.OK
+
+    def on_format_location(self, _splitmux, _fragment_id, _udata) -> str:
+        """Return the location of the next segment."""
+        return segment_location(self._config)
+
+    def on_gst_log_message(
+        self,
+        category: Gst.DebugCategory,
+        level: Gst.DebugLevel,
+        file: str,
+        function: str,
+        line: int,
+        _object,
+        message: Gst.DebugMessage,
+        *_user_data: None,
+    ) -> None:
+        """Handle GStreamer log messages."""
+        self._logger_gstreamer.log(
+            GSTREAMER_LOGLEVEL_TO_PYTHON[level],
+            "%s %s:%s:%s: %s",
+            category.get_name(),
+            file,
+            line,
+            function,
+            message.get(),
+        )
+
+    def run(self) -> None:
+        """Run the GStreamer pipeline until the exit event is set."""
+        mainloop = GLib.MainLoop()
+
+        Gst.init(None)
+        # Remove logging to stderr
+        Gst.debug_remove_log_function(None)
+        Gst.debug_set_default_threshold(
+            CONFIG_LOGLEVEL_TO_GSTREAMER[self._config.gst_loglevel]
+        )
+        Gst.debug_add_log_function(self.on_gst_log_message, None)
+
+        gst_pipeline = Gst.parse_launch(self._config.pipeline)
+        appsink = gst_pipeline.get_by_name(  # type: ignore[attr-defined]
+            "sink",
+        )
+        appsink.connect("new-sample", self.on_new_sample)
+        mux = gst_pipeline.get_by_name("mux")  # type: ignore[attr-defined]
+        mux.connect("format-location", self.on_format_location, None)
+
+        gst_pipeline.set_state(Gst.State.PLAYING)
+        while not self._exit_event.is_set():
+            time.sleep(1)
+
+        gst_pipeline.set_state(Gst.State.NULL)
+        mainloop.quit()
+
+
+def run_gstreamer(
+    config: GstProcessConfig,
+    frame_queue: Queue[bytes],  # pylint: disable=unsubscriptable-object
+    exit_event: Event,
+) -> None:
+    """Entrypoint of the GStreamer child process."""
+    setproctitle.setproctitle(config.alias)
+    enable_child_logging(config.sensitive_strings, config.log_level)
+    GstRunner(config, frame_queue, exit_event).run()

--- a/viseron/components/gstreamer/stream.py
+++ b/viseron/components/gstreamer/stream.py
@@ -264,7 +264,7 @@ class Stream(FFmpegStream):
             return self._process_frames_proc.exitcode
         return None
 
-    def read(self) -> SharedFrame | None:  # type: ignore[override]
+    def read(self) -> SharedFrame | None:
         """Return a single frame from Gst buffer."""
         try:
             if self._process_frames_proc:

--- a/viseron/components/gstreamer/stream.py
+++ b/viseron/components/gstreamer/stream.py
@@ -31,7 +31,7 @@ from .const import (
     ENV_GSTREAMER_PATH,
     PIXEL_FORMAT,
 )
-from .gst_process import GstProcessConfig, run_gstreamer
+from .gst_process import GstProcessConfig, gst_logger_names, run_gstreamer
 from .pipeline import AbstractPipeline, BasePipeline, JetsonPipeline, RawPipeline
 
 if TYPE_CHECKING:
@@ -163,6 +163,7 @@ class Stream(FFmpegStream):
             name=self.alias,
             daemon=True,
             context=CHILD_PROCESS_START_METHOD,
+            child_logger_names=gst_logger_names(self._camera_identifier),
         )
         self._process_frames_proc_exit.clear()
         self._process_frames_proc.start()

--- a/viseron/components/gstreamer/stream.py
+++ b/viseron/components/gstreamer/stream.py
@@ -3,15 +3,9 @@
 # pyright: reportMissingModuleSource=false
 from __future__ import annotations
 
-import datetime
 import logging
-import multiprocessing as mp
 import os
-import time
 from typing import TYPE_CHECKING, Any
-
-import gi
-import setproctitle
 
 from viseron.components.ffmpeg.stream import FFprobe, Stream as FFmpegStream
 from viseron.const import (
@@ -23,33 +17,27 @@ from viseron.const import (
 )
 from viseron.domains.camera.shared_frames import SharedFrame
 from viseron.helpers import pop_if_full
-from viseron.helpers.logs import UnhelpfullLogFilter
+from viseron.helpers.child_process_context import (
+    CHILD_PROCESS_START_METHOD,
+    get_child_process_context,
+)
+from viseron.helpers.logs import SensitiveInformationFilter, UnhelpfullLogFilter
 from viseron.watchdog.process_watchdog import RestartableProcess
 
 from .const import (
     CONFIG_GSTREAMER_LOGLEVEL,
     CONFIG_GSTREAMER_RECOVERABLE_ERRORS,
-    CONFIG_LOGLEVEL_TO_GSTREAMER,
     CONFIG_RAW_PIPELINE,
     ENV_GSTREAMER_PATH,
-    GSTREAMER_LOGLEVEL_TO_PYTHON,
     PIXEL_FORMAT,
 )
+from .gst_process import GstProcessConfig, run_gstreamer
 from .pipeline import AbstractPipeline, BasePipeline, JetsonPipeline, RawPipeline
 
 if TYPE_CHECKING:
-    from multiprocessing.synchronize import Event as EventClass
+    import multiprocessing as mp
 
     from viseron.components.gstreamer.camera import Camera
-
-# pylint: disable=useless-suppression
-# pylint: disable=wrong-import-position,wrong-import-order,no-name-in-module
-gi.require_version("Gst", "1.0")
-gi.require_version("GstApp", "1.0")
-from gi.repository import GLib, Gst, GstApp  # noqa: E402
-
-# pylint: enable=useless-suppression
-# pylint: enable=wrong-import-position,wrong-import-order,no-name-in-module
 
 
 class Stream(FFmpegStream):
@@ -81,8 +69,9 @@ class Stream(FFmpegStream):
 
         self._logger_gstreamer = logging.getLogger(f"{self._logger.name}.gstreamer")
         self._process_frames_proc: RestartableProcess | None = None
-        self._frame_queue: mp.Queue[bytes] = mp.Queue(maxsize=1)
-        self._process_frames_proc_exit = mp.Event()
+        self._mp_context = get_child_process_context()
+        self._frame_queue: mp.Queue[bytes] = self._mp_context.Queue(maxsize=1)
+        self._process_frames_proc_exit = self._mp_context.Event()
 
         self._output_fps = self.fps
         self._pixel_format = PIXEL_FORMAT.lower()
@@ -148,98 +137,32 @@ class Stream(FFmpegStream):
         """
         raise NotImplementedError
 
-    def on_new_sample(self, app_sink: GstApp.AppSink) -> Gst.FlowReturn:
-        """Process new buffer from appsink."""
-        sample = app_sink.get_last_sample()
-
-        if not isinstance(sample, Gst.Sample):
-            self._logger.debug("Did not get sample from appsink")
-            return Gst.FlowReturn.ERROR
-
-        buffer = sample.get_buffer()
-        if not buffer:
-            self._logger.debug("Could not get buffer from sample")
-            return Gst.FlowReturn.ERROR
-
-        success, map_info = buffer.map(Gst.MapFlags.READ)
-        if not success:
-            self._logger.debug("Could not map buffer data")
-            return Gst.FlowReturn.ERROR
-
-        pop_if_full(self._frame_queue, bytes(map_info.data))
-
-        buffer.unmap(map_info)
-        return Gst.FlowReturn.OK
-
-    def on_format_location(self, _splitmux, _fragment_id, _udata) -> str:
-        """Return the location of the next segment."""
-        timestamp = int(datetime.datetime.now().timestamp())
-        return os.path.join(
-            self._camera.temp_segments_folder,
-            f"{timestamp}.{self._camera.extension}",
-        )
-
-    def on_gst_log_message(
-        self,
-        category: Gst.DebugCategory,
-        level: Gst.DebugLevel,
-        file: str,
-        function: str,
-        line: int,
-        _object,
-        message: Gst.DebugMessage,
-        *_user_data: None,
-    ):
-        """Handle GStreamer log messages."""
-        self._logger_gstreamer.log(
-            GSTREAMER_LOGLEVEL_TO_PYTHON[level],
-            "%s %s:%s:%s: %s",
-            category.get_name(),
-            file,
-            line,
-            function,
-            message.get(),
-        )
-
-    def run_gstreamer(self, process_frames_proc_exit: EventClass) -> None:
-        """Run GStreamer in a subprocess."""
-        setproctitle.setproctitle(self.alias)
-        mainloop = GLib.MainLoop()
-
-        Gst.init(None)
-        # Remove logging to stderr
-        Gst.debug_remove_log_function(None)
-        Gst.debug_set_default_threshold(
-            CONFIG_LOGLEVEL_TO_GSTREAMER[self._config[CONFIG_GSTREAMER_LOGLEVEL]]
-        )
-        Gst.debug_add_log_function(self.on_gst_log_message, None)
-
-        gst_pipeline = Gst.parse_launch(" ".join(self._pipeline.build_pipeline()))
-        appsink = gst_pipeline.get_by_name(  # type: ignore[attr-defined]
-            "sink",
-        )
-        appsink.connect("new-sample", self.on_new_sample)
-        mux = gst_pipeline.get_by_name("mux")  # type: ignore[attr-defined]
-        mux.connect("format-location", self.on_format_location, None)
-
-        gst_pipeline.set_state(Gst.State.PLAYING)
-        while not process_frames_proc_exit.is_set():
-            time.sleep(1)
-
-        gst_pipeline.set_state(Gst.State.NULL)
-        mainloop.quit()
-
     def start_pipe(self) -> None:
         """Start piping frames from GStreamer."""
-        self._logger.debug(
-            f"GStreamer decoder command: {' '.join(self._pipeline.build_pipeline())}"
+        pipeline = " ".join(self._pipeline.build_pipeline())
+        self._logger.debug(f"GStreamer decoder command: {pipeline}")
+
+        gst_config = GstProcessConfig(
+            camera_identifier=self._camera_identifier,
+            alias=self.alias,
+            pipeline=pipeline,
+            gst_loglevel=self._config[CONFIG_GSTREAMER_LOGLEVEL],
+            temp_segments_folder=self._camera.temp_segments_folder,
+            extension=self._camera.extension,
+            sensitive_strings=tuple(SensitiveInformationFilter.sensitive_strings),
+            log_level=logging.getLogger().level,
         )
 
         self._process_frames_proc = RestartableProcess(
-            target=self.run_gstreamer,
-            args=(self._process_frames_proc_exit,),
+            target=run_gstreamer,
+            args=(
+                gst_config,
+                self._frame_queue,
+                self._process_frames_proc_exit,
+            ),
             name=self.alias,
             daemon=True,
+            context=CHILD_PROCESS_START_METHOD,
         )
         self._process_frames_proc_exit.clear()
         self._process_frames_proc.start()

--- a/viseron/components/logger/__init__.py
+++ b/viseron/components/logger/__init__.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 
+from viseron.helpers.logs import refresh_child_log_levels
 from viseron.helpers.validators import CameraIdentifier, CoerceNoneToDict, Maybe
 
 from .const import (
@@ -76,6 +77,7 @@ def setup(vis: Viseron, config: dict[str, Any]) -> bool:
         # During reload, apply only the changes between the old and new config to avoid
         # resetting log levels unnecessarily and causing log spam.
         _apply_config_changes(vis, logger_config)
+        refresh_child_log_levels()
         return True
 
     vis.data[COMPONENT] = {}
@@ -102,6 +104,7 @@ def setup(vis: Viseron, config: dict[str, Any]) -> bool:
             vis, logger_config[CONFIG_LOGS], vis.data[COMPONENT][CONFIG_CAMERAS]
         )
 
+    refresh_child_log_levels()
     return True
 
 

--- a/viseron/helpers/child_process_context.py
+++ b/viseron/helpers/child_process_context.py
@@ -1,0 +1,33 @@
+"""Multiprocessing context used for long-running child processes.
+
+Children are created with the ``forkserver`` start method instead of ``fork``.
+``forkserver.ensure_running()`` fork+execs a fresh interpreter, so the snapshot
+children fork from is clean no matter how much memory the main process is using or
+when the child is created.
+
+Note that multiprocessing primitives are context-bound: a Queue or Event created in
+the fork context cannot be passed to a forkserver child. Anything shared with a child
+must be created from the context returned here.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+from typing import cast
+
+CHILD_PROCESS_START_METHOD = "forkserver"
+
+_PRELOAD_SET = False
+
+
+def get_child_process_context() -> mp.context.ForkServerContext:
+    """Return the multiprocessing context for long-running child processes."""
+    global _PRELOAD_SET  # noqa: PLW0603  # pylint: disable=global-statement
+
+    context = cast(
+        "mp.context.ForkServerContext", mp.get_context(CHILD_PROCESS_START_METHOD)
+    )
+    if not _PRELOAD_SET:
+        context.set_forkserver_preload(["viseron.helpers.child_process_preload"])
+        _PRELOAD_SET = True
+    return context

--- a/viseron/helpers/child_process_preload.py
+++ b/viseron/helpers/child_process_preload.py
@@ -1,0 +1,29 @@
+"""Modules preloaded into the multiprocessing forkserver.
+
+Importing any ``viseron.*`` submodule executes ``viseron/__init__.py``, which pulls
+in roughly a lot of dependencies. Preloading the child entrypoints means every child
+shares that copy-on-write instead of importing a private copy after forking.
+Only works together with ``gc.freeze()`` in the child.
+"""
+
+import importlib
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+PRELOAD_MODULES = (
+    "viseron.components.ffmpeg.frame_reader",
+    "viseron.components.gstreamer.gst_process",
+)
+
+
+def preload() -> None:
+    """Import the child process entrypoint modules, ignoring failures."""
+    for module in PRELOAD_MODULES:
+        try:
+            importlib.import_module(module)
+        except Exception:  # pylint: disable=broad-except # noqa: BLE001
+            LOGGER.debug(f"Could not preload {module}", exc_info=True)
+
+
+preload()

--- a/viseron/helpers/child_process_preload.py
+++ b/viseron/helpers/child_process_preload.py
@@ -1,7 +1,7 @@
 """Modules preloaded into the multiprocessing forkserver.
 
 Importing any ``viseron.*`` submodule executes ``viseron/__init__.py``, which pulls
-in roughly a lot of dependencies. Preloading the child entrypoints means every child
+in a lot of dependencies. Preloading the child entrypoints means every child
 shares that copy-on-write instead of importing a private copy after forking.
 Only works together with ``gc.freeze()`` in the child.
 """

--- a/viseron/helpers/logs.py
+++ b/viseron/helpers/logs.py
@@ -24,6 +24,7 @@ from viseron.helpers import parse_size_to_bytes
 
 if typing.TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator
+    from multiprocessing.context import BaseContext
     from types import TracebackType
 
 LOGGER = logging.getLogger(__name__)
@@ -527,6 +528,95 @@ def enable_logging(level: int = logging.INFO) -> None:
     _setup_logging(level, rollover=True)
 
 
+class ChildLogLevels:
+    """Log levels of the loggers a child process creates, shared through memory.
+
+    The logger component installs its overrides on the logger class and on the
+    already existing loggers, which child processes can't access when using forkserver.
+    The effective levels are therefore resolved in the parent and read back from
+    shared memory by the child, which allows the child to start with the current levels.
+    """
+
+    def __init__(self, mp_context: BaseContext, logger_names: tuple[str, ...]) -> None:
+        self._logger_names = logger_names
+        self._levels = mp_context.Array("i", len(logger_names))
+        self._changed = mp_context.Event()
+        self._resolve()
+
+    def _resolve(self) -> None:
+        """Store the levels the parent resolves for the child loggers."""
+        for index, logger_name in enumerate(self._logger_names):
+            self._levels[index] = logging.getLogger(logger_name).getEffectiveLevel()
+
+    def start(self) -> threading.Thread:
+        """Apply the levels in this process and keep applying every refresh."""
+        self.apply()
+        thread = threading.Thread(
+            target=self._watch, name="child_log_levels", daemon=True
+        )
+        thread.start()
+        return thread
+
+    def _watch(self) -> NoReturn:
+        """Apply every refresh the parent makes, for the life of the process."""
+        while True:
+            self.wait_and_apply()
+
+    def refresh(self) -> None:
+        """Resolve the levels again and notify the child that they changed."""
+        self._resolve()
+        self._changed.set()
+
+    def wait_and_apply(self, timeout: float | None = None) -> bool:
+        """Block until the parent refreshes the levels, then apply them.
+
+        Returns False if the timeout was reached before a refresh. The event is
+        cleared before the levels are read, so a refresh that lands while they
+        are being applied results in another, idempotent, round.
+        """
+        if not self._changed.wait(timeout):
+            return False
+        self._changed.clear()
+        self.apply()
+        return True
+
+    def apply(self) -> None:
+        """Apply the shared levels to the loggers in this process."""
+        for logger_name, level in zip(self._logger_names, self._levels[:], strict=True):
+            logging.getLogger(logger_name).setLevel(level)
+
+
+_CHILD_LOG_LEVELS: dict[str, ChildLogLevels] = {}
+_CHILD_LOG_LEVELS_LOCK = threading.Lock()
+
+
+def register_child_log_levels(
+    key: str, mp_context: BaseContext, logger_names: tuple[str, ...]
+) -> ChildLogLevels:
+    """Return shared log levels for a child process, registered for refreshes."""
+    child_log_levels = ChildLogLevels(mp_context, logger_names)
+    with _CHILD_LOG_LEVELS_LOCK:
+        _CHILD_LOG_LEVELS[key] = child_log_levels
+    return child_log_levels
+
+
+def unregister_child_log_levels(key: str) -> None:
+    """Stop refreshing the log levels of a child that is gone."""
+    with _CHILD_LOG_LEVELS_LOCK:
+        _CHILD_LOG_LEVELS.pop(key, None)
+
+
+def refresh_child_log_levels() -> None:
+    """Push the current log levels to every registered child process.
+
+    Called when the logger component has applied a new configuration.
+    """
+    with _CHILD_LOG_LEVELS_LOCK:
+        child_log_levels = list(_CHILD_LOG_LEVELS.values())
+    for child in child_log_levels:
+        child.refresh()
+
+
 def enable_child_logging(sensitive_strings: tuple[str, ...], level: int) -> None:
     """Configure logging inside a child process.
 
@@ -534,6 +624,8 @@ def enable_child_logging(sensitive_strings: tuple[str, ...], level: int) -> None
     logging configuration, so it has to be re-established.
     The sensitive strings collected by the parent are not inherited either and are
     therefore passed in and seeded here.
+    The levels of the loggers the child creates are restored by `ChildLogLevels`
+    before the child entrypoint runs.
     The log file is not rotated since the parent already did that on startup.
     """
     _setup_logging(level, sensitive_strings=sensitive_strings)

--- a/viseron/helpers/logs.py
+++ b/viseron/helpers/logs.py
@@ -6,17 +6,27 @@ import io
 import logging
 import os
 import re
+import sys
 import threading
 import typing
-from typing import Any, AnyStr, ClassVar, Literal, NoReturn, TextIO
+from logging.handlers import RotatingFileHandler
+from typing import Any, AnyStr, ClassVar, Final, Literal, NoReturn, TextIO
 
 from colorlog import ColoredFormatter
 
-from viseron.const import ENV_DEV_WARNINGS
+from viseron.const import (
+    ENV_DEV_WARNINGS,
+    ENV_LOG_BACKUP_COUNT,
+    ENV_LOG_MAX_BYTES,
+    VISERON_LOG_PATH,
+)
+from viseron.helpers import parse_size_to_bytes
 
 if typing.TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator
     from types import TracebackType
+
+LOGGER = logging.getLogger(__name__)
 
 LOG_FORMAT = "%(asctime)s.%(msecs)03d [%(levelname)-8s] [%(name)s] - %(message)s"
 STREAM_LOG_FORMAT = "%(log_color)s" + LOG_FORMAT
@@ -394,3 +404,136 @@ def development_warning(logger: logging.Logger, message: str) -> None:
     """Log a warning in development mode."""
     if os.environ.get(ENV_DEV_WARNINGS, None):
         logger.warning(message)
+
+
+def _get_rotation_rules() -> tuple[int, int]:
+    """Return log rotation rules from the environment."""
+    env_max_bytes = os.getenv(ENV_LOG_MAX_BYTES)
+    env_backup_count = os.getenv(ENV_LOG_BACKUP_COUNT)
+
+    max_bytes = 0
+    if env_max_bytes is not None:
+        try:
+            max_bytes = parse_size_to_bytes(env_max_bytes)
+        except ValueError as error:
+            LOGGER.error(
+                f"Failed to parse {ENV_LOG_MAX_BYTES} as int, using default value",
+                exc_info=error,
+            )
+
+    backup_count = 1
+    if env_backup_count is not None:
+        try:
+            backup_count = parse_size_to_bytes(env_backup_count)
+        except ValueError as error:
+            LOGGER.error(
+                f"Failed to parse {ENV_LOG_BACKUP_COUNT} as int, using default value",
+                exc_info=error,
+            )
+
+    return max_bytes, backup_count
+
+
+# Third party loggers that are too chatty on their default level
+NOISY_LOGGERS: Final[dict[str, int]] = {
+    "apscheduler.scheduler": logging.ERROR,
+    "apscheduler.executors": logging.ERROR,
+    "requests": logging.WARNING,
+    "urllib3": logging.WARNING,
+    "httpx": logging.WARNING,
+    "httpcore": logging.WARNING,
+    "tornado.access": logging.WARNING,
+    "tornado.application": logging.WARNING,
+    "tornado.general": logging.WARNING,
+    "sqlalchemy.engine": logging.WARNING,
+    "watchdog.observers.inotify_buffer": logging.WARNING,
+}
+
+
+def _silence_noisy_loggers() -> None:
+    """Raise the log level of noisy third party loggers."""
+    for logger_name, level in NOISY_LOGGERS.items():
+        logging.getLogger(logger_name).setLevel(level)
+
+
+def _install_excepthooks() -> None:
+    """Log uncaught exceptions from the main thread as well as from threads."""
+    sys.excepthook = lambda *args: logging.getLogger(None).error(
+        "Uncaught exception", exc_info=args
+    )
+    threading.excepthook = lambda args: logging.getLogger(None).error(
+        "Uncaught thread exception in thread %s",
+        args.thread.name if args.thread else "unknown",
+        exc_info=(
+            args.exc_type,
+            args.exc_value,
+            args.exc_traceback,
+        ),  # type: ignore[arg-type]
+    )
+
+
+def _setup_logging(
+    level: int,
+    *,
+    sensitive_strings: tuple[str, ...] = (),
+    rollover: bool = False,
+) -> None:
+    """Configure the root logger with Viserons handlers and filters.
+
+    Any handlers already attached to the root logger are replaced, making this
+    safe to call more than once.
+    """
+    for sensitive_string in sensitive_strings:
+        SensitiveInformationFilter.add_sensitive_string(sensitive_string)
+
+    root_logger = logging.getLogger()
+    root_logger.propagate = False
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+
+    sensitive_information_filter = SensitiveInformationFilter()
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(ViseronLogFormat())
+    stream_handler.addFilter(DuplicateFilter())
+    stream_handler.addFilter(sensitive_information_filter)
+    root_logger.addHandler(stream_handler)
+
+    max_bytes, backup_count = _get_rotation_rules()
+    file_handler = RotatingFileHandler(
+        VISERON_LOG_PATH,
+        maxBytes=max_bytes,
+        backupCount=backup_count,
+        delay=True,
+    )
+    file_handler.setFormatter(
+        logging.Formatter(fmt=LOG_FORMAT, datefmt=LOG_DATE_FORMAT)
+    )
+    file_handler.addFilter(sensitive_information_filter)
+    if rollover:
+        file_handler.doRollover()
+    root_logger.addHandler(file_handler)
+
+    root_logger.setLevel(level)
+    _silence_noisy_loggers()
+    _install_excepthooks()
+
+
+def enable_logging(level: int = logging.INFO) -> None:
+    """Enable logging in the main process.
+
+    Rotates the log file so that every start of Viseron gets a fresh log.
+    """
+    _setup_logging(level, rollover=True)
+
+
+def enable_child_logging(sensitive_strings: tuple[str, ...], level: int) -> None:
+    """Configure logging inside a child process.
+
+    Children created with the forkserver start method do not inherit the parent's
+    logging configuration, so it has to be re-established.
+    The sensitive strings collected by the parent are not inherited either and are
+    therefore passed in and seeded here.
+    The log file is not rotated since the parent already did that on startup.
+    """
+    _setup_logging(level, sensitive_strings=sensitive_strings)

--- a/viseron/watchdog/process_watchdog.py
+++ b/viseron/watchdog/process_watchdog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import gc
 import logging
 import multiprocessing as mp
 import os
@@ -9,7 +10,6 @@ import signal
 from typing import TYPE_CHECKING
 
 from apscheduler.schedulers.background import BackgroundScheduler
-from apscheduler.schedulers.base import SchedulerNotRunningError
 
 from viseron.const import VISERON_SIGNAL_SHUTDOWN
 from viseron.helpers import utcnow
@@ -21,6 +21,50 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 LOGGER = logging.getLogger(__name__)
+
+
+class _ChildProcessTarget:
+    """Picklable wrapper executed as the child process entrypoint."""
+
+    def __init__(self, target: Callable, start_watchdogs: bool) -> None:
+        self._target = target
+        self._start_watchdogs = start_watchdogs
+        self._background_scheduler: BackgroundScheduler | None = None
+        self._thread_watchdog: ThreadWatchDog | None = None
+        self._subprocess_watchdog: SubprocessWatchDog | None = None
+        self._process_watchdog: ProcessWatchDog | None = None
+
+    def __call__(self, *args, **kwargs):
+        """Set up the child process, then run the wrapped target.
+
+        Creating a new session (setsid) ensures the child process becomes the leader
+        of a new session and process group. This makes signal management) more robust
+        and prevents the process from receiving signals intended for the parent group.
+
+        gc.freeze() moves everything already allocated into a permanent generation
+        that the collector never scans again. Without it the collector writes to the
+        gc header of every tracked object.
+        """
+        os.setsid()
+        gc.freeze()
+        ThreadWatchDog.started = False
+        SubprocessWatchDog.started = False
+        ProcessWatchDog.started = False
+        if self._start_watchdogs:
+            self._start_local_watchdogs()
+        self._target(*args, **kwargs)
+
+    def _start_local_watchdogs(self) -> None:
+        """Start watchdogs inside the child process.
+
+        Threads, subprocesses and processes are monitored in the parent, but if the
+        child itself spawns long-running entities, those need to be monitored too.
+        """
+        self._background_scheduler = BackgroundScheduler(timezone="UTC", daemon=True)
+        self._background_scheduler.start()
+        self._thread_watchdog = ThreadWatchDog(self._background_scheduler)
+        self._subprocess_watchdog = SubprocessWatchDog(self._background_scheduler)
+        self._process_watchdog = ProcessWatchDog(self._background_scheduler)
 
 
 class RestartableProcess:
@@ -36,6 +80,7 @@ class RestartableProcess:
         name=None,
         grace_period=20,
         register=True,
+        context: str | None = None,
         stage: str | None = VISERON_SIGNAL_SHUTDOWN,
         create_process_method: Callable[[], mp.Process] | None = None,
         start_watchdogs: bool = False,
@@ -47,16 +92,13 @@ class RestartableProcess:
         self._kwargs = kwargs
         self._kwargs["name"] = name
         self._original_target: Callable | None = self._kwargs.get("target")
+        self._ctx = mp.get_context(context)
         self._process: mp.Process | None = None
         self._started = False
         self._start_time: float | None = None
         self._register = register
         self._create_process_method = create_process_method
         self._start_watchdogs = start_watchdogs
-        self._background_scheduler: BackgroundScheduler | None = None
-        self._thread_watchdog: ThreadWatchDog | None = None
-        self._subprocess_watchdog: SubprocessWatchDog | None = None
-        self._process_watchdog: ProcessWatchDog | None = None
         if self._register:
             ProcessWatchDog.register(self)
         setattr(self, "__stage__", stage)
@@ -111,33 +153,14 @@ class RestartableProcess:
         # Always (re)set the wrapped target so that restarts also create a new
         # process that calls os.setsid() before executing the user target.
         if self._original_target:
-            original_target = self._original_target
-
-            def wrapped_target(*targs, **tkwargs):
-                """Wrap original target to establish its own session ID.
-
-                Creating a new session (setsid) ensures the child process becomes
-                the leader of a new session and process group. This makes signal
-                management (e.g. terminating entire groups) more robust and
-                prevents the process from receiving signals intended for the
-                parent group.
-
-                Watchdogs are also started inside the process if enabled.
-                """
-                os.setsid()
-                ThreadWatchDog.started = False
-                SubprocessWatchDog.started = False
-                ProcessWatchDog.started = False
-                if self._start_watchdogs:
-                    self._start_local_watchdogs()
-                original_target(*targs, **tkwargs)
-
-            self._kwargs["target"] = wrapped_target
+            self._kwargs["target"] = _ChildProcessTarget(
+                self._original_target, self._start_watchdogs
+            )
 
         if self._create_process_method:
             self._process = self._create_process_method()
         else:
-            self._process = mp.Process(
+            self._process = self._ctx.Process(  # type: ignore[attr-defined]
                 *self._args,
                 **self._kwargs,
             )
@@ -194,22 +217,6 @@ class RestartableProcess:
         self._started = False
         ProcessWatchDog.unregister(self)
 
-        if (
-            self._thread_watchdog
-            and self._subprocess_watchdog
-            and self._process_watchdog
-        ):
-            self._thread_watchdog.stop()
-            self._subprocess_watchdog.stop()
-            self._process_watchdog.stop()
-
-        if self._background_scheduler:
-            try:
-                self._background_scheduler.remove_all_jobs()
-                self._background_scheduler.shutdown(wait=False)
-            except SchedulerNotRunningError as err:
-                LOGGER.warning(f"Failed to shutdown scheduler: {err}")
-
     def terminate(self) -> None:
         """Terminate the process and everything it started."""
         self._started = False
@@ -225,19 +232,6 @@ class RestartableProcess:
         if self._process:
             self._signal_process_group(signal.SIGKILL)
             self._process.kill()
-
-    def _start_local_watchdogs(self) -> None:
-        """Start local watchdogs inside the process.
-
-        Threads, subprocesses and processes are monitored in the parent,
-        but if the process itself spawns long-running entities, those need to
-        be monitored as well.
-        """
-        self._background_scheduler = BackgroundScheduler(timezone="UTC", daemon=True)
-        self._background_scheduler.start()
-        self._thread_watchdog = ThreadWatchDog(self._background_scheduler)
-        self._subprocess_watchdog = SubprocessWatchDog(self._background_scheduler)
-        self._process_watchdog = ProcessWatchDog(self._background_scheduler)
 
 
 class ProcessWatchDog(WatchDog):

--- a/viseron/watchdog/process_watchdog.py
+++ b/viseron/watchdog/process_watchdog.py
@@ -13,6 +13,10 @@ from apscheduler.schedulers.background import BackgroundScheduler
 
 from viseron.const import VISERON_SIGNAL_SHUTDOWN
 from viseron.helpers import utcnow
+from viseron.helpers.logs import (
+    register_child_log_levels,
+    unregister_child_log_levels,
+)
 from viseron.watchdog import WatchDog
 from viseron.watchdog.subprocess_watchdog import SubprocessWatchDog
 from viseron.watchdog.thread_watchdog import ThreadWatchDog
@@ -20,15 +24,23 @@ from viseron.watchdog.thread_watchdog import ThreadWatchDog
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from viseron.helpers.logs import ChildLogLevels
+
 LOGGER = logging.getLogger(__name__)
 
 
 class _ChildProcessTarget:
     """Picklable wrapper executed as the child process entrypoint."""
 
-    def __init__(self, target: Callable, start_watchdogs: bool) -> None:
+    def __init__(
+        self,
+        target: Callable,
+        start_watchdogs: bool,
+        child_log_levels: ChildLogLevels | None = None,
+    ) -> None:
         self._target = target
         self._start_watchdogs = start_watchdogs
+        self._child_log_levels = child_log_levels
         self._background_scheduler: BackgroundScheduler | None = None
         self._thread_watchdog: ThreadWatchDog | None = None
         self._subprocess_watchdog: SubprocessWatchDog | None = None
@@ -38,7 +50,7 @@ class _ChildProcessTarget:
         """Set up the child process, then run the wrapped target.
 
         Creating a new session (setsid) ensures the child process becomes the leader
-        of a new session and process group. This makes signal management) more robust
+        of a new session and process group. This makes signal management more robust
         and prevents the process from receiving signals intended for the parent group.
 
         gc.freeze() moves everything already allocated into a permanent generation
@@ -52,6 +64,8 @@ class _ChildProcessTarget:
         ProcessWatchDog.started = False
         if self._start_watchdogs:
             self._start_local_watchdogs()
+        if self._child_log_levels:
+            self._child_log_levels.start()
         self._target(*args, **kwargs)
 
     def _start_local_watchdogs(self) -> None:
@@ -84,6 +98,7 @@ class RestartableProcess:
         stage: str | None = VISERON_SIGNAL_SHUTDOWN,
         create_process_method: Callable[[], mp.Process] | None = None,
         start_watchdogs: bool = False,
+        child_logger_names: tuple[str, ...] | None = None,
         **kwargs,
     ) -> None:
         self._args = args
@@ -99,6 +114,20 @@ class RestartableProcess:
         self._register = register
         self._create_process_method = create_process_method
         self._start_watchdogs = start_watchdogs
+        self._child_log_levels: ChildLogLevels | None = None
+        if child_logger_names:
+            if create_process_method:
+                raise ValueError(
+                    "child_logger_names needs the wrapped target, which is not used "
+                    "by processes created with create_process_method"
+                )
+            if not name:
+                raise ValueError("child_logger_names requires a name to key them by")
+            # Registered here and unregistered when the process is stopped, so that
+            # a reload of the logger component reaches the child while it runs.
+            self._child_log_levels = register_child_log_levels(
+                name, self._ctx, child_logger_names
+            )
         if self._register:
             ProcessWatchDog.register(self)
         setattr(self, "__stage__", stage)
@@ -154,7 +183,7 @@ class RestartableProcess:
         # process that calls os.setsid() before executing the user target.
         if self._original_target:
             self._kwargs["target"] = _ChildProcessTarget(
-                self._original_target, self._start_watchdogs
+                self._original_target, self._start_watchdogs, self._child_log_levels
             )
 
         if self._create_process_method:
@@ -212,23 +241,31 @@ class RestartableProcess:
         if self._process:
             self._process.join(timeout=timeout)
 
-    def stop(self) -> None:
-        """Stop (unregister) the process."""
+    def _unregister(self) -> None:
+        """Stop monitoring the process and free what is tied to its lifetime.
+
+        Not called by restart, which reuses everything the process was created
+        with, including its shared log levels.
+        """
         self._started = False
         ProcessWatchDog.unregister(self)
+        if self._child_log_levels:
+            unregister_child_log_levels(self._name)
+
+    def stop(self) -> None:
+        """Stop (unregister) the process."""
+        self._unregister()
 
     def terminate(self) -> None:
         """Terminate the process and everything it started."""
-        self._started = False
-        ProcessWatchDog.unregister(self)
+        self._unregister()
         if self._process:
             self._signal_process_group(signal.SIGTERM)
             self._process.terminate()
 
     def kill(self) -> None:
         """Kill the process and everything it started."""
-        self._started = False
-        ProcessWatchDog.unregister(self)
+        self._unregister()
         if self._process:
             self._signal_process_group(signal.SIGKILL)
             self._process.kill()


### PR DESCRIPTION
Viseron uses multiprocessing to spread the load on the hosts available CPU's. This is great for performance, but consumes a lot of memory since the default `fork` method that python uses causes the parents objects to be copied to the child process.

This is especially problematic for things like the camera frame reader which stops/starts on user demand or reconnects, meaning they can be started after the entire application has initialized, thus consuming several gigabytes of RAM for no good reason.

This becomes extra problematic on larger setups.

This PR aims to partially fix this (not all processes are refactored yet) by using the `forkserver` method instead.