### PR TITLE
Show a loading indicator for the first camera snapshot

### DIFF
--- a/frontend/src/components/camera/CameraCard.tsx
+++ b/frontend/src/components/camera/CameraCard.tsx
@@ -31,7 +31,6 @@ import { CameraUptime } from "components/camera/CameraUptime";
 import { FailedCameraCard } from "components/camera/FailedCameraCard";
 import { useAuthContext } from "context/AuthContext";
 import { ViseronContext } from "context/ViseronContext";
-import { useFirstRender } from "hooks/UseFirstRender";
 import useOnScreen from "hooks/UseOnScreen";
 import { useCamera, useCameraStartStop } from "lib/api/camera";
 import { BASE_PATH } from "lib/api/client";
@@ -63,9 +62,6 @@ interface CameraCardProps {
   border?: string;
 }
 
-const blankImage =
-  "data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E";
-
 function SuccessCameraCard({
   camera,
   buttons = true,
@@ -79,7 +75,6 @@ function SuccessCameraCard({
   const ref: any = useRef<HTMLDivElement>(undefined);
   const onScreen = useOnScreen<HTMLDivElement>(ref);
   const isVisible = usePageVisibility();
-  const firstRender = useFirstRender();
 
   const cameraStartStop = useCameraStartStop();
 
@@ -92,30 +87,25 @@ function SuccessCameraCard({
         .substring(7)}${width ? `&width=${Math.trunc(width)}` : ""}`,
     [camera.identifier],
   );
-  const [snapshotURL, setSnapshotURL] = useState({
-    // Show blank image on start
-    url: blankImage,
+  const [snapshotURL, setSnapshotURL] = useState<{
+    // null until the first snapshot has been requested
+    url: string | null;
+    disableSpinner: boolean;
+    disableTransition: boolean;
+    loading: boolean;
+  }>({
+    url: null,
+    // Spinner and transition are only used until the first snapshot has loaded
     disableSpinner: false,
     disableTransition: false,
-    loading: true,
+    loading: false,
   });
   const updateSnapshot = useRef<NodeJS.Timeout | null>(undefined);
   const updateImage = useCallback(() => {
     setSnapshotURL((prevSnapshotURL) => {
-      if (prevSnapshotURL.loading && !firstRender) {
+      if (prevSnapshotURL.loading) {
         // Dont load new image if we are still loading
         return prevSnapshotURL;
-      }
-      if (firstRender) {
-        // Make sure we show the spinner on the first image fetched.
-        return {
-          url: generateSnapshotURL(
-            ref.current ? ref.current.offsetWidth : null,
-          ),
-          disableSpinner: false,
-          disableTransition: false,
-          loading: true,
-        };
       }
       return {
         ...prevSnapshotURL,
@@ -123,7 +113,7 @@ function SuccessCameraCard({
         loading: true,
       };
     });
-  }, [firstRender, generateSnapshotURL]);
+  }, [generateSnapshotURL]);
 
   useEffect(() => {
     // If element is on screen and browser is visible, start interval to fetch images
@@ -155,6 +145,14 @@ function SuccessCameraCard({
     camera.still_image.available,
     camera.still_image.refresh_interval,
   ]);
+
+  const mediaPlaceholderSx = {
+    aspectRatio: camera.still_image.width / camera.still_image.height,
+    backgroundColor: theme.palette.background.default,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  };
 
   return (
     <div
@@ -194,16 +192,7 @@ function SuccessCameraCard({
         >
           <CardMedia>
             {!camera.connected ? (
-              <Box
-                sx={{
-                  aspectRatio:
-                    camera.still_image.width / camera.still_image.height,
-                  backgroundColor: theme.palette.background.default,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                }}
-              >
+              <Box sx={mediaPlaceholderSx}>
                 <VideoOff
                   size={48}
                   style={{
@@ -211,6 +200,16 @@ function SuccessCameraCard({
                     opacity: 0.5,
                   }}
                 />
+              </Box>
+            ) : snapshotURL.url === null ? (
+              // No snapshot requested yet, card is off screen or disconnected
+              <Box
+                sx={mediaPlaceholderSx}
+                data-testid="camera-snapshot-loading"
+              >
+                {camera.still_image.available ? (
+                  <CircularProgress enableTrackSlot />
+                ) : null}
               </Box>
             ) : (
               <Image
@@ -222,6 +221,7 @@ function SuccessCameraCard({
                   camera.still_image.width / camera.still_image.height
                 }
                 color={theme.palette.background.default}
+                loading={<CircularProgress enableTrackSlot />}
                 onLoad={() => {
                   setSnapshotURL((prevSnapshotURL) => ({
                     ...prevSnapshotURL,

--- a/frontend/tests/components/camera/CameraCard.test.tsx
+++ b/frontend/tests/components/camera/CameraCard.test.tsx
@@ -1,0 +1,80 @@
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { renderWithContext } from "tests/utils/renderWithContext";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { CameraCard } from "components/camera/CameraCard";
+
+// IntersectionObserver only reports visibility after the first render
+const { onScreenStore } = vi.hoisted(() => {
+  const listeners = new Set<() => void>();
+  return {
+    onScreenStore: {
+      value: false,
+      subscribe(listener: () => void) {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+      set(value: boolean) {
+        this.value = value;
+        listeners.forEach((listener) => listener());
+      },
+    },
+  };
+});
+
+vi.mock("hooks/UseOnScreen", async () => {
+  const { useSyncExternalStore } = await import("react");
+  return {
+    default: () =>
+      useSyncExternalStore(
+        (listener: () => void) => onScreenStore.subscribe(listener),
+        () => onScreenStore.value,
+      ),
+  };
+});
+
+afterEach(() => {
+  onScreenStore.value = false;
+});
+
+const renderCameraCard = () =>
+  renderWithContext(<CameraCard camera_identifier="camera1" buttons={false} />);
+
+const snapshotSrc = "/api/v1/camera/camera1/snapshot";
+
+describe("CameraCard", () => {
+  test("shows a loading indicator before the first snapshot is requested", async () => {
+    renderCameraCard();
+
+    expect(
+      await screen.findByTestId("camera-snapshot-loading"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+  });
+
+  test("keeps the loading indicator up until the first snapshot has loaded", async () => {
+    const { container } = renderCameraCard();
+    await screen.findByText("Camera 1");
+
+    // A load fired while off screen is not the first snapshot
+    container.querySelectorAll("img").forEach((img) => fireEvent.load(img));
+
+    act(() => onScreenStore.set(true));
+
+    const snapshot = await screen.findByRole("img");
+    await waitFor(() =>
+      expect(snapshot).toHaveAttribute(
+        "src",
+        expect.stringContaining(snapshotSrc),
+      ),
+    );
+    // The snapshot is still in flight, so the spinner has to stay visible.
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+
+    fireEvent.load(snapshot);
+
+    await waitFor(() =>
+      expect(screen.queryByRole("progressbar")).not.toBeInTheDocument(),
+    );
+  });
+});


### PR DESCRIPTION
## Problem

On the landing page, camera cards render an empty box while the first snapshot is being fetched. On a slow camera (or a slow network) the card just looks broken until the image appears.

The card *tries* to show a spinner for the first snapshot, but the logic never fires:

1. `SuccessCameraCard` primes the snapshot state with a blank `data:` SVG. That image loads immediately, and its `onLoad` handler sets `disableSpinner: true` — so the spinner is suppressed before the first real snapshot is ever requested.
2. The `useFirstRender()` branch in `updateImage()` is meant to re-enable the spinner for the first image, but `useFirstRender()` is only `true` during the very first render. `updateImage()` first runs when `useOnScreen` flips to `true`, which IntersectionObserver only reports asynchronously *after* that render. The branch is unreachable in practice.

There is a second, related bug: if the blank image had not finished loading by the time the card scrolled into view, `loading` was still `true`, so `updateImage()` bailed out and the first snapshot was delayed until the next refresh interval.

## Fix

Drop the blank placeholder image and track "no snapshot requested yet" as `url: null`. That answers the "is this the first image?" question directly, so `useFirstRender` is no longer needed here, and it gives the card something to render while it waits:

- `url === null` → an aspect-ratio placeholder with a `CircularProgress`, matching the existing disconnected-camera placeholder (shared `mediaPlaceholderSx`).
- once a snapshot is requested → `Image` renders with `disableSpinner: false`, so its spinner stays up until the snapshot actually loads, then fades the image in as before.

Cameras with `still_image.available === false` keep rendering an empty placeholder rather than spinning forever, and disconnected cameras keep their `VideoOff` placeholder.

The same `CameraCard` is used by `CameraPickerGrid`, so the camera picker dialog gets the same treatment.

Because the placeholder uses the card's real aspect ratio and `background.default` — the same values the `Image` already uses — the swap from spinner to thumbnail causes no layout shift and follows the theme.

## Testing

- New `frontend/tests/components/camera/CameraCard.test.tsx` covers both the pre-request placeholder and the spinner staying up until the first snapshot fires `load`. Both tests fail against `dev` and pass with this change.
- Full frontend suite passes (49 tests), plus `tsc --noEmit`, ESLint and Prettier.
- Verified in Chromium through the existing Playwright + MSW harness with an artificially delayed snapshot endpoint: spinners appear on every card on `/` and in the camera picker dialog on `/live`, and are gone once the thumbnails land. Checked dark and light themes, desktop and mobile viewports, and a camera with `still_image.available: false` (which correctly does not spin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)