### PR TITLE
Fix timezone-dependent failures in tokens.test.ts

### DIFF
--- a/frontend/tests/lib/tokens.test.ts
+++ b/frontend/tests/lib/tokens.test.ts
@@ -1,30 +1,30 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { getDayjs } from "lib/helpers/dates";
+import { getDayjs, getDayjsFromDateTimeString } from "lib/helpers/dates";
 import * as tokens from "lib/tokens";
 import * as types from "lib/types";
 
 const TOKENS_KEY = "tokens";
 
-const NOW = getDayjs();
+const EXPIRES_AT = getDayjs().add(3600, "second");
 const TOKEN_RESPONSE: types.AuthTokenResponse = {
   header: "header",
   payload: "payload",
   expiration: 3600,
-  expires_at: NOW.add(3600, "second").toISOString(),
-  expires_at_timestamp: NOW.add(3600, "second").unix(),
-  session_expires_at: NOW.add(3600, "second").toISOString(),
-  session_expires_at_timestamp: NOW.add(3600, "second").unix(),
+  expires_at: EXPIRES_AT.toISOString(),
+  expires_at_timestamp: EXPIRES_AT.unix(),
+  session_expires_at: EXPIRES_AT.toISOString(),
+  session_expires_at_timestamp: EXPIRES_AT.unix(),
 };
 
+// Convert the same way the code does. Reusing EXPIRES_AT gives a dayjs
+// instance that holds the same instant but differs internally outside UTC.
 const TOKEN_DATA: types.StoredTokens = {
-  header: "header",
-  payload: "payload",
-  expiration: 3600,
-  expires_at: NOW.add(3600, "second"),
-  expires_at_timestamp: NOW.add(3600, "second").unix(),
-  session_expires_at: NOW.add(3600, "second"),
-  session_expires_at_timestamp: NOW.add(3600, "second").unix(),
+  ...TOKEN_RESPONSE,
+  expires_at: getDayjsFromDateTimeString(TOKEN_RESPONSE.expires_at),
+  session_expires_at: getDayjsFromDateTimeString(
+    TOKEN_RESPONSE.session_expires_at,
+  ),
 };
 
 vi.useFakeTimers();
@@ -128,6 +128,10 @@ describe("Tokens", () => {
       const result = tokens.genTokens(TOKEN_RESPONSE);
 
       expect(result).toEqual(TOKEN_DATA);
+      expect(result.expires_at.toISOString()).toBe(TOKEN_RESPONSE.expires_at);
+      expect(result.session_expires_at.toISOString()).toBe(
+        TOKEN_RESPONSE.session_expires_at,
+      );
     });
   });
 


### PR DESCRIPTION
Follow-up to #1500, where I noticed this while getting the suite to run locally.

## Problem

Three tests in `tests/lib/tokens.test.ts` fail for anyone whose machine is not on UTC:

- `loadTokens > load tokens from LocalStorage`
- `storeTokens > store tokens in LocalStorage`
- `genTokens > generates stored tokens with converted date values`

```
AssertionError: expected { header: 'header', …(6) } to strictly equal { header: 'header', …(6) }
Compared values serialize to the same structure.

- Expected
+ Received
+     "$u": false,
```

CI is green because GitHub runners are UTC. This is not Node-version related — it reproduces on the pinned Node 24 under `TZ=America/New_York`.

## Cause

The fixture builds its expected `StoredTokens` dates one way:

```ts
expires_at: NOW.add(3600, "second"),
```

while the code under test builds them another — by parsing the response string:

```ts
expires_at: getDayjsFromDateTimeString(tokens.expires_at),
```

Both hold the same instant and serialize to the same ISO string, but they are not *structurally* equal outside UTC, and `toStrictEqual`/`toEqual` compare dayjs internals:

- `.tz()` ends in `utcOffset(offset, true)`, which sets `$u = (offset === 0)`.
- dayjs arithmetic round-trips through `Utils.w(..., { utc: this.$u })`, and the utc plugin's parse does `if (cfg.utc) this.$u = true` — so a `$u` of `false` is never re-assigned and comes back as `undefined`.

In UTC the offset is 0, so `$u` is `true` and survives the `.add()`. At any other offset it is `false` and degrades to `undefined`, so expected and received differ by that one internal flag.

## Fix

Derive the fixture's dates from the response strings using the same conversion the code uses. That makes the comparison structurally sound in any zone, and states more directly what `StoredTokens` is — the response with its two date strings converted.

Since the fixture now uses the same call as `genTokens`, I added assertions that the converted dates round-trip back to the response strings, so that test still checks the conversion rather than just comparing two identical expressions.

## Testing

`tests/lib/tokens.test.ts` on Node 24:

| TZ | before | after |
|---|---|---|
| UTC | pass | pass |
| America/New_York | **3 failed** | pass |
| Australia/Sydney | **3 failed** | pass |
| Asia/Kolkata | **3 failed** | pass |
| Pacific/Chatham (+12:45) | **3 failed** | pass |

Full suite, `tsc --noEmit` and Prettier all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)