### PR TITLE
Fix frontend vitest suite on Node >= 22 (web storage globals)

### DIFF
--- a/frontend/tests/environment.test.ts
+++ b/frontend/tests/environment.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "vitest";
+
+// Guards the execArgv workaround in vite.config.ts. Without it Node >= 22
+// shadows jsdom's storage and every test touching localStorage throws.
+describe("test environment", () => {
+  test.each(["localStorage", "sessionStorage"] as const)(
+    "%s is jsdom's Storage",
+    (key) => {
+      const storage = globalThis[key];
+
+      expect(storage).toBeInstanceOf(Storage);
+
+      storage.setItem("probe", "value");
+      expect(storage.getItem("probe")).toBe("value");
+      storage.removeItem("probe");
+      expect(storage.getItem("probe")).toBeNull();
+    },
+  );
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -103,6 +103,8 @@ export default defineConfig(({ mode }) => {
       setupFiles: "tests/setupTests.ts",
       include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
       testTimeout: 30000,
+      // Disable Node's own Web Storage so jsdom owns localStorage again
+      execArgv: ["--no-experimental-webstorage"],
     },
   };
 });


### PR DESCRIPTION
## Problem

On Node 26 the frontend test suite fails almost entirely — **27 of 47 tests**, across every test file that mounts a component:

```
TypeError: Cannot read properties of undefined (reading 'getItem')
 ❯ src/context/ColorModeContext.tsx:98:33
     const stored = localStorage.getItem("chosenMode");
```

Node also prints:

```
ExperimentalWarning: localStorage is not available because --localstorage-file was not provided.
```

## Cause

Two behaviours combine:

1. **Node >= 22 defines its own Web Storage globals.** `globalThis.localStorage` exists as an accessor, but it evaluates to `undefined` unless the process was started with `--localstorage-file`. (`sessionStorage` is defined and usable, but it is Node's, not jsdom's.)
2. **Vitest's jsdom environment will not overwrite a global that already exists**, unless the name is on its own hardcoded allowlist. From `populateGlobal` → `getWindowKeys` in `vitest/dist`:

   ```js
   if (k in global) return keysArray.includes(k);
   return true;
   ```

   `localStorage` and `sessionStorage` are not on that list, so on Node < 22 they are copied from jsdom via the `return true` branch, and on Node >= 22 they are silently dropped.

The result is that jsdom's storage is never installed and every test sees Node's unusable global. This is environmental — it reproduces on `dev` with no source changes, and CI does not catch it because `ci-frontend.yaml` pins `NODE_VERSION: 24`, where `localStorage` still happens to be usable through jsdom.

## Fix

Start the vitest workers with `--no-experimental-webstorage`, so Node does not define the globals at all and jsdom owns them again:

```ts
execArgv: ["--no-experimental-webstorage"],
```

I checked the flag is accepted on Node 22, 24 and 26, so it is safe for the pinned CI version as well as for contributors on newer Node. Note this is `test.execArgv` and not `test.poolOptions.*.execArgv`, since `poolOptions` was removed in Vitest 4.

`tests/environment.test.ts` guards the behaviour, so if this regresses it surfaces as one clear failure instead of every component test breaking at once.

## Testing

| | before | after |
|---|---|---|
| Node 26.7.0 | 27 failed, 20 passed | **49 passed** |
| Node 24 (CI version) | 47 passed | **49 passed** |

Also checked: `tsc --noEmit`, Prettier, and that the flag does not break `--pool=threads` (worker_threads rejects some Node options in `execArgv`; this one is fine).

## Unrelated issue found while testing

`tests/lib/tokens.test.ts` has 3 failures that are **timezone**-dependent, not Node-dependent — they reproduce on Node 24 under `TZ=America/New_York` and pass under `TZ=UTC`. `toStrictEqual` compares dayjs internals, and `getDayjs().add(3600, "second")` and `getDayjsFromDateTimeString(...)` build structurally different instances (`$u` set vs absent) outside UTC. CI never sees it because GitHub runners are UTC. Left out of this PR to keep it focused — happy to send a follow-up if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)